### PR TITLE
Use Compress4J

### DIFF
--- a/drivers/jvm/core/build.gradle
+++ b/drivers/jvm/core/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.apache.tika:tika-core:2.9.2'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.8.22'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.22'
-    implementation 'org.rauschig:jarchivelib:1.2.0'
+    implementation 'io.github.compress4j:compress4j:2.1.1'
     implementation 'org.apache.commons:commons-compress:1.26.1'
 
     protobuf files('../../../proto/')

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginDownloader.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginDownloader.kt
@@ -4,8 +4,11 @@ import au.com.dius.pact.core.support.Result
 import au.com.dius.pact.core.support.isNotEmpty
 import au.com.dius.pact.core.support.json.JsonParser
 import au.com.dius.pact.core.support.json.JsonValue
+import io.github.compress4j.archivers.ArchiveFormat
+import io.github.compress4j.archivers.ArchiverFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.commons.codec.digest.DigestUtils
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
 import org.apache.commons.io.FilenameUtils
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.SystemUtils.IS_OS_LINUX
@@ -15,8 +18,6 @@ import org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS
 import org.apache.commons.lang3.SystemUtils.OS_ARCH
 import org.apache.commons.lang3.SystemUtils.OS_NAME
 import org.apache.hc.client5.http.fluent.Request
-import org.rauschig.jarchivelib.ArchiveFormat
-import org.rauschig.jarchivelib.ArchiverFactory
 import java.io.File
 import java.io.StringReader
 import java.util.zip.GZIPInputStream
@@ -192,7 +193,7 @@ object DefaultPluginDownloader: PluginDownloader {
           }
         }
 
-        val archiver = ArchiverFactory.createArchiver(ArchiveFormat.ZIP)
+        val archiver = ArchiverFactory.createArchiver<ZipArchiveEntry>(ArchiveFormat.ZIP)
         archiver.extract(fileResult.value, pluginDir)
         return Result.Ok(fileResult.value)
       }


### PR DESCRIPTION
Use [Compress4J](https://github.com/compress4j/compress4j) instead of JArchiveLib to prevent CVE-2024-26308 and CVE-2024-25710

the reason for switching to Compress4J
https://github.com/thrau/jarchivelib/issues/100

resolves #79 