### PR TITLE
feat: linux musl static bins / windows aarch64

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -31,10 +31,10 @@ jobs:
         run: scripts/install-plugin-cli.sh
         shell: bash
       - name: Install Protobuf plugin
-        run: ~/bin/pact-plugin-cli -y install protobuf
+        run: ~/.pact/bin/pact-plugin-cli -y install protobuf
         shell: bash
       - name: Install csv plugin
-        run: ~/bin/pact-plugin-cli -y install csv
+        run: ~/.pact/bin/pact-plugin-cli -y install csv
         shell: bash
       - name: Install Pact verifier
         run: scripts/install-verifier-cli.sh
@@ -51,8 +51,8 @@ jobs:
           nohup ./target/debug/csv-provider &
           PID=$!
           trap "kill $PID" EXIT
-          pact_do_not_track=true ~/bin/pact_verifier_cli -f ../csv-consumer-rust/target/pacts/CsvClient-CsvServer.json -p 8080
-          pact_do_not_track=true ~/bin/pact_verifier_cli -f ../csv-consumer-jvm/build/pacts/CsvClient-CsvServer.json -p 8080
+          pact_do_not_track=true ~/.pact/bin/pact_verifier_cli -f ../csv-consumer-rust/target/pacts/CsvClient-CsvServer.json -p 8080
+          pact_do_not_track=true ~/.pact/bin/pact_verifier_cli -f ../csv-consumer-jvm/build/pacts/CsvClient-CsvServer.json -p 8080
           cd ../csv-provider-jvm
           mkdir -p server/src/test/resources/pacts
           cp ../csv-consumer-jvm/build/pacts/CsvClient-CsvServer.json server/src/test/resources/pacts
@@ -70,7 +70,7 @@ jobs:
           nohup ./target/debug/csv-provider &
           PID=$!
           trap "kill $PID" EXIT
-          pact_do_not_track=true ~/bin/pact_verifier_cli -f ../csv-consumer-jvm/build/pacts/CsvClient-CsvServer.json -p 8080
+          pact_do_not_track=true ~/.pact/bin/pact_verifier_cli -f ../csv-consumer-jvm/build/pacts/CsvClient-CsvServer.json -p 8080
         shell: bash
         working-directory: examples/csv
         if: runner.os == 'Windows'
@@ -110,7 +110,7 @@ jobs:
         run: scripts/install-plugin-cli.sh
         shell: bash
       - name: Install Protobuf plugin
-        run: ~/bin/pact-plugin-cli -y install protobuf
+        run: ~/.pact/bin/pact-plugin-cli -y install protobuf
         shell: bash
       - name: Install Pact verifier
         run: scripts/install-verifier-cli.sh
@@ -138,8 +138,8 @@ jobs:
           PID=$!
           trap "kill $PID" EXIT
           timeout --foreground -s TERM 30s bash -c 'while [[ "$(curl -s -o /dev/null -m 3 -L -w ''%{http_code}'' -XPOST -d'{}' http://127.0.0.1:8111)" != "200" ]]; do echo "Waiting for http://127.0.0.1:8111" && sleep 2; done'
-          pact_do_not_track=true ~/bin/pact_verifier_cli -f ../protobuf-consumer-rust/target/pacts/protobuf-consumer-rust-protobuf-provider.json -p 8111
-          pact_do_not_track=true ~/bin/pact_verifier_cli -f ../protobuf-consumer-jvm/build/pacts/protobuf-consumer-protobuf-provider.json -p 8111
+          pact_do_not_track=true ~/.pact/bin/pact_verifier_cli -f ../protobuf-consumer-rust/target/pacts/protobuf-consumer-rust-protobuf-provider.json -p 8111
+          pact_do_not_track=true ~/.pact/bin/pact_verifier_cli -f ../protobuf-consumer-jvm/build/pacts/protobuf-consumer-protobuf-provider.json -p 8111
         shell: bash
         working-directory: examples/protobuf
         if: runner.os == 'Linux'
@@ -158,8 +158,8 @@ jobs:
           PID=$!
           trap "kill $PID" EXIT
           timeout --foreground -s TERM 30s bash -c 'while [[ "$(curl -s -o /dev/null -m 3 -L -w ''%{http_code}'' -XPOST -d'{}' http://127.0.0.1:8111)" != "200" ]]; do echo "Waiting for http://127.0.0.1:8111" && sleep 2; done'
