### PR TITLE
feat: add arrayContains to matching rule definition grammar and docs

### DIFF
--- a/docs/matching-rule-definition-expressions.md
+++ b/docs/matching-rule-definition-expressions.md
@@ -85,6 +85,25 @@ If an expression is provided, that will be used instead of the type matching rul
 
 For example: `atMost(2)`
 
+### arrayContains(EXPRESSION [, EXPRESSION, ...])
+
+Configures an array-contains matching rule. Each expression defines a variant
+that must be found in the array. Matching is successful if each variant matches
+at least one item in the array. Order does not matter, and extra items are allowed.
+
+For example: `arrayContains(matching(equalTo, 'PUBLIC'))`
+
+Multiple required values: `arrayContains(matching(equalTo, 'PUBLIC'), matching(regex, 'PRIVATE.*', 'PRIVATE_LINK'))`
+
+With references (for complex object variants):
+`arrayContains(matching($'variant1'), matching($'variant2'))`
+
+Mixed inline and reference variants:
+`arrayContains(matching(equalTo, 'PUBLIC'), matching($'complexVariant'))`
+
+Can be composed with other expressions:
+`atLeast(2), eachValue(matching(type, 'example')), arrayContains(matching(equalTo, 'PUBLIC'))`
+
 ## Composing expressions
 
 Expressions can be composed by separating them with a comma. For example

--- a/docs/matching-rule-definition.g4
+++ b/docs/matching-rule-definition.g4
@@ -17,6 +17,7 @@ matchingDefinitionExp :
       | 'notEmpty' LEFT_BRACKET primitiveValue RIGHT_BRACKET
       | 'eachKey' LEFT_BRACKET matchingDefinitionExp RIGHT_BRACKET
       | 'eachValue' LEFT_BRACKET matchingDefinitionExp RIGHT_BRACKET
+      | 'arrayContains' LEFT_BRACKET matchingDefinitionExp ( COMMA matchingDefinitionExp )* RIGHT_BRACKET
       | 'atLeast' LEFT_BRACKET DIGIT+ RIGHT_BRACKET
       | 'atMost' LEFT_BRACKET DIGIT+ RIGHT_BRACKET
     )


### PR DESCRIPTION
## Summary

- Add `arrayContains` to the ANTLR4 grammar (`.g4`) and markdown documentation
- `arrayContains(EXPRESSION [, EXPRESSION, ...])` — each expression defines a variant that must be found in the array
- Supports inline matchers and references (`matching($'name')`)
- Cannot be combined with `eachValue`, `eachKey`, `atLeast`, or `atMost`

## Context

The plugin matching expression language is missing `arrayContains` — while the native DSLs (JS `arrayContaining()`, JVM `arrayContaining()`) support it, and `MatchingRule::ArrayContains` exists in pact_models + pact_matching, there's no way to trigger it from plugin expressions.

This PR updates the grammar docs. The parser implementation is in a separate PR to pact-foundation/pact-reference.

## Related PRs

- pact-foundation/pact-reference (pending airlock): expression parser implementation
- pactflow/pact-protobuf-plugin#236: protobuf plugin wiring + integration tests

## Test plan

- [ ] Grammar doc is consistent with the parser implementation
- [ ] Markdown examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)