### PR TITLE
feat(cli): support PACT_PLUGIN_CLI_SKIP_LOAD

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 pact-plugin-driver = "0.6.1"
-clap = { version = "4.4.11", features = [ "derive", "cargo" ] }
+clap = { version = "4.4.11", features = [ "derive", "cargo", "env" ] }
 comfy-table = "7.1.1"
 home = "0.5.9"
 anyhow = "1.0.86"

--- a/cli/README.md
+++ b/cli/README.md
@@ -141,6 +141,11 @@ Options:
   -v, --version <VERSION>
           The version to install. This is only used for known plugins
 
+      --skip-load
+          Skip auto-loading of plugin
+          
+          [env: PACT_PLUGIN_CLI_SKIP_LOAD=]
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -76,7 +76,11 @@ enum Commands {
 
     #[clap(short, long)]
     /// The version to install. This is only used for known plugins.
-    version: Option<String>
+    version: Option<String>,
+
+    #[clap(long,env="PACT_PLUGIN_CLI_SKIP_LOAD")]
+    /// Skip auto-loading of plugin
+    skip_load: bool
   },
 
   /// Remove a plugin
@@ -232,8 +236,8 @@ fn main() -> Result<(), ExitCode> {
   let result = match &cli.command {
     Commands::List(command) => list_plugins(command),
     Commands::Env => print_env(),
-    Commands::Install { yes, skip_if_installed, source, source_type, version } => {
-      install::install_plugin(source, source_type, *yes || cli.yes, *skip_if_installed, version)
+    Commands::Install { yes, skip_if_installed, source, source_type, version, skip_load } => {
+      install::install_plugin(source, source_type, *yes || cli.yes, *skip_if_installed, version, *skip_load)
     },
     Commands::Remove { yes, name, version } => remove_plugin(name, version, *yes || cli.yes),
     Commands::Enable { name, version } => enable_plugin(name, version),

--- a/cli/tests/cmd/install.stdout
+++ b/cli/tests/cmd/install.stdout
@@ -23,5 +23,10 @@ Options:
   -v, --version <VERSION>
           The version to install. This is only used for known plugins
 
+      --skip-load
+          Skip auto-loading of plugin
+          
+          [env: PACT_PLUGIN_CLI_SKIP_LOAD=]
+
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
Allow skipping the auto load of plugins, to allow installing the avro plugin whilst we sort the below snag which will be introduced by #69 

Avro plugin has failed to load on windows since moving to threads in [commit](https://github.com/pact-foundation/pact-plugins/commit/d9e441e967c7fb53dbe0992b2787dc21fbd67c7e#diff-5a5d79260a9aa82b30f9693013d16a88f6fc14135d71220b14655c64c7e8d4d5) 

Amending the following logback.xml from the installed pact-avro-plugin

From

https://github.com/austek/pact-avro-plugin/blob/main/modules/plugin/src/main/resources/logback.xml


To

```xml
<configuration>
</configuration>
```

will allow the plugin framework to pick up the plugins loaded message (serverKey and port).

So there may be a change required in the pact-avro-plugin to support.

This can easily be reproduced with on a windows machine by performing `pact-plugin-cli install -y avro`