-          pact_do_not_track=true ~/bin/pact_verifier_cli -f ../protobuf-consumer-rust/target/pacts/protobuf-consumer-rust-protobuf-provider.json -p 8111
-          pact_do_not_track=true ~/bin/pact_verifier_cli -f ../protobuf-consumer-jvm/build/pacts/protobuf-consumer-protobuf-provider.json -p 8111
+          pact_do_not_track=true ~/.pact/bin/pact_verifier_cli -f ../protobuf-consumer-rust/target/pacts/protobuf-consumer-rust-protobuf-provider.json -p 8111
+          pact_do_not_track=true ~/.pact/bin/pact_verifier_cli -f ../protobuf-consumer-jvm/build/pacts/protobuf-consumer-protobuf-provider.json -p 8111
         shell: bash
         working-directory: examples/protobuf
         if: runner.os != 'Linux'
@@ -199,7 +199,7 @@ jobs:
         run: scripts/install-plugin-cli.sh
         shell: bash
       - name: Install Protobuf plugin
-        run: ~/bin/pact-plugin-cli -y install protobuf
+        run: ~/.pact/bin/pact-plugin-cli -y install protobuf
         shell: bash
       - name: Install Pact verifier
         run: scripts/install-verifier-cli.sh

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
     env:
       PACT_DO_NOT_TRACK: true
       RUST_LOG: trace
@@ -24,7 +24,7 @@ jobs:
         with:
           toolchain: stable
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install plugin cli
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
     env:
       PACT_DO_NOT_TRACK: true
       RUST_LOG: trace
@@ -99,7 +99,7 @@ jobs:
         with:
           toolchain: stable
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Go
@@ -173,7 +173,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
     env:
       PACT_DO_NOT_TRACK: true
       RUST_LOG: trace
@@ -188,7 +188,7 @@ jobs:
         with:
           toolchain: stable
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Go

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,7 @@ jobs:
       run: scripts/install-plugin-cli.sh
       shell: bash
     - name: Install Protobuf plugin
-      run: ~/bin/pact-plugin-cli -y install protobuf
+      run: ~/.pact/bin/pact-plugin-cli -y install protobuf
       shell: bash
     - name: Run plugin driver tests
       run: ./gradlew -s --no-daemon -i check
@@ -61,7 +61,7 @@ jobs:
         run: scripts/install-plugin-cli.sh
         shell: bash
       - name: Install Protobuf plugin
-        run: ~/bin/pact-plugin-cli -y install protobuf
+        run: ~/.pact/bin/pact-plugin-cli -y install protobuf
         shell: bash
       - name: Run plugin driver tests
         run: ./gradlew -s --no-daemon -i check

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 19
@@ -18,7 +18,7 @@ jobs:
         distribution: 'temurin'
         java-version: 19
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build plugin driver
@@ -51,7 +51,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.jdk }}
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build plugin driver

--- a/.github/workflows/plugin-cli.yml
+++ b/.github/workflows/plugin-cli.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -15,7 +15,7 @@ jobs:
           toolchain: stable
           components: clippy
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build plugin CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Rust caching
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: rust
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -55,7 +53,7 @@ jobs:
         run: choco install -y llvm
         if: runner.os == 'Windows'
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cargo flags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,23 +4,53 @@ on:
   release:
     types: [published]
 
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - feat/musl_built_binaries
+  
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-release:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - operating-system: ubuntu-20.04
+            targets: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl
+          - operating-system: windows-2019
+            targets: aarch64-pc-windows-msvc,x86_64-pc-windows-msvc
+          - operating-system: macos-12
+            targets: aarch64-apple-darwin,x86_64-apple-darwin
+      fail-fast: false
     env:
       pact_do_not_track: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-          target: aarch64-apple-darwin
+          targets: ${{ matrix.targets }}
+
+      - name: Rust caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: runner.os == 'Linux'
+        uses: docker/setup-buildx-action@v3
+
       - name: Install LLVM
         run: choco install -y llvm
         if: runner.os == 'Windows'
