### PR TITLE
Utilize request pieces from common.proto in PactConsumerTest request

### DIFF
--- a/examples/gRPC/area_calculator/consumer-jvm/src/test/java/io/pact/example/grpc/consumer/PactConsumerTest.java
+++ b/examples/gRPC/area_calculator/consumer-jvm/src/test/java/io/pact/example/grpc/consumer/PactConsumerTest.java
@@ -42,7 +42,7 @@ public class PactConsumerTest {
   V4Pact calculateRectangleArea(PactBuilder builder) {
     return builder
       // Tell Pact we need the Protobuf plugin
-      .usingPlugin("protobuf")
+      .usingPlugin("protobuf", "0.1.13")
       // We will use a V4 synchronous message interaction for the test
       .expectsToReceive("calculate rectangle area request", "core/interaction/synchronous-message")
       // We need to pass all the details for the interaction over to the plugin
@@ -54,10 +54,13 @@ public class PactConsumerTest {
 
         // Details on the request message (ShapeMessage) we will send
         "request", Map.of(
-          "rectangle", Map.of(
-              "length", "matching(number, 3)",
-              "width", "matching(number, 4)"
+          "device_context", Map.of(
+              "device_id", "matching(number, 4)",
+              "carrier_name", "matching(type, 'foo')"
           )),
+          "listener_context", Map.of(
+              "listener_id", "matching(number, 1)"
+          ),
 
         // Details on the response message we expect to get back (AreaResponse)
         "response", List.of(

--- a/examples/gRPC/area_calculator/proto/area_calculator.proto
+++ b/examples/gRPC/area_calculator/proto/area_calculator.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package area_calculator;
 
+import "common.proto";
+
 option php_generic_services = true;
 option go_package = "io.pact/area_calculator";
 
@@ -17,6 +19,8 @@ message ShapeMessage {
     Circle circle = 3;
     Triangle triangle = 4;
     Parallelogram parallelogram = 5;
+    DeviceContext device_context = 6; // device data; populate as many fields as you can
+    ListenerContext listener_context = 7;
   }
 }
 
@@ -27,6 +31,23 @@ message Square {
 message Rectangle {
   float length = 1;
   float width = 2;
+}
+
+message DeviceContext {
+  int32 vendor_id = 1; // (required) vendor ID of the device on which the app is being used
+  int64 device_id = 2 [jstype = JS_STRING]; // (required) device ID of the device on which the app is being used
+  string carrier_name = 3; // (recommended) carrier name (e.g. "t-mobile") of the device on which the app is being used
+  string user_agent = 4; // (recommended) browser/app user agent associated with the request
+  string network_type = 5; // (recommended) network type (e.g. "wifi") the device is using to connect to the internet
+  string system_version = 6; // (recommended) system version of the device on which the app is being used
+  string app_version = 7; // (recommended) app version (e.g. 2022.01.1) of the app is being used
+  string vendor_name = 8; // (soft requirement) vendor short-name (e.g. "android") of the device on which the app is being used
+  string accessory_id = 9; // (recommended) device accessory ID of the device on which the app is being used
+  string device_category = 10; // (recommended) device CATEGORY property (e.g. "SMARTPHONES") of the device on which the app is being used
+  string device_type = 11; // (recommended) device TYPE property (e.g. "BLU_RAY") of the device on which the app is being used
+  string reporting_vendor = 12; // (recommended) device REPORTING_VENDOR property (e.g. "SAMSUNG") of the device on which the app is being used
+  string device_ad_category = 13; // (soft requirement) site device category (e.g. "android") for ads of the device on which the app is being used
+  string device_code = 14; // (required) unique device name (e.g. "greenfield-iphone") of the device on which the app is being used
 }
 
 message Circle {

--- a/examples/gRPC/area_calculator/proto/common.proto
+++ b/examples/gRPC/area_calculator/proto/common.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package area_calculator;
+
+option java_multiple_files = true;
+option go_package = "io.pact/area_calculator";
+
+message ListenerContext {
+  int64 listener_id = 1 [jstype = JS_STRING]; // (required) Pandora LID (e.g. 1234567890) of the account associated with the request
+  string username = 2; // (recommended) user account (e.g. "jane.doe@gmail.com") associated with the request
+  int64 listener_date_created = 3; // (recommended) account creation date of listener in milliseconds since epoch (e.g. 1615842902467)
+  bool filter_explicit_content = 4; // (soft requirement) whether listener account has explicit filter enabled
+  string zip_code = 5; // (soft requirement) listener's registered zip code (e.g. "28904")
+  string country_code = 6; // (recommended) country code associated with the listener's account (e.g. "US")
+  int32 birth_year = 7; // (soft requirement) listener's registered birth year (e.g. 1984)
+  string gender = 8; // (soft requirement) listener's registered gender from the Gender enum (e.g. "MALE")
+  int64 last_expiration = 9; // (recommended) most recent account expiration date in milliseconds since epoch (e.g. 1615842902467)
+  string sponsored_comp_name = 10; // (recommended) last complete sponsored trial name
+  bool used_trial = 11; // (recommended) did listener use their trial opportunity?
+  bool used_in_app_trial = 12; // (recommended) did listener use their in-app trial opportunity?
+  string listener_state = 13; // (recommended) listener's account state from the ListenerState enum (e.g. "REGISTERED")
+}
+
+message StationContext {
+  string station_seed_pandora_id = 1; // (soft requirement) Pandora (music) ID of station initial seed, if one exists (e.g. "AR:1234")
+  string station_pandora_id = 2; // (soft requirement) Pandora (music) ID of playback source (e.g. "ST:0:13455")
+  string station_type = 3; // (soft requirement) Pandora station type from the StationType enum (e.g. "QUICKMIX")
+  bool is_advertiser_station = 4; // (recommended) is station created by an advertiser?
+}
+
+message Status {
+  StatusCode status_code = 1; // status of the response
+  string error_message = 2; // additional info about the error, if an error occurred
+}
+
+enum StatusCode {
+  OK = 0; // the request was processed successfully
+  INVALID_REQUEST = 1; // the request failed because it was a bad request
+  ERROR = 2; // the server was unable to fulfill a valid request (or we dont know)
+}


### PR DESCRIPTION
This illustrates a situation where a proto file (area_calculator.proto) imports another proto (common.proto) which is used in the request specified by PactConsumerTest

```
        "request", Map.of(
          "device_context", Map.of(
              "device_id", "matching(number, 4)",
              "carrier_name", "matching(type, 'foo')"
          )),
          "listener_context", Map.of(
              "listener_id", "matching(number, 1)"
          ),
```