### PR TITLE
Remove rustls-tls feature from reqwest

### DIFF
--- a/drivers/rust/driver/Cargo.lock
+++ b/drivers/rust/driver/Cargo.lock
@@ -1727,7 +1727,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -2519,25 +2518,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/drivers/rust/driver/Cargo.toml
+++ b/drivers/rust/driver/Cargo.toml
@@ -55,7 +55,7 @@ zip = "0.6.2"
 [dependencies.reqwest]
 version = "0.11.16"
 default-features = false
-features = ["rustls-tls", "rustls-tls-native-roots", "json", "gzip", "deflate", "stream"]
+features = ["rustls-tls-native-roots", "json", "gzip", "deflate", "stream"]
 
 [dev-dependencies]
 env_logger = "0.10.0"


### PR DESCRIPTION
Having **rustls-tls** in features is basically an alias for 'rustls-tls-webpki-roots' according to [here](https://docs.rs/crate/reqwest/latest/features#rustls-tls).  
And there already is the feature to use 'rustls-tls-native-roots'.  
Moreover 'rustls-tls-webpki-roots' pulls in a crate with a license considered copyleft. (webpki-roots)