### PR TITLE
fix(008): Include testRunId in JVM host log messages and plugin log format

### DIFF
--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginHostServer.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginHostServer.kt
@@ -36,8 +36,8 @@ internal class PluginHostGrpcService : PluginHostGrpc.PluginHostImplBase() {
     } else {
       if (shortId.isNotEmpty()) "[plugin:$shortId]" else "[plugin]"
     }
-    val message = "$prefix ${request.message}"
     val testRunId = request.testRunId.ifEmpty { null }
+    val message = if (testRunId != null) "$prefix [$testRunId] ${request.message}" else "$prefix ${request.message}"
     if (testRunId != null) MDC.put("testRunId", testRunId)
     try {
       when (request.level.uppercase()) {

--- a/examples/csv/csv-consumer-jvm/build.gradle
+++ b/examples/csv/csv-consumer-jvm/build.gradle
@@ -14,8 +14,8 @@ dependencies {
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
-  testImplementation 'au.com.dius.pact.consumer:junit5:4.7.1'
-  testImplementation 'io.pact.plugin.driver:core:1.0.0-beta.3'
+  testImplementation 'au.com.dius.pact.consumer:junit5:4.7.3'
+  testImplementation 'io.pact.plugin.driver:core:1.0.0-beta.5'
   testImplementation 'ch.qos.logback:logback-classic:1.4.11'
   testImplementation 'org.hamcrest:hamcrest:2.2'
   testImplementation('com.github.javafaker:javafaker:1.0.2') {

--- a/examples/csv/csv-consumer-rust/Cargo.lock
+++ b/examples/csv/csv-consumer-rust/Cargo.lock
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "pact-plugin-driver"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2198,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "pact_consumer"
 version = "1.4.5"
-source = "git+https://github.com/pact-foundation/pact-reference.git#5974547cb456d9f19f71645e5019a55d92fb1448"
+source = "git+https://github.com/pact-foundation/pact-reference.git#40318b16472d15c516f091dc530eac3d963ce44c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2215,13 +2215,14 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "uuid 1.23.3",
  "yansi",
 ]
 
 [[package]]
 name = "pact_matching"
 version = "2.0.7"
-source = "git+https://github.com/pact-foundation/pact-reference.git#5974547cb456d9f19f71645e5019a55d92fb1448"
+source = "git+https://github.com/pact-foundation/pact-reference.git#40318b16472d15c516f091dc530eac3d963ce44c"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2619,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2639,9 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2675,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2974,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3517,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "js-sys",
@@ -3538,9 +3539,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",

--- a/examples/csv/csv-consumer-rust/Cargo.toml
+++ b/examples/csv/csv-consumer-rust/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8.5"
 test-log = "0.2.16"
 
 [patch.crates-io]
-pact-plugin-driver = { version = "1.0.0-beta.3", path = "../../../drivers/rust/driver" }
+pact-plugin-driver = { path = "../../../drivers/rust/driver" }
 pact_consumer = { git = "https://github.com/pact-foundation/pact-reference.git" }
 pact_matching = { git = "https://github.com/pact-foundation/pact-reference.git" }
 pact_mock_server = { git = "https://github.com/pact-foundation/pact-core-mock-server.git" }

--- a/plugins/csv/Cargo.lock
+++ b/plugins/csv/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
  "log",
  "logos 0.12.1",
  "maplit",
- "pact-plugin-driver 1.0.0-beta.3",
+ "pact-plugin-driver 1.0.0-beta.6",
  "pact_matching",
  "pact_models",
  "prost",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "pact-plugin-driver"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/plugins/csv/src/main.rs
+++ b/plugins/csv/src/main.rs
@@ -106,6 +106,15 @@ async fn init_logging() {
   }
 
   let mut builder = env_logger::Builder::from_env(Env::new().filter("LOG_LEVEL"));
+  builder.format(|buf, record| {
+    use std::io::Write;
+    let test_run_id = TEST_RUN_ID.try_with(|id| id.clone()).unwrap_or_default();
+    if !test_run_id.is_empty() {
+      writeln!(buf, "[{} {} {}] {}", record.level(), record.target(), test_run_id, record.args())
+    } else {
+      writeln!(buf, "[{} {}] {}", record.level(), record.target(), record.args())
+    }
+  });
   let inner = builder.build();
 
   let host_tx = match std::env::var("PACT_PLUGIN_HOST") {

--- a/plugins/jsonrpc/src/main.rs
+++ b/plugins/jsonrpc/src/main.rs
@@ -107,7 +107,17 @@ async fn init_logging() {
     PLUGIN_INSTANCE_ID.set(id).ok();
   }
 
-  let inner = env_logger::Builder::from_default_env().build();
+  let mut builder = env_logger::Builder::from_default_env();
+  builder.format(|buf, record| {
+    use std::io::Write;
+    let test_run_id = TEST_RUN_ID.try_with(|id| id.clone()).unwrap_or_default();
+    if !test_run_id.is_empty() {
+      writeln!(buf, "[{} {} {}] {}", record.level(), record.target(), test_run_id, record.args())
+    } else {
+      writeln!(buf, "[{} {}] {}", record.level(), record.target(), record.args())
+    }
+  });
+  let inner = builder.build();
 
   let host_tx = match std::env::var("PACT_PLUGIN_HOST") {
     Ok(host_addr) => {


### PR DESCRIPTION
## Summary

Two gaps in the proposal 008 observability chain that caused `testRunId` to be invisible in log output:

**JVM driver — `PluginHostServer.kt`**

The `log` RPC handler received `testRunId` from the plugin's `LogMessage` and set it in SLF4J MDC, but the log message string itself only contained `[pluginName:shortId]`. MDC visibility depends on the logging pattern configured by the consumer, so the ID was silently dropped for users without `%X{testRunId}` in their pattern.

Fix: include `testRunId` inline in the message: `[pluginName:shortId] [testRunId] message`.

**CSV and JSON-RPC plugins — `main.rs`**

`PluginHostLogger::log()` already reads `TEST_RUN_ID` from the tokio task-local and sends it to the host via the `LogMessage` RPC. But `self.inner.log(record)` wrote to the plugin's own stderr using env_logger's default format, which has no awareness of the task-local — so the plugin's own log file never showed `testRunId`.

Fix: add a custom `builder.format()` closure that reads `TEST_RUN_ID.try_with()` at format time. This is safe because the closure runs synchronously within the tokio task-local scope set by `.scope()`.

## Test plan

- [ ] JVM consumer test log output shows `[pluginName:shortId] [<uuid>] <message>` for plugin log entries
- [ ] CSV plugin stderr shows `[LEVEL target <uuid>] message` when a testRunId is in scope
- [ ] JSON-RPC plugin stderr shows `[LEVEL target <uuid>] message` when a testRunId is in scope
- [ ] Log lines emitted outside a request scope (e.g. plugin startup) still format cleanly without a UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)