### PR TITLE
feat: musl pact-plugin-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: plugins/csv/target/artifacts/*
+          file: plugins/csv/release_artifacts/*
           file_glob: true
           tag: ${{ github.ref }}
       - if: startsWith(github.ref, 'refs/tags/pact-plugin-cli')
@@ -49,6 +49,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: cli/target/artifacts/*
+          file: cli/release_artifacts/*
           file_glob: true
           tag: ${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build
 target
 pacts
 *.out
+release_artifacts
 
 # Misc
 

--- a/cli/release.sh
+++ b/cli/release.sh
@@ -9,37 +9,51 @@ fi
 echo Building Release for "$1"
 
 cargo clean
-mkdir -p target/artifacts/
+mkdir -p release_artifacts
 
 case "$1" in
   Linux)    echo "Building for Linux"
             docker run --rm --user "$(id -u)":"$(id -g)" -v "$(pwd):/workspace" -w /workspace -t pactfoundation/rust-musl-build -c 'cargo build --release'
-            gzip -c target/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-linux-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-linux-x86_64.gz > target/artifacts/pact-plugin-cli-linux-x86_64.gz.sha256
+            gzip -c target/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-x86_64.gz > release_artifacts/pact-plugin-cli-linux-x86_64.gz.sha256
 
             # Build aarch64
-            cargo install cross
+            cargo install cross@0.2.5
+            cargo clean
             cross build --target aarch64-unknown-linux-gnu --release
-            gzip -c target/aarch64-unknown-linux-gnu/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-linux-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-linux-aarch64.gz > target/artifacts/pact-plugin-cli-linux-aarch64.gz.sha256
+            gzip -c target/aarch64-unknown-linux-gnu/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-aarch64.gz > release_artifacts/pact-plugin-cli-linux-aarch64.gz.sha256
+
+            cargo clean
+            cross build --release --target=x86_64-unknown-linux-musl
+            gzip -c target/x86_64-unknown-linux-musl/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-musl-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-musl-x86_64.gz > release_artifacts/pact-plugin-cli-linux-musl-x86_64.gz.sha256
+
+            echo -- Build the musl aarch64 release artifacts --
+            cargo clean
+            cross build --release --target=aarch64-unknown-linux-musl
+            gzip -c target/aarch64-unknown-linux-musl/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-aarch64-musl.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-musl-aarch64.gz > release_artifacts/pact-plugin-cli-linux-musl-aarch64.gz.sha256
+
+
             ;;
   Windows)  echo  "Building for Windows"
             cargo build --release
-            gzip -c target/release/pact-plugin-cli.exe > target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz > target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz.sha256
+            gzip -c target/release/pact-plugin-cli.exe > release_artifacts/pact-plugin-cli-windows-x86_64.exe.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-windows-x86_64.exe.gz > release_artifacts/pact-plugin-cli-windows-x86_64.exe.gz.sha256
             ;;
   macOS)    echo  "Building for OSX"
             cargo build --release
-            gzip -c target/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-osx-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-osx-x86_64.gz > target/artifacts/pact-plugin-cli-osx-x86_64.gz.sha256
+            gzip -c target/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-osx-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-osx-x86_64.gz > release_artifacts/pact-plugin-cli-osx-x86_64.gz.sha256
 
             # M1
             export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
             export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
             cargo build --target aarch64-apple-darwin --release
 
-            gzip -c target/aarch64-apple-darwin/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-osx-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-osx-aarch64.gz > target/artifacts/pact-plugin-cli-osx-aarch64.gz.sha256
+            gzip -c target/aarch64-apple-darwin/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-osx-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-osx-aarch64.gz > release_artifacts/pact-plugin-cli-osx-aarch64.gz.sha256
             ;;
   *)        echo "$1 is not a recognised OS"
             exit 1

--- a/cli/release.sh
+++ b/cli/release.sh
@@ -26,14 +26,14 @@ case "$1" in
 
             cargo clean
             cross build --release --target=x86_64-unknown-linux-musl
-            gzip -c target/x86_64-unknown-linux-musl/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-musl-x86_64.gz
-            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-musl-x86_64.gz > release_artifacts/pact-plugin-cli-linux-musl-x86_64.gz.sha256
+            gzip -c target/x86_64-unknown-linux-musl/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz > release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz.sha256
 
             echo -- Build the musl aarch64 release artifacts --
             cargo clean
             cross build --release --target=aarch64-unknown-linux-musl
             gzip -c target/aarch64-unknown-linux-musl/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-aarch64-musl.gz
-            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-musl-aarch64.gz > release_artifacts/pact-plugin-cli-linux-musl-aarch64.gz.sha256
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-aarch64-musl.gz > release_artifacts/pact-plugin-cli-linux-aarch64-musl.gz.sha256
 
 
             ;;

--- a/plugins/csv/release.sh
+++ b/plugins/csv/release.sh
@@ -9,36 +9,36 @@ fi
 echo Building Release for "$1"
 
 cargo clean
-mkdir -p target/artifacts/
+mkdir -p release_artifacts
 
 case "$1" in
   Linux)    echo "Building for Linux"
             docker run --rm --user "$(id -u)":"$(id -g)" -v "$(pwd):/workspace" -w /workspace -t pactfoundation/rust-musl-build -c 'cargo build --release'
-            gzip -c target/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-linux-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-linux-x86_64.gz > target/artifacts/pact-csv-plugin-linux-x86_64.gz.sha256
-            cp pact-plugin.json target/artifacts/
+            gzip -c target/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-linux-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-linux-x86_64.gz > release_artifacts/pact-csv-plugin-linux-x86_64.gz.sha256
+            cp pact-plugin.json release_artifacts/
             cargo install cross
             cross build --target aarch64-unknown-linux-gnu --release
-            gzip -c target/aarch64-unknown-linux-gnu/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-linux-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-linux-aarch64.gz > target/artifacts/pact-csv-plugin-linux-aarch64.gz.sha256
+            gzip -c target/aarch64-unknown-linux-gnu/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-linux-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-linux-aarch64.gz > release_artifacts/pact-csv-plugin-linux-aarch64.gz.sha256
             ;;
   Windows)  echo  "Building for Windows"
             cargo build --release
-            gzip -c target/release/pact-csv-plugin.exe > target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz > target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz.sha256
+            gzip -c target/release/pact-csv-plugin.exe > release_artifacts/pact-csv-plugin-windows-x86_64.exe.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-windows-x86_64.exe.gz > release_artifacts/pact-csv-plugin-windows-x86_64.exe.gz.sha256
             ;;
   macOS)    echo  "Building for OSX"
             cargo build --release
-            gzip -c target/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-osx-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-osx-x86_64.gz > target/artifacts/pact-csv-plugin-osx-x86_64.gz.sha256
+            gzip -c target/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-osx-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-osx-x86_64.gz > release_artifacts/pact-csv-plugin-osx-x86_64.gz.sha256
 
             # M1
             export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
             export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
             cargo build --target aarch64-apple-darwin --release
 
-            gzip -c target/aarch64-apple-darwin/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-osx-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-osx-aarch64.gz > target/artifacts/pact-csv-plugin-osx-aarch64.gz.sha256
+            gzip -c target/aarch64-apple-darwin/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-osx-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-osx-aarch64.gz > release_artifacts/pact-csv-plugin-osx-aarch64.gz.sha256
             ;;
   *)        echo "$1 is not a recognised OS"
             exit 1


### PR DESCRIPTION
Create musl based variants of

- pact-plugin-cli

Tracking issue:- https://github.com/pact-foundation/devrel/issues/30

Follows on from https://github.com/pact-foundation/pact-reference/pull/372

Will also require updates in pact-plugin-cli to

- provide support to check for and download musl variants (also in jvm and rust drivers)

Additionally

- pins cross to 0.2.5 to ensure we build against the correct version of glib, [issue](https://github.com/pact-foundation/pact-reference/issues/354) from pact-ref

Should fix #52 by triggering a re-release, this artifact was missing from the last release