@@ -28,27 +58,36 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - if: startsWith(github.ref, 'refs/tags/csv-plugin')
-        run: ./release.sh ${{ runner.os }}
+      - name: Cargo flags
+        id: cargo-flags
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" = "release" ]]; then
+            echo "flags=--release" >> "$GITHUB_OUTPUT"
+          else
+            echo "flags=" >> "$GITHUB_OUTPUT"
+          fi 
+      - if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request' ||
+          startsWith(github.ref, 'refs/tags/csv-plugin')
+        run: ./release.sh ${{ runner.os }} ${{ steps.cargo-flags.outputs.flags }}
         shell: bash
         working-directory: plugins/csv
-      - name: Upload Release Assets
-        if: startsWith(github.ref, 'refs/tags/csv-plugin')
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: plugins/csv/target/artifacts/*
-          file_glob: true
-          tag: ${{ github.ref }}
-      - if: startsWith(github.ref, 'refs/tags/pact-plugin-cli')
-        run: ./release.sh ${{ runner.os }}
+      - if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request' ||
+          startsWith(github.ref, 'refs/tags/pact-plugin-cli')
+        run: ./release.sh ${{ runner.os }} ${{ steps.cargo-flags.outputs.flags }}
         shell: bash
         working-directory: cli
       - name: Upload Release Assets
-        if: startsWith(github.ref, 'refs/tags/pact-plugin-cli')
+        if: |
+          startsWith(github.ref, 'refs/tags/pact-plugin-cli') ||
+          startsWith(github.ref, 'refs/tags/csv-plugin')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: cli/target/artifacts/*
+          file: release_artifacts/*
           file_glob: true
           tag: ${{ github.ref }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,10 @@ jobs:
         run: scripts/install-plugin-cli.sh
         shell: bash
       - name: Install Protobuf plugin
-        run: ~/bin/pact-plugin-cli -y install protobuf
+        run: ~/.pact/bin/pact-plugin-cli -y install protobuf
         shell: bash
       - name: Install csv plugin
-        run: ~/bin/pact-plugin-cli -y install csv
+        run: ~/.pact/bin/pact-plugin-cli -y install csv
         shell: bash
       - name: Tests
         run: cargo test
@@ -63,7 +63,7 @@ jobs:
           curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.88.77/pact-1.88.77-linux-x86_64.tar.gz
           tar xzf pact-1.88.77-linux-x86_64.tar.gz
           VER=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          pact/bin/pact-broker publish -a "$VER+$GITHUB_SHA" -b https://pact-foundation.pactflow.io -k ${{ secrets.PACTFLOW_TOKEN }} target/pacts
+          pact/bin/pact-broker publish -a "$VER+$GITHUB_SHA" -b https://saf.pactflow.io -k ${{ secrets.PACTFLOW_TOKEN }} target/pacts
         working-directory: drivers/rust/driver_pact_tests
         if: runner.os == 'Linux'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
     env:
       pact_do_not_track: true
     steps:
@@ -17,7 +17,7 @@ jobs:
           toolchain: stable
           components: clippy
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install plugin cli
@@ -63,7 +63,7 @@ jobs:
           curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.88.77/pact-1.88.77-linux-x86_64.tar.gz
           tar xzf pact-1.88.77-linux-x86_64.tar.gz
           VER=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          pact/bin/pact-broker publish -a "$VER+$GITHUB_SHA" -b https://saf.pactflow.io -k ${{ secrets.PACTFLOW_TOKEN }} target/pacts
+          pact/bin/pact-broker publish -a "$VER+$GITHUB_SHA" -b https://pact-foundation.pactflow.io -k ${{ secrets.PACTFLOW_TOKEN }} target/pacts
         working-directory: drivers/rust/driver_pact_tests
         if: runner.os == 'Linux'
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ build
 target
 pacts
 *.out
+# Generated Release Artifacts
+release_artifacts
 
 # Misc
 

--- a/cli/release.sh
+++ b/cli/release.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+set -e
+set -x
+
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
+
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+
 if [ $# -lt 1 ]
 then
     echo "Usage : $0 <Linux|Windows|macOS>"
@@ -7,41 +17,107 @@ then
 fi
 
 echo Building Release for "$1"
+APP=pact-plugin-cli
+OS=$1
+shift;
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
+install_cross() {
+    cargo install cross@0.2.5
+}
 
-cargo clean
-mkdir -p target/artifacts/
+build_linux_x86_64() {
+    install_cross
+    cargo clean
+    cross build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/${APP}" \
+            "$ARTIFACTS_DIR/${APP}-linux-x86_64.gz"
 
-case "$1" in
+    fi
+}
+
+build_linux_aarch64() {
+    install_cross
+    cargo clean
+    cross build --target=aarch64-unknown-linux-musl "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/${APP}" \
+            "$ARTIFACTS_DIR/${APP}-linux-aarch64.gz"
+    fi
+}
+# Build the x86_64 darwin release
+build_macos_x86_64() {
+    #cargo clean
+    cargo build --target x86_64-apple-darwin "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/${APP}" \
+            "$ARTIFACTS_DIR/${APP}-osx-x86_64.gz"
+        gzip_and_sum \
+                    "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/${APP}" \
+                    "$ARTIFACTS_DIR/${APP}-macos-x86_64.gz"
+    fi
+}
+
+# Build the aarch64 darwin release
+build_macos_aarch64() {
+    #cargo clean
+    cargo build --target aarch64-apple-darwin "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/${APP}" \
+            "$ARTIFACTS_DIR/${APP}-osx-aarch64.gz"
+        gzip_and_sum \
+                    "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/${APP}" \
+                    "$ARTIFACTS_DIR/${APP}-macos-aarch64.gz"
+    fi
+}
+
+# Build the x86_64 windows release
+build_windows_x86_64() {
+    #cargo clean
+    cargo build --target x86_64-pc-windows-msvc "${cargo_flags[@]}"
+
+    # If --release in cargo flags, then gzip and sum the release artifacts
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/release/${APP}.exe" \
+            "$ARTIFACTS_DIR/${APP}-windows-x86_64.exe.gz"
+    fi
+}
+
+# Build the aarch64 windows release
+build_windows_aarch64() {
+    #cargo clean
+    cargo build --target aarch64-pc-windows-msvc "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-pc-windows-msvc/release/${APP}.exe" \
+            "$ARTIFACTS_DIR/${APP}-windows-aarch64.exe.gz"
+    fi
+}
+
+case "$OS" in
   Linux)    echo "Building for Linux"
-            docker run --rm --user "$(id -u)":"$(id -g)" -v "$(pwd):/workspace" -w /workspace -t pactfoundation/rust-musl-build -c 'cargo build --release'
-            gzip -c target/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-linux-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-linux-x86_64.gz > target/artifacts/pact-plugin-cli-linux-x86_64.gz.sha256
-
-            # Build aarch64
-            cargo install cross
-            cross build --target aarch64-unknown-linux-gnu --release
-            gzip -c target/aarch64-unknown-linux-gnu/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-linux-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-linux-aarch64.gz > target/artifacts/pact-plugin-cli-linux-aarch64.gz.sha256
+            build_linux_x86_64
+            build_linux_aarch64
             ;;
-  Windows)  echo  "Building for Windows"
-            cargo build --release
-            gzip -c target/release/pact-plugin-cli.exe > target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz > target/artifacts/pact-plugin-cli-windows-x86_64.exe.gz.sha256
+  Windows)  echo "Building for windows"
+            build_windows_x86_64
+            build_windows_aarch64
             ;;
-  macOS)    echo  "Building for OSX"
-            cargo build --release
-            gzip -c target/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-osx-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-osx-x86_64.gz > target/artifacts/pact-plugin-cli-osx-x86_64.gz.sha256
-
-            # M1
-            export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-            export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
-            cargo build --target aarch64-apple-darwin --release
-
-            gzip -c target/aarch64-apple-darwin/release/pact-plugin-cli > target/artifacts/pact-plugin-cli-osx-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-plugin-cli-osx-aarch64.gz > target/artifacts/pact-plugin-cli-osx-aarch64.gz.sha256
+  macOS)    echo  "Building for macos"
+            build_macos_x86_64
+            build_macos_aarch64
             ;;
-  *)        echo "$1 is not a recognised OS"
+  *)        echo "$OS is not a recognised OS"
             exit 1
             ;;
 esac

--- a/plugins/csv/Cross.toml
+++ b/plugins/csv/Cross.toml
@@ -1,4 +1,10 @@
-[target.aarch64-unknown-linux-gnu]
+[target.x86_64-unknown-linux-musl]
+pre-build=[
+    "apt-get update && apt-get install --assume-yes wget unzip",
+    "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
+    "unzip protoc-21.5-linux-x86_64.zip -d /usr/local/"
+]
+[target.aarch64-unknown-linux-musl]
 pre-build=[
     "dpkg --add-architecture arm64 && apt-get update && apt-get install --assume-yes wget unzip",
     "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",

--- a/plugins/csv/release.sh
+++ b/plugins/csv/release.sh
@@ -1,46 +1,123 @@
 #!/bin/bash
 
+set -e
+set -x
+
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd )"
+
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+
 if [ $# -lt 1 ]
 then
-    echo "Usage : $0 <Linux|Windows|macOS>"
+    echo "Usage : $0 <Linux|Windows|macOS> <cargo flags>"
     exit
 fi
 
-echo Building Release for "$1"
+APP=pact-csv-plugin
+OS=$1
+shift;
+echo Building Release for "$OS"
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
+install_cross() {
+    cargo install cross@0.2.5
+}
 
-cargo clean
-mkdir -p target/artifacts/
+build_linux_x86_64() {
+    install_cross
+    cargo clean
+    cross build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/${APP}" \
+            "$ARTIFACTS_DIR/${APP}-linux-x86_64.gz"
 
-case "$1" in
+    fi
+}
+
+build_linux_aarch64() {
+    install_cross
+    cargo clean
+    cross build --target=aarch64-unknown-linux-musl "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/${APP}" \
+            "$ARTIFACTS_DIR/${APP}-linux-aarch64.gz"
+    fi
+}
+# Build the x86_64 darwin release
+build_macos_x86_64() {
+    #cargo clean
+    cargo build --target x86_64-apple-darwin "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/${APP}" \
+            "$ARTIFACTS_DIR/${APP}-osx-x86_64.gz"
+        gzip_and_sum \
+                    "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/${APP}" \
+                    "$ARTIFACTS_DIR/${APP}-macos-x86_64.gz"
+    fi
+}
+
+# Build the aarch64 darwin release
+build_macos_aarch64() {
+    #cargo clean
+    cargo build --target aarch64-apple-darwin "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/${APP}" \
+            "$ARTIFACTS_DIR/${APP}-osx-aarch64.gz"
+        gzip_and_sum \
+                    "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/${APP}" \
+                    "$ARTIFACTS_DIR/${APP}-macos-aarch64.gz"
+    fi
+}
+
+# Build the x86_64 windows release
+build_windows_x86_64() {
+    #cargo clean
+    cargo build --target x86_64-pc-windows-msvc "${cargo_flags[@]}"
+
+    # If --release in cargo flags, then gzip and sum the release artifacts
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/release/${APP}.exe" \
+            "$ARTIFACTS_DIR/${APP}-windows-x86_64.exe.gz"
+    fi
+}
+
+# Build the aarch64 windows release
+build_windows_aarch64() {
+    #cargo clean
+    cargo build --target aarch64-pc-windows-msvc "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-pc-windows-msvc/release/${APP}.exe" \
+            "$ARTIFACTS_DIR/${APP}-windows-aarch64.exe.gz"
+    fi
+}
+
+case "$OS" in
   Linux)    echo "Building for Linux"
-            docker run --rm --user "$(id -u)":"$(id -g)" -v "$(pwd):/workspace" -w /workspace -t pactfoundation/rust-musl-build -c 'cargo build --release'
-            gzip -c target/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-linux-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-linux-x86_64.gz > target/artifacts/pact-csv-plugin-linux-x86_64.gz.sha256
-            cp pact-plugin.json target/artifacts/
-            cargo install cross
-            cross build --target aarch64-unknown-linux-gnu --release
-            gzip -c target/aarch64-unknown-linux-gnu/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-linux-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-linux-aarch64.gz > target/artifacts/pact-csv-plugin-linux-aarch64.gz.sha256
+            build_linux_x86_64
+            build_linux_aarch64
             ;;
-  Windows)  echo  "Building for Windows"
-            cargo build --release
-            gzip -c target/release/pact-csv-plugin.exe > target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz > target/artifacts/pact-csv-plugin-windows-x86_64.exe.gz.sha256
+  Windows)  echo "Building for windows"
+            build_windows_x86_64
+            build_windows_aarch64
             ;;
-  macOS)    echo  "Building for OSX"
-            cargo build --release
-            gzip -c target/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-osx-x86_64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-osx-x86_64.gz > target/artifacts/pact-csv-plugin-osx-x86_64.gz.sha256
-
-            # M1
-            export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-            export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
-            cargo build --target aarch64-apple-darwin --release
-
-            gzip -c target/aarch64-apple-darwin/release/pact-csv-plugin > target/artifacts/pact-csv-plugin-osx-aarch64.gz
-            openssl dgst -sha256 -r target/artifacts/pact-csv-plugin-osx-aarch64.gz > target/artifacts/pact-csv-plugin-osx-aarch64.gz.sha256
+  macOS)    echo  "Building for macos"
+            build_macos_x86_64
+            build_macos_aarch64
             ;;
-  *)        echo "$1 is not a recognised OS"
+  *)        echo "$OS is not a recognised OS"
             exit 1
             ;;
 esac

--- a/scripts/gzip-and-sum.sh
+++ b/scripts/gzip-and-sum.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Gzip and sum a file.
+#
+# Usage: gzip_and_sum <orig_file> <target_file> [<digest_file>]
+#
+# - orig_file: the file to gzip and sum
+# - target_file: the file to write the gzipped file to
+# - digest_file: the file to write the digest to. If not provided, defaults to
+#   <target_file>.sha256
+gzip_and_sum() {
+    orig_file=$1
+    target_file=$2
+    digest_file=${3:-$target_file.sha256}
+
+    gzip --stdout --best "$orig_file" > "$target_file"
+    openssl dgst -sha256 -r "$target_file" > "$digest_file"
+}

--- a/scripts/install-plugin-cli.sh
+++ b/scripts/install-plugin-cli.sh
@@ -5,32 +5,40 @@ set -x
 
 VERSION="0.1.0"
 
-mkdir -p ~/bin
+mkdir -p ~/.pact/bin
 case "$(uname -s)" in
 
    Darwin)
      echo '== Installing plugin CLI for Mac OSX =='
-     if [ "$(uname -m)" == "arm64" ]; then
-        curl -L -o ~/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-osx-aarch64.gz
+     if [ "$(uname -m)" = "arm64" ]; then
+        curl -L -o ~/.pact/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-osx-aarch64.gz
      else
-        curl -L -o ~/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-osx-x86_64.gz
+        curl -L -o ~/.pact/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-osx-x86_64.gz
      fi
-     gunzip -N -f ~/bin/pact-plugin-cli.gz
-     chmod +x ~/bin/pact-plugin-cli
+     gunzip -N -f ~/.pact/bin/pact-plugin-cli.gz
+     chmod +x ~/.pact/bin/pact-plugin-cli
      ;;
 
    Linux)
      echo '== Installing plugin CLI for Linux =='
-     curl -L -o ~/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-linux-x86_64.gz
-     gunzip -N -f ~/bin/pact-plugin-cli.gz
-     chmod +x ~/bin/pact-plugin-cli
+     if [ "$(uname -m)" = "aarch64" ]; then
+      curl -L -o ~/.pact/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-linux-aarch64.gz
+     else
+      curl -L -o ~/.pact/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-linux-x86_64.gz
+     fi
+     gunzip -N -f ~/.pact/bin/pact-plugin-cli.gz
+     chmod +x ~/.pact/bin/pact-plugin-cli
      ;;
 
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
      echo '== Installing plugin CLI for MS Windows =='
-     curl -L -o ~/bin/pact-plugin-cli.exe.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-windows-x86_64.exe.gz
-     gunzip -N -f ~/bin/pact-plugin-cli.exe.gz
-     chmod +x ~/bin/pact-plugin-cli.exe
+     if [ "$(uname -m)" = "aarch64" ]; then
+      curl -L -o ~/.pact/bin/pact-plugin-cli.exe.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-windows-aarch64.exe.gz
+     else
+      curl -L -o ~/.pact/bin/pact-plugin-cli.exe.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-windows-x86_64.exe.gz
+     fi
+     gunzip -N -f ~/.pact/bin/pact-plugin-cli.exe.gz
+     chmod +x ~/.pact/bin/pact-plugin-cli.exe
      ;;
 
    *)

--- a/scripts/install-verifier-cli.sh
+++ b/scripts/install-verifier-cli.sh
@@ -5,32 +5,40 @@ set -x
 
 VERSION="0.9.20"
 
-mkdir -p ~/bin
+mkdir -p ~/.pact/bin
 case "$(uname -s)" in
 
    Darwin)
-     echo '== Installing verifier CLI for Mac OSX =='
-     if [ "$(uname -m)" == "arm64" ]; then
-        curl -L -o ~/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-osx-aarch64.gz
+     echo '== Installing pact verifier CLI for Mac OSX =='
+     if [ "$(uname -m)" = "arm64" ]; then
+        curl -L -o ~/.pact/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-osx-aarch64.gz
      else
-        curl -L -o ~/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-osx-x86_64.gz
+        curl -L -o ~/.pact/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-osx-x86_64.gz
      fi
-     gunzip -N -f ~/bin/pact_verifier_cli.gz
-     chmod +x ~/bin/pact_verifier_cli
+     gunzip -N -f ~/.pact/bin/pact_verifier_cli.gz
+     chmod +x ~/.pact/bin/pact_verifier_cli
      ;;
 
    Linux)
-     echo '== Installing verifier CLI for Linux =='
-     curl -L -o ~/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-linux-x86_64.gz
-     gunzip -N -f ~/bin/pact_verifier_cli.gz
-     chmod +x ~/bin/pact_verifier_cli
+     echo '== Installing pact verifier CLI for Linux =='
+     if [ "$(uname -m)" = "aarch64" ]; then
+      curl -L -o ~/.pact/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-linux-aarch64.gz
+     else
+      curl -L -o ~/.pact/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-linux-x86_64.gz
+     fi
+     gunzip -N -f ~/.pact/bin/pact_verifier_cli.gz
+     chmod +x ~/.pact/bin/pact_verifier_cli
      ;;
 
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
-     echo '== Installing verifier CLI for MS Windows =='
-     curl -L -o ~/bin/pact_verifier_cli.exe.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-windows-x86_64.exe.gz
-     gunzip -N -f ~/bin/pact_verifier_cli.exe.gz
-     chmod +x ~/bin/pact_verifier_cli.exe
+     echo '== Installing pact verifier CLI for MS Windows =='
+     if [ "$(uname -m)" = "aarch64" ]; then
+      curl -L -o ~/.pact/bin/pact_verifier_cli.exe.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-windows-aarch64.exe.gz
+     else
+      curl -L -o ~/.pact/bin/pact_verifier_cli.exe.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v${VERSION}/pact_verifier_cli-windows-x86_64.exe.gz
+     fi
+     gunzip -N -f ~/.pact/bin/pact_verifier_cli.exe.gz
+     chmod +x ~/.pact/bin/pact_verifier_cli.exe
      ;;
 
    *)

--- a/scripts/run-grpc-examples.sh
+++ b/scripts/run-grpc-examples.sh
@@ -44,7 +44,7 @@ trap "kill $PID" EXIT
 sleep 1
 ls -la
 PROVIDER_PORT=$(cat provider.go.out | cut -f4 -d:)
-~/bin/pact_verifier_cli -f ../consumer-jvm/build/pacts/grpc-consumer-jvm-area-calculator-provider.json\
+~/.pact/bin/pact_verifier_cli -f ../consumer-jvm/build/pacts/grpc-consumer-jvm-area-calculator-provider.json\
   -f ../consumer-rust/target/pacts/grpc-consumer-rust-area-calculator-provider.json\
   -f ../consumer-go/pacts/grpc-consumer-go-area-calculator-provider.json\
   -p "$PROVIDER_PORT"


### PR DESCRIPTION
feat: linux musl static bins / windows aarch64

- create linux executables linked statically to musl
  - drop gnu (glibc) target, executable will work on alpine & glibc based distros (debian etc)
- create windows aarch64 target
- refactor release script & workflow to match pact-reference
  - builds on pull request to master/main branch, in debug mode
- update installer script
 - more supported platforms
 - install to ~/.pact/bin

Related epics

- musl all the things
  - https://github.com/pact-foundation/devrel/issues/30

## yak shaves

- macos-latest is now arm64 and setup-protoc action needed updating to at least v1.3.0 to support arm.
- reverted macos-latest runners to macos-12 to retain existing behaviour
- updating pact-verifier-cli to 1.x.x results in example test failures. examples probably needs deps updating