### PR TITLE
feat(008): Add test run ID thread-local and inject testContext into V2 plugin requests

### DIFF
--- a/drivers/rust/driver/src/lib.rs
+++ b/drivers/rust/driver/src/lib.rs
@@ -27,5 +27,6 @@ pub mod plugin_models;
 pub mod proto;
 pub(crate) mod proto_v2;
 pub mod repository;
+pub mod test_context;
 pub mod utils;
 pub mod verification;

--- a/drivers/rust/driver/src/plugin_log_sink.rs
+++ b/drivers/rust/driver/src/plugin_log_sink.rs
@@ -3,10 +3,11 @@
 use std::sync::RwLock;
 
 use lazy_static::lazy_static;
+use serde::Serialize;
 use tracing::{debug, error, info, warn};
 
 /// Source of a plugin log entry
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum PluginLogSource {
   /// Raw line read from the plugin process stderr
   Stderr,
@@ -15,7 +16,7 @@ pub enum PluginLogSource {
 }
 
 /// Structured log entry produced by a running plugin
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PluginLogEntry {
   /// Plugin name from its manifest
   pub plugin_name: String,

--- a/drivers/rust/driver/src/plugin_models.rs
+++ b/drivers/rust/driver/src/plugin_models.rs
@@ -243,13 +243,16 @@ impl PluginClient {
         .compare_contents(Request::new(request))
         .await
         .map(|response| response.into_inner()),
-      PluginClient::V2(client) => client
-        .compare_contents(Request::new(Self::convert_message::<
-          _,
-          proto_v2::CompareContentsRequest,
-        >(request)?))
-        .await
-        .and_then(|response| Self::convert_message(response.into_inner())),
+      PluginClient::V2(client) => {
+        let mut v2_req = Self::convert_message::<_, proto_v2::CompareContentsRequest>(request)?;
+        if v2_req.test_context.is_none() {
+          v2_req.test_context = crate::test_context::current_test_context();
+        }
+        client
+          .compare_contents(Request::new(v2_req))
+          .await
+          .and_then(|response| Self::convert_message(response.into_inner()))
+      }
     }
   }
 
@@ -262,13 +265,17 @@ impl PluginClient {
         .configure_interaction(Request::new(request))
         .await
         .map(|response| response.into_inner()),
-      PluginClient::V2(client) => client
-        .configure_interaction(Request::new(Self::convert_message::<
-          _,
-          proto_v2::ConfigureInteractionRequest,
-        >(request)?))
-        .await
-        .and_then(|response| Self::convert_message(response.into_inner())),
+      PluginClient::V2(client) => {
+        let mut v2_req =
+          Self::convert_message::<_, proto_v2::ConfigureInteractionRequest>(request)?;
+        if v2_req.test_context.is_none() {
+          v2_req.test_context = crate::test_context::current_test_context();
+        }
+        client
+          .configure_interaction(Request::new(v2_req))
+          .await
+          .and_then(|response| Self::convert_message(response.into_inner()))
+      }
     }
   }
 

--- a/drivers/rust/driver/src/test_context.rs
+++ b/drivers/rust/driver/src/test_context.rs
@@ -1,0 +1,36 @@
+//! Thread-local test run ID for log correlation across driver and plugin log entries
+
+use std::cell::RefCell;
+
+thread_local! {
+  static CURRENT_TEST_RUN_ID: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Set the test run ID for the current thread. Pass `None` to clear it.
+///
+/// Should be called by the test framework (pact_consumer, pact_ffi) before any plugin
+/// calls, so that the ID is included in `testContext` of outgoing gRPC requests and can
+/// be used to correlate plugin log entries with a specific test.
+pub fn set_test_run_id(id: Option<String>) {
+  CURRENT_TEST_RUN_ID.with(|cell| *cell.borrow_mut() = id);
+}
+
+/// Return the test run ID set for the current thread, if any.
+pub fn current_test_run_id() -> Option<String> {
+  CURRENT_TEST_RUN_ID.with(|cell| cell.borrow().clone())
+}
+
+/// Build a `prost_types::Struct` containing `{ "testRunId": "<id>" }` when a test run ID
+/// is set on the current thread, or return `None` if none is set.
+pub(crate) fn current_test_context() -> Option<prost_types::Struct> {
+  current_test_run_id().map(|id| {
+    let mut fields = ::std::collections::BTreeMap::new();
+    fields.insert(
+      "testRunId".to_string(),
+      prost_types::Value {
+        kind: Some(prost_types::value::Kind::StringValue(id)),
+      },
+    );
+    prost_types::Struct { fields }
+  })
+}


### PR DESCRIPTION
## Summary

- Adds a `test_context` module to the Rust plugin driver with a **thread-local test run ID**. Callers (`pact_consumer`, `pact_ffi`) set this before making plugin calls so all plugin log entries from that call can be correlated with a specific test.
- Automatically injects `testContext: { "testRunId": "<id>" }` into V2 `ConfigureInteractionRequest` and `CompareContentsRequest` when a test run ID is present on the current thread. Injection happens after the V1→V2 encode/decode conversion in `PluginClient`, so the frozen V1 proto structs are not changed.
- Adds `#[derive(Serialize)]` to `PluginLogSource` and `PluginLogEntry` so entries can be serialised to JSON for retrieval via the FFI (`pactffi_get_plugin_logs`).

Part of [proposal 008 — Plugin observability and logging](docs/proposals/008_Plugin_observability_and_logging.md). The corresponding `pact-reference` changes (FFI sink registration, `pactffi_set_test_run_id`, `pactffi_register_plugin_log_callback`, `pactffi_get_plugin_logs`, and `pact_consumer` UUID injection) will be submitted in a separate PR once this is released.

## Test plan

- [ ] `cargo check` passes cleanly in the driver crate
- [ ] Existing driver tests pass (`cargo test --package pact-plugin-driver`)
- [ ] Verify that a V2-capable plugin receives `testContext.testRunId` in a `ConfigureInteractionRequest` when the thread-local is set
- [ ] Verify that V1-only plugins are unaffected (no `test_context` field on V1 proto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)