### PR TITLE
Feat/pact plugin detect musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: cli/target/artifacts/*
+          file: cli/release_artifacts/*
           file_glob: true
           tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: plugins/csv/target/artifacts/*
+          file: plugins/csv/release_artifacts/*
           file_glob: true
           tag: ${{ github.ref }}
       - if: startsWith(github.ref, 'refs/tags/pact-plugin-cli')

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build
 target
 pacts
 *.out
+release_artifacts
 
 # Misc
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1479,9 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "pact-plugin-driver"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e63ffe3c61b92258856a9b0558d1526dfc4313a84280a452eec684513251b2"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "ariadne"
@@ -130,14 +130,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.74"
+name = "async-stream"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -305,9 +327,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -315,7 +337,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -381,7 +403,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
@@ -705,44 +727,44 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -875,11 +897,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -993,7 +1015,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -1214,7 +1236,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
@@ -1457,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "pact-plugin-driver"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cead6a8c9f5e0de8f13cdf00d2fd684d00b79d70baa10c3f74b9d0b211dfdcd6"
+checksum = "26e63ffe3c61b92258856a9b0558d1526dfc4313a84280a452eec684513251b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1499,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "pact_models"
-version = "1.1.12"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a732b44f4ede0e0fde65944a9f421c34c2c7051bde14e0f44f4b31bf3c71ed"
+checksum = "2bac0a22137e661623246c4da170f3123ff9ead87644d1d16ceb6604c5752440"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1668,7 +1690,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
@@ -1709,28 +1731,28 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1738,53 +1760,53 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
  "itertools 0.10.5",
- "lazy_static",
  "log",
  "multimap",
+ "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1860,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1872,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1921,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "async-compression",
  "base64",
@@ -1949,6 +1971,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -2109,35 +2132,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -2350,7 +2373,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
@@ -2371,20 +2394,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2399,9 +2411,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2409,7 +2421,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -2484,7 +2496,7 @@ checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
@@ -2543,9 +2555,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2578,7 +2590,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
@@ -2665,16 +2677,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64",
  "bytes",
- "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2693,15 +2704,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
+checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2756,7 +2767,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
 ]
 
 [[package]]
@@ -2892,9 +2903,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
 ]
@@ -2966,7 +2977,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3000,7 +3011,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3013,9 +3024,9 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-streams"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3078,12 +3089,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [dependencies]
-pact-plugin-driver = { version = "0.5.1" }
+pact-plugin-driver = { version = "0.5.2", path = "../drivers/rust/driver" }
 clap = { version = "4.4.11", features = [ "derive", "cargo" ] }
 comfy-table = "7.1.0"
 home = "0.5.5"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [dependencies]
-pact-plugin-driver = "0.4.6"
+pact-plugin-driver = { version = "0.5.1" }
 clap = { version = "4.4.11", features = [ "derive", "cargo" ] }
 comfy-table = "7.1.0"
 home = "0.5.5"

--- a/cli/release.sh
+++ b/cli/release.sh
@@ -17,13 +17,13 @@ case "$1" in
   Linux)    echo "Building for Linux"
             cargo install cross@0.2.5
 
-            echo -- Build the musl x86_64 release artifacts --
+            echo -- Build the x86_64 release artifacts --
             cargo clean
             cross build --target x86_64-unknown-linux-gnu --release
             gzip -c target/x86_64-unknown-linux-gnu/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-x86_64.gz
             openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-x86_64.gz > release_artifacts/pact-plugin-cli-linux-x86_64.gz.sha256
 
-            echo -- Build the musl aarch64 release artifacts --
+            echo -- Build the aarch64 release artifacts --
             cargo clean
             cross build --target aarch64-unknown-linux-gnu --release
             gzip -c target/aarch64-unknown-linux-gnu/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-aarch64.gz
@@ -34,14 +34,6 @@ case "$1" in
             cross build --release --target=x86_64-unknown-linux-musl
             gzip -c target/x86_64-unknown-linux-musl/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz
             openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz > release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz.sha256
-
-
-            echo -- Build the musl aarch64 release artifacts --
-            cargo clean
-            cross build --target aarch64-unknown-linux-gnu --release
-            gzip -c target/aarch64-unknown-linux-gnu/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-aarch64.gz
-            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-aarch64.gz > release_artifacts/pact-plugin-cli-linux-aarch64.gz.sha256
-
 
             echo -- Build the musl aarch64 release artifacts --
             cargo clean

--- a/cli/release.sh
+++ b/cli/release.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
+set -e
+set -u
 
 if [ $# -lt 1 ]
 then
@@ -9,37 +11,62 @@ fi
 echo Building Release for "$1"
 
 cargo clean
-mkdir -p target/artifacts/
+mkdir -p release_artifacts
 
 case "$1" in
   Linux)    echo "Building for Linux"
-            docker run --rm --user "$(id -u)":"$(id -g)" -v "$(pwd):/workspace" -w /workspace -t pactfoundation/rust-musl-build -c 'cargo build --release'
-            gzip -c target/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-linux-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-linux-x86_64.gz > target/artifacts/pact-plugin-cli-linux-x86_64.gz.sha256
+            cargo install cross@0.2.5
 
-            # Build aarch64
-            cargo install cross
+            echo -- Build the musl x86_64 release artifacts --
+            cargo clean
+            cross build --target x86_64-unknown-linux-gnu --release
+            gzip -c target/x86_64-unknown-linux-gnu/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-x86_64.gz > release_artifacts/pact-plugin-cli-linux-x86_64.gz.sha256
+
+            echo -- Build the musl aarch64 release artifacts --
+            cargo clean
             cross build --target aarch64-unknown-linux-gnu --release
-            gzip -c target/aarch64-unknown-linux-gnu/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-linux-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-linux-aarch64.gz > target/artifacts/pact-plugin-cli-linux-aarch64.gz.sha256
+            gzip -c target/aarch64-unknown-linux-gnu/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-aarch64.gz > release_artifacts/pact-plugin-cli-linux-aarch64.gz.sha256
+
+            echo -- Build the musl x86_64 release artifacts --
+            cargo clean
+            cross build --release --target=x86_64-unknown-linux-musl
+            gzip -c target/x86_64-unknown-linux-musl/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz > release_artifacts/pact-plugin-cli-linux-x86_64-musl.gz.sha256
+
+
+            echo -- Build the musl aarch64 release artifacts --
+            cargo clean
+            cross build --target aarch64-unknown-linux-gnu --release
+            gzip -c target/aarch64-unknown-linux-gnu/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-aarch64.gz > release_artifacts/pact-plugin-cli-linux-aarch64.gz.sha256
+
+
+            echo -- Build the musl aarch64 release artifacts --
+            cargo clean
+            cross build --release --target=aarch64-unknown-linux-musl
+            gzip -c target/aarch64-unknown-linux-musl/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-linux-aarch64-musl.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-linux-aarch64-musl.gz > release_artifacts/pact-plugin-cli-linux-aarch64-musl.gz.sha256
+
             ;;
   Windows)  echo  "Building for Windows"
             cargo build --release
-            gzip -c target/release/pact-plugin-cli.exe > target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz > target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz.sha256
+            gzip -c target/release/pact-plugin-cli.exe > release_artifacts/pact-plugin-cli-windows-x86_64.exe.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-windows-x86_64.exe.gz > release_artifacts/pact-plugin-cli-windows-x86_64.exe.gz.sha256
             ;;
   macOS)    echo  "Building for OSX"
             cargo build --release
-            gzip -c target/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-osx-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-osx-x86_64.gz > target/artifacts/pact-plugin-cli-osx-x86_64.gz.sha256
+            gzip -c target/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-osx-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-osx-x86_64.gz > release_artifacts/pact-plugin-cli-osx-x86_64.gz.sha256
 
             # M1
             export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
             export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
             cargo build --target aarch64-apple-darwin --release
 
-            gzip -c target/aarch64-apple-darwin/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-osx-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-osx-aarch64.gz > target/artifacts/pact-plugin-cli-osx-aarch64.gz.sha256
+            gzip -c target/aarch64-apple-darwin/release/pact-plugin-cli > release_artifacts/pact-plugin-cli-osx-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-plugin-cli-osx-aarch64.gz > release_artifacts/pact-plugin-cli-osx-aarch64.gz.sha256
             ;;
   *)        echo "$1 is not a recognised OS"
             exit 1

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginDownloader.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginDownloader.kt
@@ -96,8 +96,20 @@ object DefaultPluginDownloader: PluginDownloader, KLogging() {
 
     // Check for a single exec .gz file
     val ext = if (os == "windows") ".exe" else ""
-    val gzFile = "pact-${manifest.name}-plugin-$os-$arch$muslExt$ext.gz"
-    val shaFileName = "pact-${manifest.name}-plugin-$os-$arch$muslExt$ext.gz.sha256"
+    val gzFile = "pact-${manifest.name}-plugin-$os-$arch$ext.gz"
+    val shaFileName = "pact-${manifest.name}-plugin-$os-$arch$ext.gz.sha256"
+
+    if (isMusl()){
+      val gzFileMusl = "pact-${manifest.name}-plugin-$os-$arch$muslExt$ext.gz"
+      val shaFileNameMusl = "pact-${manifest.name}-plugin-$os-$arch$muslExt$ext.gz.sha256"
+
+      if (githubFileExists(url, tag, gzFileMusl)){
+        val gzFile = gzFileMusl
+        val shaFileName = shaFileNameMusl
+      } else {
+        logger.warn { "musl detected, but no musl specific plugin implementation found - you may experience issues" }
+      }
+    }
     if (githubFileExists(url, tag, gzFile)) {
       logger.debug { "Found a GZipped file $gzFile" }
       when (val fileResult = downloadFileFromGithub(url, tag, gzFile, pluginDir)) {
@@ -131,8 +143,21 @@ object DefaultPluginDownloader: PluginDownloader, KLogging() {
     }
 
     // Check for an arch specific Zip file
-    val archZipFile = "pact-${manifest.name}-plugin-$os-$arch$muslExt.zip"
-    val archZipShaFile = "pact-${manifest.name}-plugin-$os-$arch$muslExt.zip.sha256"
+    val archZipFile = "pact-${manifest.name}-plugin-$os-$arch.zip"
+    val archZipShaFile = "pact-${manifest.name}-plugin-$os-$arch.zip.sha256"
+
+    if (isMusl()){
+      val archZipFileMusl = "pact-${manifest.name}-plugin-$os-$arch$muslExt.zip"
+      val archZipShaFileMusl = "pact-${manifest.name}-plugin-$os-$arch$muslExt.zip.sha256"
+
+      if (githubFileExists(url, tag, archZipFileMusl)){
+        val archZipFile = archZipFileMusl
+        val archZipShaFile = archZipShaFileMusl
+      } else {
+        logger.warn { "musl detected, but no musl specific plugin implementation found - you may experience issues" }
+      }
+    }
+
     if (githubFileExists(url, tag, archZipFile)) {
       return downloadZipFile(pluginDir, url, tag, archZipFile, archZipShaFile)
     }
@@ -150,9 +175,23 @@ object DefaultPluginDownloader: PluginDownloader, KLogging() {
     if (githubFileExists(url, tag, tarGzFile)) {
       return downloadTarGzfile(pluginDir, url, tag, tarGzFile, tarGzShaFile)
     }
+
     // Check for an arch specific tar.gz file
-    val archTarGzFile = "pact-${manifest.name}-plugin-$os-$arch$muslExt.tar.gz"
-    val archTarGzShaFile = "pact-${manifest.name}-plugin-$os-$arch$muslExt.tag.gz.sha256"
+    val archTarGzFile = "pact-${manifest.name}-plugin-$os-$arch.tar.gz"
+    val archTarGzShaFile = "pact-${manifest.name}-plugin-$os-$arch.tag.gz.sha256"
+
+    if (isMusl()){
+      val archTarGzFileMusl = "pact-${manifest.name}-plugin-$os-$arch$muslExt.tar.gz"
+      val archTarGzShaFileMusl = "pact-${manifest.name}-plugin-$os-$arch$muslExt.tag.gz.sha256"
+
+      if (githubFileExists(url, tag, archTarGzFileMusl)){
+        val archTarGzFile = archTarGzFileMusl
+        val archTarGzShaFile = archTarGzShaFileMusl
+      } else {
+        logger.warn { "musl detected, but no musl specific plugin implementation found - you may experience issues" }
+      }
+    }
+
     if (githubFileExists(url, tag, archTarGzFile)) {
       return downloadTarGzfile(pluginDir, url, tag, archTarGzFile, archTarGzShaFile)
     }
@@ -162,9 +201,23 @@ object DefaultPluginDownloader: PluginDownloader, KLogging() {
     if (githubFileExists(url, tag, tgzFile)) {
       return downloadTarGzfile(pluginDir, url, tag, tgzFile, tgzShaFile)
     }
+
     // Check for an arch specific tgz file
-    val archTgzFile = "pact-${manifest.name}-plugin-$os-$arch$muslExt.tgz"
-    val archTgzShaFile = "pact-${manifest.name}-plugin-$os-$arch$muslExt.tgz.sha256"
+    val archTgzFile = "pact-${manifest.name}-plugin-$os-$arch.tgz"
+    val archTgzShaFile = "pact-${manifest.name}-plugin-$os-$arch.tgz.sha256"
+
+    if (isMusl()){
+      val archTgzFileMusl = "pact-${manifest.name}-plugin-$os-$arch$muslExt.tgz"
+      val archTgzShaFileMusl = "pact-${manifest.name}-plugin-$os-$arch$muslExt.tgz.sha256"
+  
+      if (githubFileExists(url, tag, archTgzFileMusl)){
+        val archTgzFile = archTgzFileMusl
+        val archTgzShaFileMusl = archTgzShaFileMusl
+      } else {
+        logger.warn { "musl detected, but no musl specific plugin implementation found - you may experience issues" }
+      }
+    }
+
     if (githubFileExists(url, tag, archTgzFile)) {
       return downloadTarGzfile(pluginDir, url, tag, archTgzFile, archTgzShaFile)
     }

--- a/drivers/rust/driver/src/download.rs
+++ b/drivers/rust/driver/src/download.rs
@@ -59,12 +59,12 @@ pub async fn download_plugin_executable(
   tag: &String,
   display_progress: bool
 ) -> anyhow::Result<PathBuf> {
-  let (os, arch) = os_and_arch()?;
+  let (os, arch, musl) = os_and_arch()?;
 
   // Check for a single exec .gz file
   let ext = if os == "windows" { ".exe" } else { "" };
-  let gz_file = format!("pact-{}-plugin-{}-{}{}.gz", manifest.name, os, arch, ext);
-  let sha_file = format!("pact-{}-plugin-{}-{}{}.gz.sha256", manifest.name, os, arch, ext);
+  let gz_file = format!("pact-{}-plugin-{}-{}{}{}.gz", manifest.name, os, arch,musl, ext);
+  let sha_file = format!("pact-{}-plugin-{}-{}{}{}.gz.sha256", manifest.name, os, arch,musl, ext);
   if github_file_exists(http_client, base_url, tag, gz_file.as_str()).await? {
     debug!(file = %gz_file, "Found a GZipped file");
     let file = download_file_from_github(http_client, base_url, tag, gz_file.as_str(), plugin_dir, display_progress).await?;
@@ -87,8 +87,8 @@ pub async fn download_plugin_executable(
   }
 
   // Check for an arch specific Zip file
-  let zip_file = format!("pact-{}-plugin-{}-{}.zip", manifest.name, os, arch);
-  let zip_sha_file = format!("pact-{}-plugin-{}-{}.zip.sha256", manifest.name, os, arch);
+  let zip_file = format!("pact-{}-plugin-{}-{}{}.zip", manifest.name, os, arch, musl);
+  let zip_sha_file = format!("pact-{}-plugin-{}-{}{}.zip.sha256", manifest.name, os, arch, musl);
   if github_file_exists(http_client, base_url, tag, zip_file.as_str()).await? {
     return download_zip_file(plugin_dir, http_client, base_url, tag, zip_file, zip_sha_file, display_progress).await;
   }
@@ -108,15 +108,15 @@ pub async fn download_plugin_executable(
   }
 
   // Check for an arch specific tar.gz file
-  let tar_gz_file = format!("pact-{}-plugin-{}-{}.tar.gz", manifest.name, os, arch);
-  let tar_gz_sha_file = format!("pact-{}-plugin-{}-{}.tar.gz.sha256", manifest.name, os, arch);
+  let tar_gz_file = format!("pact-{}-plugin-{}-{}{}.tar.gz", manifest.name, os, arch, musl);
+  let tar_gz_sha_file = format!("pact-{}-plugin-{}-{}{}.tar.gz.sha256", manifest.name, os, arch, musl);
   if github_file_exists(http_client, base_url, tag, tar_gz_file.as_str()).await? {
     return download_tar_gz_file(plugin_dir, http_client, base_url, tag, tar_gz_file, tar_gz_sha_file, display_progress).await;
   }
 
   // Check for an arch specific tgz file
-  let tgz_file = format!("pact-{}-plugin-{}-{}.tgz", manifest.name, os, arch);
-  let tgz_sha_file = format!("pact-{}-plugin-{}-{}.tgz.sha256", manifest.name, os, arch);
+  let tgz_file = format!("pact-{}-plugin-{}-{}{}.tgz", manifest.name, os, arch, musl);
+  let tgz_sha_file = format!("pact-{}-plugin-{}-{}{}.tgz.sha256", manifest.name, os, arch, musl);
   if github_file_exists(http_client, base_url, tag, tgz_file.as_str()).await? {
     return download_tar_gz_file(plugin_dir, http_client, base_url, tag, tgz_file, tgz_sha_file, display_progress).await;
   }

--- a/plugins/csv/Cross.toml
+++ b/plugins/csv/Cross.toml
@@ -4,3 +4,15 @@ pre-build=[
     "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
     "unzip protoc-21.5-linux-x86_64.zip -d /usr/local/"
 ]
+[target.x86_64-unknown-linux-musl]
+pre-build=[
+    "apt-get update && apt-get install --assume-yes wget unzip",
+    "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
+    "unzip protoc-21.5-linux-x86_64.zip -d /usr/local/"
+]
+[target.aarch64-unknown-linux-musl]
+pre-build=[
+    "dpkg --add-architecture arm64 && apt-get update && apt-get install --assume-yes wget unzip",
+    "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
+    "unzip protoc-21.5-linux-x86_64.zip -d /usr/local/"
+]

--- a/plugins/csv/release.sh
+++ b/plugins/csv/release.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
+set -e
+set -u
 
 if [ $# -lt 1 ]
 then
@@ -9,36 +11,52 @@ fi
 echo Building Release for "$1"
 
 cargo clean
-mkdir -p target/artifacts/
+mkdir -p release_artifacts
 
 case "$1" in
   Linux)    echo "Building for Linux"
             docker run --rm --user "$(id -u)":"$(id -g)" -v "$(pwd):/workspace" -w /workspace -t pactfoundation/rust-musl-build -c 'cargo build --release'
-            gzip -c target/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-linux-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-linux-x86_64.gz > target/artifacts/pact-csv-plugin-linux-x86_64.gz.sha256
-            cp pact-plugin.json target/artifacts/
-            cargo install cross
+            gzip -c target/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-linux-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-linux-x86_64.gz > release_artifacts/pact-csv-plugin-linux-x86_64.gz.sha256
+            cp pact-plugin.json release_artifacts/
+            cargo install cross@0.2.5
+
+            echo -- Build the aarch64 release artifacts --
+            cargo clean
             cross build --target aarch64-unknown-linux-gnu --release
-            gzip -c target/aarch64-unknown-linux-gnu/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-linux-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-linux-aarch64.gz > target/artifacts/pact-csv-plugin-linux-aarch64.gz.sha256
+            gzip -c target/aarch64-unknown-linux-gnu/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-linux-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-linux-aarch64.gz > release_artifacts/pact-csv-plugin-linux-aarch64.gz.sha256
+
+            echo -- Build the musl x86_64 release artifacts --
+            cargo clean
+            cross build --release --target=x86_64-unknown-linux-musl
+            gzip -c target/x86_64-unknown-linux-musl/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-linux-x86_64-musl.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-linux-x86_64-musl.gz > release_artifacts/pact-csv-plugin-linux-x86_64-musl.gz.sha256
+
+            echo -- Build the musl aarch64 release artifacts --
+            cargo clean
+            cross build --release --target=aarch64-unknown-linux-musl
+            gzip -c target/aarch64-unknown-linux-musl/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-linux-aarch64-musl.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-linux-aarch64-musl.gz > release_artifacts/pact-csv-plugin-linux-aarch64-musl.gz.sha256
+
             ;;
   Windows)  echo  "Building for Windows"
             cargo build --release
-            gzip -c target/release/pact-csv-plugin.exe > target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz > target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz.sha256
+            gzip -c target/release/pact-csv-plugin.exe > release_artifacts/pact-csv-plugin-windows-x86_64.exe.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-windows-x86_64.exe.gz > release_artifacts/pact-csv-plugin-windows-x86_64.exe.gz.sha256
             ;;
   macOS)    echo  "Building for OSX"
             cargo build --release
-            gzip -c target/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-osx-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-osx-x86_64.gz > target/artifacts/pact-csv-plugin-osx-x86_64.gz.sha256
+            gzip -c target/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-osx-x86_64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-osx-x86_64.gz > release_artifacts/pact-csv-plugin-osx-x86_64.gz.sha256
 
             # M1
             export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
             export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
             cargo build --target aarch64-apple-darwin --release
 
-            gzip -c target/aarch64-apple-darwin/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-osx-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-osx-aarch64.gz > target/artifacts/pact-csv-plugin-osx-aarch64.gz.sha256
+            gzip -c target/aarch64-apple-darwin/release/pact-csv-plugin > release_artifacts/pact-csv-plugin-osx-aarch64.gz
+            openssl dgst -sha256 -r release_artifacts/pact-csv-plugin-osx-aarch64.gz > release_artifacts/pact-csv-plugin-osx-aarch64.gz.sha256
             ;;
   *)        echo "$1 is not a recognised OS"
             exit 1


### PR DESCRIPTION
Create musl based variants of

- pact-plugin-cli

Tracking issue:- https://github.com/pact-foundation/devrel/issues/30

Follows on from https://github.com/pact-foundation/pact-reference/pull/372

Updates jvm and rust drivers

- check for musl presence
  - compile time flag for rust
  - ldd lookup jvm
- download musl variants, prefixed with `-musl`
- fallback to non musl variant, if not provided and warn the user that issues may occur.

Additionally

- pins cross to 0.2.5 to ensure we build against the correct version of glib, [issue](https://github.com/pact-foundation/pact-reference/issues/354) from pact-ref
- fix #52  - there was an error before building (I believe it was linked to a path `path = "../drivers/rust/driver"` in the docker builder, but this context wasn't passed available. I switched it out to use cross 0.2.5 for consistency


## Testing notes

Have tested out the pact-plugin-cli with the rust driver in pact-php and pact-go forked workflows. Haven't tested the jvm drivers post the update to fallback to non musl variants but will test it out.