### PR TITLE
fix(cli): --skip-if-installed always skipped

### DIFF
--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -136,7 +136,11 @@ pub(crate) async fn fetch_json_from_url(source: &str, http_client: &Client) -> a
 }
 
 fn already_installed(manifest: &PactPluginManifest) -> bool {
-  find_plugin(&manifest.name, &Some(manifest.version.clone())).is_ok()
+  if let Ok(res) = find_plugin(&manifest.name, &Some(manifest.version.clone())) {
+    return res.len() > 0
+  }
+
+  return false
 }
 
 fn create_plugin_dir(manifest: &PactPluginManifest, override_prompt: bool) -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
`find_plugin` returns a vector, so the `is_ok()` check wasn't sufficient to detect the presence of a plugin.

I think this should be sufficient, given the lookup is on the name and version.

It seems to work on both named and unnamed plugins, and specific versions.

Fixes #16 