### PR TITLE
feat: add support for Lua transport plugins to both drivers

### DIFF
--- a/docs/writing-plugin-guide.md
+++ b/docs/writing-plugin-guide.md
@@ -5,8 +5,8 @@ test or during provider verification). They are designed to be stateless and res
 that is running the tests. They can be written in any language that has gRPC support, but ideally should
 be written in a language that has minimal system dependencies.
 
-Alternatively, a content-matcher/content-generator plugin can be written in **Lua** and embedded directly in the
-driver's own process instead of run as a separate gRPC child process - see
+Alternatively, a plugin (content-matcher/content-generator, transport, or both) can be written in **Lua** and
+embedded directly in the driver's own process instead of run as a separate gRPC child process - see
 [Writing plugins in Lua](#writing-plugins-in-lua) below.
 
 **IMPORTANT NOTE:** Please keep the end users in mind when selecting a language to write a plugin in. If you use, say
@@ -119,11 +119,10 @@ Refer to the [Plugin drivers](plugin-driver-design.md) for more details.
 
 ## Writing plugins in Lua
 
-As an alternative to a compiled gRPC server, a content-matcher/content-generator plugin can be written in **Lua**
-and run embedded directly in the driver's own process, instead of as a separate child process. This trades away
-language-agnosticism (only Lua is supported this way) for a much simpler authoring experience: no gRPC boilerplate,
-no protobuf code generation, and no separate executable to build and distribute per OS/architecture - just `.lua`
-files.
+As an alternative to a compiled gRPC server, a plugin can be written in **Lua** and run embedded directly in the
+driver's own process, instead of as a separate child process. This trades away language-agnosticism (only Lua is
+supported this way) for a much simpler authoring experience: no gRPC boilerplate, no protobuf code generation, and
+no separate executable to build and distribute per OS/architecture - just `.lua` files.
 
 Both drivers embed a real Lua 5.4 interpreter, so a script behaves identically on either one:
 
@@ -137,13 +136,21 @@ See the [JWT plugin](../plugins/jwt) for a complete, working reference implement
 
 ### Scope
 
-Only content matching and generation is supported: `compareContents`, `configureInteraction`, and `generateContent`.
-Mock-server hosting and provider-verification RPCs (`verifyInteraction`/`prepareInteractionForVerification`) are
-only ever invoked for `TRANSPORT`-registered plugins, never for `CONTENT_MATCHER`/`CONTENT_GENERATOR` ones (see
-[Content Matchers and Generators](content-matcher-design.md)), so there's no reason to support them for a Lua
-plugin - a Lua plugin gets full provider-verification support for free through `compareContents`/`generateContents`
-alone, since the core verifier makes the real request to the provider and then reuses ordinary content matching to
-compare the actual response against the expected one.
+A Lua plugin can register any combination of `CONTENT_MATCHER`/`CONTENT_GENERATOR` and `TRANSPORT` catalogue
+entries from its `init` function - the same way an `exec` (gRPC) plugin does. For a content-matcher/generator
+plugin, only `compareContents`, `configureInteraction`, and `generateContent` are ever called (see
+[Content Matchers and Generators](content-matcher-design.md)); a Lua plugin gets full provider-verification support
+for free through `compareContents`/`generateContent` alone, since the core verifier makes the real request to the
+provider and then reuses ordinary content matching to compare the actual response against the expected one.
+
+For a `TRANSPORT`-registered plugin, the mock-server (`start_mock_server`/`shutdown_mock_server`/
+`get_mock_server_results`) and provider-verification (`prepare_interaction_for_verification`/`verify_interaction`)
+functions are also supported (see [Entry point contract](#entry-point-contract) below). As with a gRPC transport
+plugin, the driver only calls these functions at the right points in the test lifecycle - your script is entirely
+responsible for whatever the transport actually requires (binding a listening socket for a mock server, making the
+real outbound call during verification, etc). Since Lua itself has no built-in socket support, and only pure-Lua
+LuaRocks packages are supported (see [LuaRocks support](#luarocks-support) below), a Lua transport plugin is
+realistically limited to protocols you can implement without a compiled networking extension.
 
 ### Manifest
 
@@ -214,6 +221,41 @@ tables with string keys, mapping directly to the fields of the corresponding gRP
   generate field-by-field.
 - **`update_catalogue(catalogue)` (optional)** - called whenever another plugin loads and the combined catalogue
   changes. If you don't define this function, it's a no-op.
+
+If your plugin registers a `TRANSPORT` catalogue entry, it must also define these functions. Each is called with
+either a V1-shaped or a V2-shaped request table, never both, depending on your manifest's `pluginInterfaceVersion`
+(the same static, per-plugin-instance choice the driver makes for a gRPC transport plugin) - a V2 request replaces
+the whole-Pact-as-JSON-string-plus-key fields with a single structured `interaction_contents` table, and adds a
+`test_context` field, so you don't need to parse a full Pact document just to find the interaction being handled.
+
+- **`start_mock_server(request) -> table`** - called to start a mock server for a consumer test. `request` has
+  `host_interface`, `port`, `tls`, `test_context`, and either `pact` (a JSON string, V1) or `interactions` (an array
+  of `{ interaction_type, consumer, provider, plugin_configuration }`, V2). Your script must actually stand up
+  whatever server the transport needs and return:
+  - `{ error = "..." }` - the mock server failed to start.
+  - `{ details = { key = "...", port = ..., address = "..." } }` - `key` is an ID you choose, used in later
+    `shutdown_mock_server`/`get_mock_server_results` calls to identify this server.
+- **`shutdown_mock_server(server_key) -> table`** and **`get_mock_server_results(server_key) -> table`** - called to
+  stop a mock server (returning its final results) or poll its results while still running. `server_key` is the
+  `key` you returned from `start_mock_server`. Both return:
+  ```lua
+  { ok = true, results = { { path = "...", error = "...", mismatches = { ... } }, ... } }
+  ```
+  Each `mismatches` entry is a plain string or a table, exactly like a `match_contents` mismatch (see above).
+- **`prepare_interaction_for_verification(request) -> table`** - called during provider verification, before the
+  real request is made, to build the request data. `request` has `config` and either `pact`/`interaction_key` (V1)
+  or `interaction_contents` (V2). Must return:
+  - `{ error = "..." }` - preparation failed.
+  - `{ interaction_data = { body = { ... }, metadata = { ... } } }` - `metadata` is a table keyed by metadata name;
+    each value is either a plain Lua value (JSON-like, for a non-binary value) or `{ binary = "..." }` (for a
+    binary value, e.g. raw header bytes).
+- **`verify_interaction(request) -> table`** - called to actually make the request against the real provider and
+  compare the response. `request` has `interaction_data` (shaped like `prepare_interaction_for_verification`'s
+  response above), `config`, and either `pact`/`interaction_key` (V1) or `interaction_contents` (V2). Must return:
+  - `{ error = "..." }` - the verification call itself failed (e.g. couldn't reach the provider).
+  - `{ result = { success = true/false, response_data = { ... } or nil, mismatches = { ... }, output = { "...", ... } } }`
+    - `mismatches` is an array where each entry is either a plain error string or a `match_contents`-shaped mismatch
+      table; `output` is an array of strings displayed to the user (e.g. the request/response line).
 
 ### Host functions available to your script
 

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPactPlugin.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPactPlugin.kt
@@ -37,10 +37,16 @@ private val logger = KotlinLogging.logger {}
  * - `generate_content(contents, generators, test_mode)` (optional; passthrough default)
  * - `update_catalogue(catalogue)` (optional; no-op default)
  *
- * Only content-matching (`compareContents`/`configureInteraction`/`generateContent`) is
- * implemented. Mock-server and `verifyInteraction`/`prepareInteractionForVerification` are
- * only ever invoked for `TRANSPORT`-registered plugins, not `CONTENT_MATCHER`/
- * `CONTENT_GENERATOR` ones, so they throw [UnsupportedOperationException] here.
+ * A Lua plugin that registers a `TRANSPORT` catalogue entry (instead of, or as well as, a
+ * `CONTENT_MATCHER`/`CONTENT_GENERATOR` one) must also define these functions. The plugin
+ * itself is responsible for whatever the transport actually requires (opening sockets, making
+ * outbound calls, etc.) - this driver only calls these functions at the right points in the
+ * test lifecycle, exactly as it would over gRPC for an `exec` plugin (see [LuaPluginRpcClient]):
+ * - `start_mock_server(request) -> table`
+ * - `shutdown_mock_server(server_key) -> table`
+ * - `get_mock_server_results(server_key) -> table`
+ * - `prepare_interaction_for_verification(request) -> table`
+ * - `verify_interaction(request) -> table`
  */
 class LuaPactPlugin(
   override val manifest: PactPluginManifest,

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPluginRpcClient.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPluginRpcClient.kt
@@ -4,13 +4,12 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.BytesValue
 import io.pact.plugin.Plugin
 import io.pact.plugin.v2.PluginV2
+import io.pact.plugins.jvm.core.Utils.fromProtoValue
 import io.pact.plugins.jvm.core.Utils.mapToProtoStruct
 import io.pact.plugins.jvm.core.Utils.structToMap
+import io.pact.plugins.jvm.core.Utils.toProtoValue
 import io.pact.plugins.jvm.core.lua.LuaEngine
 import java.nio.ByteBuffer
-
-private const val NOT_A_TRANSPORT_PLUGIN =
-  "is only supported by TRANSPORT plugins, not Lua content-matcher plugins"
 
 /**
  * [PactPluginRpcClient] backed by a [LuaEngine] instead of a gRPC channel - each method
@@ -88,25 +87,98 @@ class LuaPluginRpcClient(private val engine: LuaEngine) : PactPluginRpcClient {
     return builder.build()
   }
 
-  override fun startMockServer(request: Plugin.StartMockServerRequest): Plugin.StartMockServerResponse =
-    throw UnsupportedOperationException("Mock servers $NOT_A_TRANSPORT_PLUGIN")
+  override fun startMockServer(request: Plugin.StartMockServerRequest): Plugin.StartMockServerResponse {
+    val requestMap = mapOf(
+      "host_interface" to request.hostInterface,
+      "port" to request.port,
+      "tls" to request.tls,
+      "pact" to request.pact,
+      "test_context" to if (request.hasTestContext()) structToMap(request.testContext) else null
+    )
+    val result = engine.callFunction("start_mock_server", listOf(requestMap))
+    return luaToStartMockServerResponse(result)
+  }
 
-  override fun startMockServerV2(request: PluginV2.StartMockServerRequest): Plugin.StartMockServerResponse =
-    throw UnsupportedOperationException("Mock servers $NOT_A_TRANSPORT_PLUGIN")
+  override fun startMockServerV2(request: PluginV2.StartMockServerRequest): Plugin.StartMockServerResponse {
+    val requestMap = mapOf(
+      "host_interface" to request.hostInterface,
+      "port" to request.port,
+      "tls" to request.tls,
+      "interactions" to request.interactionsList.map { interactionContentsToLua(it) },
+      "test_context" to if (request.hasTestContext()) structToMap(request.testContext) else null
+    )
+    val result = engine.callFunction("start_mock_server", listOf(requestMap))
+    return luaToStartMockServerResponse(result)
+  }
 
-  override fun shutdownMockServer(request: Plugin.ShutdownMockServerRequest): Plugin.ShutdownMockServerResponse =
-    throw UnsupportedOperationException("Mock servers $NOT_A_TRANSPORT_PLUGIN")
+  override fun shutdownMockServer(request: Plugin.ShutdownMockServerRequest): Plugin.ShutdownMockServerResponse {
+    val result = engine.callFunction("shutdown_mock_server", listOf(request.serverKey))
+    val results = luaToMockServerResults(result)
+    return Plugin.ShutdownMockServerResponse.newBuilder()
+      .setOk(results.ok)
+      .addAllResults(results.resultsList)
+      .build()
+  }
 
-  override fun getMockServerResults(request: Plugin.MockServerRequest): Plugin.MockServerResults =
-    throw UnsupportedOperationException("Mock servers $NOT_A_TRANSPORT_PLUGIN")
+  override fun getMockServerResults(request: Plugin.MockServerRequest): Plugin.MockServerResults {
+    val result = engine.callFunction("get_mock_server_results", listOf(request.serverKey))
+    return luaToMockServerResults(result)
+  }
 
   override fun prepareInteractionForVerification(
     request: Plugin.VerificationPreparationRequest
-  ): Plugin.VerificationPreparationResponse =
-    throw UnsupportedOperationException("prepareInteractionForVerification $NOT_A_TRANSPORT_PLUGIN")
+  ): Plugin.VerificationPreparationResponse {
+    val requestMap = mapOf(
+      "pact" to request.pact,
+      "interaction_key" to request.interactionKey,
+      "config" to if (request.hasConfig()) structToMap(request.config) else null
+    )
+    val result = engine.callFunction("prepare_interaction_for_verification", listOf(requestMap))
+    return luaToVerificationPreparationResponse(result)
+  }
 
-  override fun verifyInteraction(request: Plugin.VerifyInteractionRequest): Plugin.VerifyInteractionResponse =
-    throw UnsupportedOperationException("verifyInteraction $NOT_A_TRANSPORT_PLUGIN")
+  override fun prepareInteractionForVerificationV2(
+    request: PluginV2.VerificationPreparationRequest
+  ): Plugin.VerificationPreparationResponse {
+    val requestMap = mutableMapOf<String, Any?>(
+      "config" to if (request.hasConfig()) structToMap(request.config) else null,
+      "test_context" to if (request.hasTestContext()) structToMap(request.testContext) else null
+    )
+    if (request.hasInteractionContents()) {
+      requestMap["interaction_contents"] = interactionContentsToLua(request.interactionContents)
+    }
+    val result = engine.callFunction("prepare_interaction_for_verification", listOf(requestMap))
+    return luaToVerificationPreparationResponse(result)
+  }
+
+  override fun verifyInteraction(request: Plugin.VerifyInteractionRequest): Plugin.VerifyInteractionResponse {
+    val requestMap = mapOf(
+      "interaction_data" to interactionDataToLua(if (request.hasInteractionData()) request.interactionData else null),
+      "config" to if (request.hasConfig()) structToMap(request.config) else null,
+      "pact" to request.pact,
+      "interaction_key" to request.interactionKey
+    )
+    val result = engine.callFunction("verify_interaction", listOf(requestMap))
+    return luaToVerifyInteractionResponse(result)
+  }
+
+  override fun verifyInteractionV2(request: PluginV2.VerifyInteractionRequest): Plugin.VerifyInteractionResponse {
+    val interactionDataV1 = if (request.hasInteractionData()) {
+      Plugin.InteractionData.parser().parseFrom(request.interactionData.toByteArray())
+    } else {
+      null
+    }
+    val requestMap = mutableMapOf<String, Any?>(
+      "interaction_data" to interactionDataToLua(interactionDataV1),
+      "config" to if (request.hasConfig()) structToMap(request.config) else null,
+      "test_context" to if (request.hasTestContext()) structToMap(request.testContext) else null
+    )
+    if (request.hasInteractionContents()) {
+      requestMap["interaction_contents"] = interactionContentsToLua(request.interactionContents)
+    }
+    val result = engine.callFunction("verify_interaction", listOf(requestMap))
+    return luaToVerifyInteractionResponse(result)
+  }
 
   // ---- Body <-> Lua ----
 
@@ -268,5 +340,215 @@ class LuaPluginRpcClient(private val engine: LuaEngine) : PactPluginRpcClient {
     item["plugin_config"]?.let { builder.pluginConfiguration = luaToPluginConfiguration(it) }
     (item["part_name"] as? String)?.let { builder.partName = it }
     return builder.build()
+  }
+
+  // ---- TRANSPORT plugin support: mock server / verification <-> Lua ----
+
+  /**
+   * Converts V2 `InteractionContents` (structured per-interaction data sent in place of a whole
+   * Pact JSON document) into a Lua-facing map shaped as
+   * `{ interaction_type, consumer, provider, plugin_configuration = { interaction_configuration, pact_configuration } }`.
+   */
+  private fun interactionContentsToLua(contents: PluginV2.InteractionContents): Map<String, Any?> {
+    val map = mutableMapOf<String, Any?>(
+      "interaction_type" to contents.interactionType,
+      "consumer" to contents.consumer,
+      "provider" to contents.provider
+    )
+    if (contents.hasPluginConfiguration()) {
+      val pluginConfiguration = contents.pluginConfiguration
+      val configMap = mutableMapOf<String, Any?>()
+      if (pluginConfiguration.hasInteractionConfiguration()) {
+        configMap["interaction_configuration"] = structToMap(pluginConfiguration.interactionConfiguration)
+      }
+      if (pluginConfiguration.hasPactConfiguration()) {
+        configMap["pact_configuration"] = structToMap(pluginConfiguration.pactConfiguration)
+      }
+      map["plugin_configuration"] = configMap
+    }
+    return map
+  }
+
+  /**
+   * Converts request/response metadata to a Lua-facing map. Each value is either a plain
+   * value (JSON-like, for a non-binary `MetadataValue`) or a `{ "binary" -> ByteBuffer }`
+   * wrapper map (for a binary `MetadataValue`), so a Lua script can tell the two apart.
+   */
+  private fun metadataToLua(metadata: Map<String, Plugin.MetadataValue>): Map<String, Any?> =
+    metadata.mapValues { (_, value) ->
+      when (value.valueCase) {
+        Plugin.MetadataValue.ValueCase.NONBINARYVALUE -> fromProtoValue(value.nonBinaryValue)
+        Plugin.MetadataValue.ValueCase.BINARYVALUE -> mapOf("binary" to ByteBuffer.wrap(value.binaryValue.toByteArray()))
+        else -> null
+      }
+    }
+
+  /** Converts a Lua metadata map (see [metadataToLua]) back into `MetadataValue`s. */
+  private fun luaToMetadata(value: Any?): Map<String, Plugin.MetadataValue> {
+    @Suppress("UNCHECKED_CAST")
+    val map = value as? Map<String, Any?> ?: return emptyMap()
+    return map.mapValues { (_, entryValue) ->
+      @Suppress("UNCHECKED_CAST")
+      val wrapper = entryValue as? Map<String, Any?>
+      val binary = wrapper?.get("binary")
+      val builder = Plugin.MetadataValue.newBuilder()
+      if (binary != null) {
+        builder.binaryValue = ByteString.copyFrom(toByteArray(binary))
+      } else {
+        builder.nonBinaryValue = toProtoValue(entryValue)
+      }
+      builder.build()
+    }
+  }
+
+  /**
+   * Converts `InteractionData` (a request/response body plus metadata) to a Lua-facing map
+   * shaped as `{ body = <body map>, metadata = <metadata map> }`, or `null` if not set.
+   */
+  private fun interactionDataToLua(data: Plugin.InteractionData?): Map<String, Any?>? {
+    if (data == null) return null
+    return mapOf(
+      "body" to bodyToLua(if (data.hasBody()) data.body else null),
+      "metadata" to metadataToLua(data.metadataMap)
+    )
+  }
+
+  /** Converts a Lua interaction-data map (see [interactionDataToLua]) back into `InteractionData`. */
+  private fun luaToInteractionData(value: Any?): Plugin.InteractionData? {
+    if (value == null) return null
+    @Suppress("UNCHECKED_CAST")
+    val map = value as? Map<String, Any?>
+      ?: throw IllegalStateException("Expected an interaction data table or nil from Lua, got $value")
+    val builder = Plugin.InteractionData.newBuilder()
+    luaToBody(map["body"])?.let { builder.body = it }
+    builder.putAllMetadata(luaToMetadata(map["metadata"]))
+    return builder.build()
+  }
+
+  /**
+   * Converts the map returned by the Lua `start_mock_server` function, shaped as either
+   * `{ error = "..." }` or `{ details = { key, port, address } }`, into a `StartMockServerResponse`.
+   */
+  private fun luaToStartMockServerResponse(value: Any?): Plugin.StartMockServerResponse {
+    @Suppress("UNCHECKED_CAST")
+    val map = value as? Map<String, Any?> ?: emptyMap()
+    val error = map["error"] as? String
+    if (error != null) {
+      return Plugin.StartMockServerResponse.newBuilder().setError(error).build()
+    }
+    @Suppress("UNCHECKED_CAST")
+    val details = map["details"] as? Map<String, Any?>
+      ?: throw IllegalStateException("Lua start_mock_server() must return either 'error' or 'details'")
+    return Plugin.StartMockServerResponse.newBuilder()
+      .setDetails(
+        Plugin.MockServerDetails.newBuilder()
+          .setKey(details["key"] as String)
+          .setPort((details["port"] as Number).toInt())
+          .setAddress(details["address"] as String)
+          .build()
+      )
+      .build()
+  }
+
+  /**
+   * Converts the map returned by the Lua `shutdown_mock_server`/`get_mock_server_results`
+   * functions, shaped as `{ ok = bool, results = { { path, error, mismatches = { ... } }, ... } }`,
+   * into `MockServerResults`. Reuses [luaValueToContentMismatches] for each result's
+   * `mismatches` field, the same helper `match_contents` responses use.
+   */
+  private fun luaToMockServerResults(value: Any?): Plugin.MockServerResults {
+    @Suppress("UNCHECKED_CAST")
+    val map = value as? Map<String, Any?> ?: emptyMap()
+    val ok = map["ok"] as? Boolean ?: true
+    @Suppress("UNCHECKED_CAST")
+    val resultsList = map["results"] as? List<Any?> ?: emptyList()
+    val builder = Plugin.MockServerResults.newBuilder().setOk(ok)
+    for (item in resultsList) {
+      @Suppress("UNCHECKED_CAST")
+      val resultMap = item as Map<String, Any?>
+      val path = resultMap["path"] as? String ?: ""
+      builder.addResults(
+        Plugin.MockServerResult.newBuilder()
+          .setPath(path)
+          .setError(resultMap["error"] as? String ?: "")
+          .addAllMismatches(luaValueToContentMismatches(path, resultMap["mismatches"]))
+          .build()
+      )
+    }
+    return builder.build()
+  }
+
+  /**
+   * Converts the map returned by the Lua `prepare_interaction_for_verification` function,
+   * shaped as either `{ error = "..." }` or `{ interaction_data = { body, metadata } }`, into a
+   * `VerificationPreparationResponse`.
+   */
+  private fun luaToVerificationPreparationResponse(value: Any?): Plugin.VerificationPreparationResponse {
+    @Suppress("UNCHECKED_CAST")
+    val map = value as? Map<String, Any?> ?: emptyMap()
+    val error = map["error"] as? String
+    if (error != null) {
+      return Plugin.VerificationPreparationResponse.newBuilder().setError(error).build()
+    }
+    val data = luaToInteractionData(map["interaction_data"])
+      ?: throw IllegalStateException(
+        "Lua prepare_interaction_for_verification() must return either 'error' or 'interaction_data'"
+      )
+    return Plugin.VerificationPreparationResponse.newBuilder().setInteractionData(data).build()
+  }
+
+  /**
+   * Converts a single Lua verification mismatch (a plain error string, or a mismatch map shaped
+   * like a `match_contents` mismatch) into a `VerificationResultItem`.
+   */
+  private fun luaToVerificationResultItem(value: Any?): Plugin.VerificationResultItem {
+    return when (value) {
+      is String -> Plugin.VerificationResultItem.newBuilder().setError(value).build()
+      is Map<*, *> -> {
+        @Suppress("UNCHECKED_CAST")
+        val map = value as Map<String, Any?>
+        val mismatchBuilder = Plugin.ContentMismatch.newBuilder()
+          .setMismatch(map["mismatch"] as? String ?: "")
+          .setPath(map["path"] as? String ?: "")
+        map["expected"]?.let { mismatchBuilder.expected = BytesValue.of(ByteString.copyFromUtf8(it.toString())) }
+        map["actual"]?.let { mismatchBuilder.actual = BytesValue.of(ByteString.copyFromUtf8(it.toString())) }
+        (map["diff"] as? String)?.let { mismatchBuilder.diff = it }
+        (map["mismatch_type"] as? String)?.let { mismatchBuilder.mismatchType = it }
+        Plugin.VerificationResultItem.newBuilder().setMismatch(mismatchBuilder.build()).build()
+      }
+      else -> throw IllegalStateException("Expected a mismatch string or table from Lua, got $value")
+    }
+  }
+
+  /**
+   * Converts the map returned by the Lua `verify_interaction` function, shaped as either
+   * `{ error = "..." }` or
+   * `{ result = { success, response_data, mismatches = { ... }, output = { ... } } }`, into a
+   * `VerifyInteractionResponse`.
+   */
+  private fun luaToVerifyInteractionResponse(value: Any?): Plugin.VerifyInteractionResponse {
+    @Suppress("UNCHECKED_CAST")
+    val map = value as? Map<String, Any?> ?: emptyMap()
+    val error = map["error"] as? String
+    if (error != null) {
+      return Plugin.VerifyInteractionResponse.newBuilder().setError(error).build()
+    }
+    @Suppress("UNCHECKED_CAST")
+    val resultMap = map["result"] as? Map<String, Any?>
+      ?: throw IllegalStateException("Lua verify_interaction() must return either 'error' or 'result'")
+
+    val builder = Plugin.VerificationResult.newBuilder()
+      .setSuccess(resultMap["success"] as? Boolean ?: false)
+    luaToInteractionData(resultMap["response_data"])?.let { builder.responseData = it }
+    @Suppress("UNCHECKED_CAST")
+    val mismatches = resultMap["mismatches"] as? List<Any?> ?: emptyList()
+    for (mismatch in mismatches) {
+      builder.addMismatches(luaToVerificationResultItem(mismatch))
+    }
+    @Suppress("UNCHECKED_CAST")
+    val output = resultMap["output"] as? List<Any?> ?: emptyList()
+    builder.addAllOutput(output.map { it.toString() })
+
+    return Plugin.VerifyInteractionResponse.newBuilder().setResult(builder.build()).build()
   }
 }

--- a/drivers/jvm/core/src/test/kotlin/io/pact/plugins/jvm/core/LuaPactPluginTest.kt
+++ b/drivers/jvm/core/src/test/kotlin/io/pact/plugins/jvm/core/LuaPactPluginTest.kt
@@ -1,6 +1,7 @@
 package io.pact.plugins.jvm.core
 
 import io.pact.plugin.Plugin
+import io.pact.plugin.v2.PluginV2
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -248,5 +249,269 @@ class LuaPactPluginTest {
     val plugin = LuaPactPlugin(manifest)
     plugin.shutdown()
     pluginDir.deleteRecursively()
+  }
+
+  private val transportPluginScript = """
+    function start_mock_server(request)
+      START_MOCK_SERVER_REQUEST = request
+      if request.port == 0 then
+        return { error = "could not bind a mock server" }
+      end
+      return { details = { key = "mock-server-1", port = 12345, address = "127.0.0.1:12345" } }
+    end
+
+    function shutdown_mock_server(server_key)
+      SHUTDOWN_SERVER_KEY = server_key
+      return {
+        ok = false,
+        results = { { path = "/foo", error = "did not match", mismatches = { "simple string mismatch" } } }
+      }
+    end
+
+    function get_mock_server_results(server_key)
+      GET_RESULTS_SERVER_KEY = server_key
+      return { ok = true, results = {} }
+    end
+
+    function prepare_interaction_for_verification(request)
+      PREPARE_REQUEST = request
+      return {
+        interaction_data = {
+          body = { content_type = "application/json", contents = "prepared-body", content_type_hint = "TEXT" },
+          metadata = { path = "/foo", tag = { binary = "raw-bytes" } }
+        }
+      }
+    end
+
+    function verify_interaction(request)
+      VERIFY_REQUEST = request
+      return {
+        result = {
+          success = true,
+          response_data = { body = { content_type = "application/json", contents = "response-body" }, metadata = {} },
+          mismatches = { "a plain mismatch", { mismatch = "a table mismatch", path = "${'$'}.foo", expected = 1, actual = 2 } },
+          output = { "POST /foo", "200 OK" }
+        }
+      }
+    end
+  """.trimIndent()
+
+  private fun transportManifest(pluginDir: File, pluginInterfaceVersion: Int): PactPluginManifest {
+    File(pluginDir, "entry.lua").writeText(transportPluginScript)
+    return DefaultPactPluginManifest(
+      pluginDir = pluginDir,
+      pluginInterfaceVersion = pluginInterfaceVersion,
+      name = "transport-test",
+      version = "0.0.0",
+      executableType = "lua",
+      minimumRequiredVersion = null,
+      entryPoint = "entry.lua",
+      entryPoints = emptyMap(),
+      args = emptyList(),
+      dependencies = emptyList()
+    )
+  }
+
+  @Test
+  fun `startMockServer v1 round trip`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-transport-plugin-test").toFile()
+    val plugin = LuaPactPlugin(transportManifest(pluginDir, 1))
+    try {
+      val request = Plugin.StartMockServerRequest.newBuilder()
+        .setHostInterface("127.0.0.1")
+        .setPort(8080)
+        .setPact("{\"consumer\":{}}")
+        .build()
+      val response = plugin.withRpcClient { it.startMockServer(request) }
+      assertTrue(response.hasDetails())
+      assertEquals("mock-server-1", response.details.key)
+      assertEquals(12345, response.details.port)
+      assertEquals("127.0.0.1:12345", response.details.address)
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `startMockServer v1 returns the lua error`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-transport-plugin-test").toFile()
+    val plugin = LuaPactPlugin(transportManifest(pluginDir, 1))
+    try {
+      val request = Plugin.StartMockServerRequest.newBuilder()
+        .setHostInterface("127.0.0.1")
+        .setPort(0)
+        .setPact("{}")
+        .build()
+      val response = plugin.withRpcClient { it.startMockServer(request) }
+      assertTrue(response.hasError())
+      assertEquals("could not bind a mock server", response.error)
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `startMockServer v2 passes structured interactions`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-transport-plugin-test").toFile()
+    val plugin = LuaPactPlugin(transportManifest(pluginDir, 2))
+    try {
+      val request = PluginV2.StartMockServerRequest.newBuilder()
+        .setHostInterface("127.0.0.1")
+        .setPort(8080)
+        .addInteractions(
+          PluginV2.InteractionContents.newBuilder()
+            .setInteractionType("Synchronous/HTTP")
+            .setConsumer("test-consumer")
+            .setProvider("test-provider")
+            .build()
+        )
+        .build()
+      val response = plugin.withRpcClient { it.startMockServerV2(request) }
+      assertTrue(response.hasDetails())
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `shutdown and get mock server results parse mismatches`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-transport-plugin-test").toFile()
+    val plugin = LuaPactPlugin(transportManifest(pluginDir, 1))
+    try {
+      val shutdownResponse = plugin.withRpcClient {
+        it.shutdownMockServer(Plugin.ShutdownMockServerRequest.newBuilder().setServerKey("mock-server-1").build())
+      }
+      assertFalse(shutdownResponse.ok)
+      assertEquals(1, shutdownResponse.resultsCount)
+      assertEquals("/foo", shutdownResponse.getResults(0).path)
+      assertEquals("simple string mismatch", shutdownResponse.getResults(0).getMismatches(0).mismatch)
+
+      val resultsResponse = plugin.withRpcClient {
+        it.getMockServerResults(Plugin.MockServerRequest.newBuilder().setServerKey("mock-server-1").build())
+      }
+      assertTrue(resultsResponse.ok)
+      assertEquals(0, resultsResponse.resultsCount)
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `prepareInteractionForVerification v1 round trip`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-transport-plugin-test").toFile()
+    val plugin = LuaPactPlugin(transportManifest(pluginDir, 1))
+    try {
+      val request = Plugin.VerificationPreparationRequest.newBuilder()
+        .setPact("{}")
+        .setInteractionKey("interaction-1")
+        .build()
+      val response = plugin.withRpcClient { it.prepareInteractionForVerification(request) }
+      assertTrue(response.hasInteractionData())
+      assertEquals("prepared-body", response.interactionData.body.content.value.toStringUtf8())
+      val metadata = response.interactionData.metadataMap
+      assertTrue(metadata["path"]!!.hasNonBinaryValue())
+      assertTrue(metadata["tag"]!!.hasBinaryValue())
+      assertEquals("raw-bytes", metadata["tag"]!!.binaryValue.toStringUtf8())
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `prepareInteractionForVerification v2 passes interaction contents`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-transport-plugin-test").toFile()
+    val plugin = LuaPactPlugin(transportManifest(pluginDir, 2))
+    try {
+      val request = PluginV2.VerificationPreparationRequest.newBuilder()
+        .setInteractionContents(
+          PluginV2.InteractionContents.newBuilder()
+            .setInteractionType("Synchronous/HTTP")
+            .setConsumer("test-consumer")
+            .setProvider("test-provider")
+            .build()
+        )
+        .build()
+      val response = plugin.withRpcClient { it.prepareInteractionForVerificationV2(request) }
+      assertTrue(response.hasInteractionData())
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `verifyInteraction v1 round trip`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-transport-plugin-test").toFile()
+    val plugin = LuaPactPlugin(transportManifest(pluginDir, 1))
+    try {
+      val interactionData = Plugin.InteractionData.newBuilder()
+        .setBody(
+          Plugin.Body.newBuilder()
+            .setContentType("application/json")
+            .setContent(com.google.protobuf.BytesValue.of(com.google.protobuf.ByteString.copyFromUtf8("request-body")))
+            .build()
+        )
+        .putMetadata(
+          "path",
+          Plugin.MetadataValue.newBuilder()
+            .setNonBinaryValue(com.google.protobuf.Value.newBuilder().setStringValue("/foo").build())
+            .build()
+        )
+        .build()
+      val request = Plugin.VerifyInteractionRequest.newBuilder()
+        .setInteractionData(interactionData)
+        .setPact("{}")
+        .setInteractionKey("interaction-1")
+        .build()
+      val response = plugin.withRpcClient { it.verifyInteraction(request) }
+      assertTrue(response.hasResult())
+      assertTrue(response.result.success)
+      assertEquals(listOf("POST /foo", "200 OK"), response.result.outputList)
+      assertEquals(2, response.result.mismatchesCount)
+      assertTrue(response.result.getMismatches(0).hasError())
+      assertEquals("a plain mismatch", response.result.getMismatches(0).error)
+      assertTrue(response.result.getMismatches(1).hasMismatch())
+      assertEquals("a table mismatch", response.result.getMismatches(1).mismatch.mismatch)
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `verifyInteraction v2 converts the v2 interaction data and contents`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-transport-plugin-test").toFile()
+    val plugin = LuaPactPlugin(transportManifest(pluginDir, 2))
+    try {
+      val interactionData = PluginV2.InteractionData.newBuilder()
+        .setBody(
+          PluginV2.Body.newBuilder()
+            .setContentType("application/json")
+            .setContent(com.google.protobuf.BytesValue.of(com.google.protobuf.ByteString.copyFromUtf8("request-body")))
+            .build()
+        )
+        .build()
+      val request = PluginV2.VerifyInteractionRequest.newBuilder()
+        .setInteractionData(interactionData)
+        .setInteractionContents(
+          PluginV2.InteractionContents.newBuilder()
+            .setInteractionType("Synchronous/HTTP")
+            .setConsumer("test-consumer")
+            .setProvider("test-provider")
+            .build()
+        )
+        .build()
+      val response = plugin.withRpcClient { it.verifyInteractionV2(request) }
+      assertTrue(response.hasResult())
+      assertTrue(response.result.success)
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
   }
 }

--- a/drivers/rust/driver/src/lua_plugin.rs
+++ b/drivers/rust/driver/src/lua_plugin.rs
@@ -10,6 +10,26 @@
 //! - `match_contents(request) -> table` - see [`PluginInstance::compare_contents`].
 //! - `generate_content(contents, generators, test_mode)` (optional) - see [`PluginInstance::generate_content`].
 //! - `update_catalogue(catalogue)` (optional) - see [`PluginInstance::update_catalogue`].
+//!
+//! A Lua plugin that registers a `TRANSPORT` catalogue entry (instead of, or as well as, a
+//! `CONTENT_MATCHER`/`CONTENT_GENERATOR` one) must also define these functions. The plugin
+//! itself is responsible for whatever the transport actually requires (opening sockets,
+//! making outbound calls, etc.) - the driver only calls these functions at the right points
+//! in the test lifecycle, exactly as it would over gRPC for an `exec` plugin:
+//!
+//! - `start_mock_server(request) -> table` - see [`PluginInstance::start_mock_server`] /
+//!   [`PluginInstance::start_mock_server_v2`].
+//! - `shutdown_mock_server(server_key) -> table` - see [`PluginInstance::shutdown_mock_server`].
+//! - `get_mock_server_results(server_key) -> table` - see [`PluginInstance::get_mock_server_results`].
+//! - `prepare_interaction_for_verification(request) -> table` - see
+//!   [`PluginInstance::prepare_interaction_for_verification`] /
+//!   [`PluginInstance::prepare_interaction_for_verification_v2`].
+//! - `verify_interaction(request) -> table` - see [`PluginInstance::verify_interaction`] /
+//!   [`PluginInstance::verify_interaction_v2`].
+//!
+//! Each of these is called with either a V1-shaped or a V2-shaped request table, never both,
+//! depending on the plugin's own `pluginInterfaceVersion` in its manifest - the same static,
+//! per-instance choice the driver makes for gRPC plugins (see `plugin_manager.rs`).
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -30,7 +50,7 @@ use crate::plugin_models::{
 };
 use crate::proto::*;
 use crate::proto_v2;
-use crate::utils::{proto_struct_to_json, to_proto_struct};
+use crate::utils::{proto_struct_to_json, proto_value_to_json, to_proto_struct, to_proto_value};
 
 /// A running Lua plugin instance. Each instance owns its own embedded Lua VM.
 pub struct LuaPactPlugin {
@@ -612,6 +632,265 @@ fn lua_to_configure_response(lua: &Lua, table: Table) -> anyhow::Result<Configur
   })
 }
 
+// ---- TRANSPORT plugin support: mock server / verification <-> Lua ----
+
+/// Converts a `google.protobuf.Struct` to a plain Lua value, `nil` if not set.
+fn struct_to_lua(lua: &Lua, value: &Option<prost_types::Struct>) -> mlua::Result<Value> {
+  match value {
+    Some(value) => lua.to_value(&proto_struct_to_json(value)),
+    None => Ok(Value::Nil),
+  }
+}
+
+/// Converts V2 `InteractionContents` (structured per-interaction data sent in place of a whole
+/// Pact JSON document) into a Lua table shaped as
+/// `{ interaction_type, consumer, provider, plugin_configuration = { interaction_configuration, pact_configuration } }`.
+fn interaction_contents_to_lua(lua: &Lua, contents: &proto_v2::InteractionContents) -> mlua::Result<Table> {
+  let table = lua.create_table()?;
+  table.set("interaction_type", contents.interaction_type.clone())?;
+  table.set("consumer", contents.consumer.clone())?;
+  table.set("provider", contents.provider.clone())?;
+  if let Some(plugin_configuration) = &contents.plugin_configuration {
+    let config_table = lua.create_table()?;
+    if let Some(interaction_configuration) = &plugin_configuration.interaction_configuration {
+      config_table.set("interaction_configuration", lua.to_value(&proto_struct_to_json(interaction_configuration))?)?;
+    }
+    if let Some(pact_configuration) = &plugin_configuration.pact_configuration {
+      config_table.set("pact_configuration", lua.to_value(&proto_struct_to_json(pact_configuration))?)?;
+    }
+    table.set("plugin_configuration", config_table)?;
+  }
+  Ok(table)
+}
+
+/// V1 `InteractionData` and V2 `InteractionData` are structurally identical (same wire format);
+/// converting via an encode/decode round trip lets the rest of this module deal with a single
+/// (V1) type, matching the approach `plugin_manager.rs` uses in the other direction (see
+/// `to_proto_v2_interaction_data`).
+fn v2_interaction_data_to_v1(data: &proto_v2::InteractionData) -> InteractionData {
+  use prost::Message;
+  InteractionData::decode(data.encode_to_vec().as_slice())
+    .expect("V1 and V2 InteractionData have identical wire format")
+}
+
+/// Converts request/response metadata to a Lua table. Each value is either a plain Lua value
+/// (JSON-like, for a non-binary `MetadataValue`) or a `{ binary = <lua string> }` wrapper table
+/// (for a binary `MetadataValue`), so a Lua script can tell the two apart.
+fn metadata_to_lua(lua: &Lua, metadata: &HashMap<String, MetadataValue>) -> mlua::Result<Table> {
+  let table = lua.create_table()?;
+  for (key, value) in metadata {
+    let lua_value = match &value.value {
+      Some(metadata_value::Value::NonBinaryValue(value)) => lua.to_value(&proto_value_to_json(value))?,
+      Some(metadata_value::Value::BinaryValue(bytes)) => {
+        let wrapper = lua.create_table()?;
+        wrapper.set("binary", lua.create_string(bytes)?)?;
+        Value::Table(wrapper)
+      }
+      None => Value::Nil,
+    };
+    table.set(key.clone(), lua_value)?;
+  }
+  Ok(table)
+}
+
+/// Converts a Lua metadata table (see [`metadata_to_lua`]) back into `MetadataValue`s.
+fn lua_to_metadata(lua: &Lua, table: Option<Table>) -> anyhow::Result<HashMap<String, MetadataValue>> {
+  let mut metadata = HashMap::new();
+  if let Some(table) = table {
+    for pair in table.pairs::<String, Value>() {
+      let (key, value) = pair?;
+      let binary: Option<mlua::String> = match &value {
+        Value::Table(wrapper) => wrapper.get("binary")?,
+        _ => None,
+      };
+      let metadata_value = if let Some(binary) = binary {
+        metadata_value::Value::BinaryValue(binary.as_bytes().to_vec())
+      } else {
+        let json: serde_json::Value = lua.from_value(value)?;
+        metadata_value::Value::NonBinaryValue(to_proto_value(&json))
+      };
+      metadata.insert(key, MetadataValue { value: Some(metadata_value) });
+    }
+  }
+  Ok(metadata)
+}
+
+/// Converts `InteractionData` (a request/response body plus metadata) to a Lua table shaped as
+/// `{ body = <body table>, metadata = <metadata table> }`, or `nil` if not set.
+fn interaction_data_to_lua(lua: &Lua, data: &Option<InteractionData>) -> mlua::Result<Value> {
+  match data {
+    None => Ok(Value::Nil),
+    Some(data) => {
+      let table = lua.create_table()?;
+      table.set("body", body_to_lua(lua, &data.body)?)?;
+      table.set("metadata", metadata_to_lua(lua, &data.metadata)?)?;
+      Ok(Value::Table(table))
+    }
+  }
+}
+
+/// Converts a Lua interaction-data table (see [`interaction_data_to_lua`]) back into
+/// `InteractionData`, or `None` if the Lua value was `nil`.
+fn lua_to_interaction_data(lua: &Lua, value: Option<Value>) -> anyhow::Result<Option<InteractionData>> {
+  match value {
+    None | Some(Value::Nil) => Ok(None),
+    Some(Value::Table(table)) => {
+      let body: Option<Value> = table.get("body")?;
+      let body = match body {
+        Some(value) => lua_to_body(value)?,
+        None => None,
+      };
+      let metadata_table: Option<Table> = table.get("metadata")?;
+      Ok(Some(InteractionData {
+        body,
+        metadata: lua_to_metadata(lua, metadata_table)?,
+      }))
+    }
+    Some(other) => Err(anyhow!("Expected an interaction data table or nil from Lua, got {}", other.type_name())),
+  }
+}
+
+/// Converts the table returned by the Lua `start_mock_server` function, shaped as either
+/// `{ error = "..." }` or `{ details = { key, port, address } }`, into a `StartMockServerResponse`.
+fn lua_to_start_mock_server_response(table: Table) -> anyhow::Result<StartMockServerResponse> {
+  let error: Option<String> = table.get("error")?;
+  if let Some(error) = error {
+    return Ok(StartMockServerResponse {
+      response: Some(start_mock_server_response::Response::Error(error)),
+    });
+  }
+
+  let details: Option<Table> = table.get("details")?;
+  let details = details.ok_or_else(|| {
+    anyhow!("Lua start_mock_server() must return either an 'error' or 'details' field")
+  })?;
+  Ok(StartMockServerResponse {
+    response: Some(start_mock_server_response::Response::Details(MockServerDetails {
+      key: details.get("key")?,
+      port: details.get("port")?,
+      address: details.get("address")?,
+    })),
+  })
+}
+
+/// Converts the table returned by the Lua `shutdown_mock_server`/`get_mock_server_results`
+/// functions, shaped as `{ ok = bool, results = { { path, error, mismatches = { ... } }, ... } }`,
+/// into `MockServerResults`. Reuses [`lua_value_to_content_mismatches`] for each result's
+/// `mismatches` field, the same helper `match_contents` responses use.
+fn lua_to_mock_server_results(table: Table) -> anyhow::Result<MockServerResults> {
+  let ok: bool = table.get("ok").unwrap_or(true);
+  let mut results = vec![];
+  let results_table: Option<Table> = table.get("results")?;
+  if let Some(results_table) = results_table {
+    for entry in results_table.sequence_values::<Table>() {
+      let entry = entry?;
+      let path: String = entry.get("path").unwrap_or_default();
+      let error: String = entry.get("error").unwrap_or_default();
+      let mismatches_value: Value = entry.get("mismatches").unwrap_or(Value::Nil);
+      results.push(MockServerResult {
+        path: path.clone(),
+        error,
+        mismatches: lua_value_to_content_mismatches(&path, mismatches_value)?,
+      });
+    }
+  }
+  Ok(MockServerResults { ok, results })
+}
+
+/// Converts the table returned by the Lua `prepare_interaction_for_verification` function,
+/// shaped as either `{ error = "..." }` or `{ interaction_data = { body, metadata } }`, into a
+/// `VerificationPreparationResponse`.
+fn lua_to_verification_preparation_response(
+  lua: &Lua,
+  table: Table,
+) -> anyhow::Result<VerificationPreparationResponse> {
+  let error: Option<String> = table.get("error")?;
+  if let Some(error) = error {
+    return Ok(VerificationPreparationResponse {
+      response: Some(verification_preparation_response::Response::Error(error)),
+    });
+  }
+
+  let data: Option<Value> = table.get("interaction_data")?;
+  let data = data.ok_or_else(|| {
+    anyhow!("Lua prepare_interaction_for_verification() must return either an 'error' or 'interaction_data' field")
+  })?;
+  let interaction_data = lua_to_interaction_data(lua, Some(data))?
+    .unwrap_or_else(|| InteractionData { body: None, metadata: HashMap::new() });
+  Ok(VerificationPreparationResponse {
+    response: Some(verification_preparation_response::Response::InteractionData(interaction_data)),
+  })
+}
+
+/// Converts a single Lua verification mismatch (a plain error string, or a mismatch table shaped
+/// like a `match_contents` mismatch) into a `VerificationResultItem`.
+fn lua_to_verification_result_item(value: Value) -> anyhow::Result<VerificationResultItem> {
+  match value {
+    Value::String(s) => Ok(VerificationResultItem {
+      result: Some(verification_result_item::Result::Error(s.to_str()?.to_string())),
+    }),
+    Value::Table(table) => {
+      let mismatch: Option<String> = table.get("mismatch")?;
+      let path: Option<String> = table.get("path")?;
+      let expected = lua_scalar_to_string(table.get("expected")?)?;
+      let actual = lua_scalar_to_string(table.get("actual")?)?;
+      let diff: Option<String> = table.get("diff")?;
+      let mismatch_type: Option<String> = table.get("mismatch_type")?;
+      Ok(VerificationResultItem {
+        result: Some(verification_result_item::Result::Mismatch(ContentMismatch {
+          expected: expected.map(|s| s.into_bytes()),
+          actual: actual.map(|s| s.into_bytes()),
+          mismatch: mismatch.unwrap_or_default(),
+          path: path.unwrap_or_default(),
+          diff: diff.unwrap_or_default(),
+          mismatch_type: mismatch_type.unwrap_or_default(),
+        })),
+      })
+    }
+    other => Err(anyhow!("Expected a mismatch string or table from Lua, got {}", other.type_name())),
+  }
+}
+
+/// Converts the table returned by the Lua `verify_interaction` function, shaped as either
+/// `{ error = "..." }` or
+/// `{ result = { success, response_data, mismatches = { ... }, output = { ... } } }`, into a
+/// `VerifyInteractionResponse`.
+fn lua_to_verify_interaction_response(lua: &Lua, table: Table) -> anyhow::Result<VerifyInteractionResponse> {
+  let error: Option<String> = table.get("error")?;
+  if let Some(error) = error {
+    return Ok(VerifyInteractionResponse {
+      response: Some(verify_interaction_response::Response::Error(error)),
+    });
+  }
+
+  let result_table: Option<Table> = table.get("result")?;
+  let result_table = result_table
+    .ok_or_else(|| anyhow!("Lua verify_interaction() must return either an 'error' or 'result' field"))?;
+
+  let success: bool = result_table.get("success").unwrap_or(false);
+  let response_data: Option<Value> = result_table.get("response_data")?;
+  let response_data = lua_to_interaction_data(lua, response_data)?;
+
+  let mut mismatches = vec![];
+  let mismatches_value: Option<Value> = result_table.get("mismatches")?;
+  if let Some(Value::Table(mismatches_table)) = mismatches_value {
+    for entry in mismatches_table.sequence_values::<Value>() {
+      mismatches.push(lua_to_verification_result_item(entry?)?);
+    }
+  }
+
+  let output: Option<Vec<String>> = result_table.get("output")?;
+
+  Ok(VerifyInteractionResponse {
+    response: Some(verify_interaction_response::Response::Result(VerificationResult {
+      success,
+      response_data,
+      mismatches,
+      output: output.unwrap_or_default(),
+    })),
+  })
+}
+
 #[async_trait]
 impl PactPluginRpc for LuaPactPlugin {
   async fn init_plugin(&mut self, request: PluginInitRequest) -> anyhow::Result<PluginInitResponse> {
@@ -713,48 +992,163 @@ impl PluginInstance for LuaPactPlugin {
 
   async fn start_mock_server(
     &self,
-    _request: StartMockServerRequest,
+    request: StartMockServerRequest,
   ) -> anyhow::Result<StartMockServerResponse> {
-    Err(anyhow!("Mock servers are not supported by Lua content-matcher plugins"))
+    let lua = self.runtime.lock().map_err(|_| anyhow!("Lua runtime mutex was poisoned"))?;
+    let start_fn: Function = lua
+      .globals()
+      .get("start_mock_server")
+      .map_err(|_| anyhow!("Lua plugin does not define a global 'start_mock_server' function"))?;
+    let request_table = lua.create_table()?;
+    request_table.set("host_interface", request.host_interface)?;
+    request_table.set("port", request.port)?;
+    request_table.set("tls", request.tls)?;
+    request_table.set("pact", request.pact)?;
+    request_table.set("test_context", struct_to_lua(&lua, &request.test_context)?)?;
+    let result: Table = start_fn
+      .call(request_table)
+      .map_err(|err| anyhow!("Lua start_mock_server() function failed - {}", err))?;
+    lua_to_start_mock_server_response(result)
   }
 
   async fn start_mock_server_v2(
     &self,
-    _request: proto_v2::StartMockServerRequest,
+    request: proto_v2::StartMockServerRequest,
   ) -> anyhow::Result<StartMockServerResponse> {
-    Err(anyhow!("Mock servers are not supported by Lua content-matcher plugins"))
+    let lua = self.runtime.lock().map_err(|_| anyhow!("Lua runtime mutex was poisoned"))?;
+    let start_fn: Function = lua
+      .globals()
+      .get("start_mock_server")
+      .map_err(|_| anyhow!("Lua plugin does not define a global 'start_mock_server' function"))?;
+    let request_table = lua.create_table()?;
+    request_table.set("host_interface", request.host_interface)?;
+    request_table.set("port", request.port)?;
+    request_table.set("tls", request.tls)?;
+    let interactions_table = lua.create_table()?;
+    for interaction in &request.interactions {
+      interactions_table.push(interaction_contents_to_lua(&lua, interaction)?)?;
+    }
+    request_table.set("interactions", interactions_table)?;
+    request_table.set("test_context", struct_to_lua(&lua, &request.test_context)?)?;
+    let result: Table = start_fn
+      .call(request_table)
+      .map_err(|err| anyhow!("Lua start_mock_server() function failed - {}", err))?;
+    lua_to_start_mock_server_response(result)
   }
 
   async fn shutdown_mock_server(
     &self,
-    _request: ShutdownMockServerRequest,
+    request: ShutdownMockServerRequest,
   ) -> anyhow::Result<ShutdownMockServerResponse> {
-    Err(anyhow!("Mock servers are not supported by Lua content-matcher plugins"))
+    let lua = self.runtime.lock().map_err(|_| anyhow!("Lua runtime mutex was poisoned"))?;
+    let shutdown_fn: Function = lua
+      .globals()
+      .get("shutdown_mock_server")
+      .map_err(|_| anyhow!("Lua plugin does not define a global 'shutdown_mock_server' function"))?;
+    let result: Table = shutdown_fn
+      .call(request.server_key)
+      .map_err(|err| anyhow!("Lua shutdown_mock_server() function failed - {}", err))?;
+    let results = lua_to_mock_server_results(result)?;
+    Ok(ShutdownMockServerResponse {
+      ok: results.ok,
+      results: results.results,
+    })
   }
 
   async fn get_mock_server_results(
     &self,
-    _request: MockServerRequest,
+    request: MockServerRequest,
   ) -> anyhow::Result<MockServerResults> {
-    Err(anyhow!("Mock servers are not supported by Lua content-matcher plugins"))
+    let lua = self.runtime.lock().map_err(|_| anyhow!("Lua runtime mutex was poisoned"))?;
+    let results_fn: Function = lua
+      .globals()
+      .get("get_mock_server_results")
+      .map_err(|_| anyhow!("Lua plugin does not define a global 'get_mock_server_results' function"))?;
+    let result: Table = results_fn
+      .call(request.server_key)
+      .map_err(|err| anyhow!("Lua get_mock_server_results() function failed - {}", err))?;
+    lua_to_mock_server_results(result)
   }
 
   async fn prepare_interaction_for_verification(
     &self,
-    _request: VerificationPreparationRequest,
+    request: VerificationPreparationRequest,
   ) -> anyhow::Result<VerificationPreparationResponse> {
-    Err(anyhow!(
-      "prepare_interaction_for_verification is only supported by TRANSPORT plugins, not Lua content-matcher plugins"
-    ))
+    let lua = self.runtime.lock().map_err(|_| anyhow!("Lua runtime mutex was poisoned"))?;
+    let prepare_fn: Function = lua.globals().get("prepare_interaction_for_verification").map_err(|_| {
+      anyhow!("Lua plugin does not define a global 'prepare_interaction_for_verification' function")
+    })?;
+    let request_table = lua.create_table()?;
+    request_table.set("pact", request.pact)?;
+    request_table.set("interaction_key", request.interaction_key)?;
+    request_table.set("config", struct_to_lua(&lua, &request.config)?)?;
+    let result: Table = prepare_fn
+      .call(request_table)
+      .map_err(|err| anyhow!("Lua prepare_interaction_for_verification() function failed - {}", err))?;
+    lua_to_verification_preparation_response(&lua, result)
+  }
+
+  async fn prepare_interaction_for_verification_v2(
+    &self,
+    request: proto_v2::VerificationPreparationRequest,
+  ) -> anyhow::Result<VerificationPreparationResponse> {
+    let lua = self.runtime.lock().map_err(|_| anyhow!("Lua runtime mutex was poisoned"))?;
+    let prepare_fn: Function = lua.globals().get("prepare_interaction_for_verification").map_err(|_| {
+      anyhow!("Lua plugin does not define a global 'prepare_interaction_for_verification' function")
+    })?;
+    let request_table = lua.create_table()?;
+    if let Some(interaction_contents) = &request.interaction_contents {
+      request_table.set("interaction_contents", interaction_contents_to_lua(&lua, interaction_contents)?)?;
+    }
+    request_table.set("config", struct_to_lua(&lua, &request.config)?)?;
+    request_table.set("test_context", struct_to_lua(&lua, &request.test_context)?)?;
+    let result: Table = prepare_fn
+      .call(request_table)
+      .map_err(|err| anyhow!("Lua prepare_interaction_for_verification() function failed - {}", err))?;
+    lua_to_verification_preparation_response(&lua, result)
   }
 
   async fn verify_interaction(
     &self,
-    _request: VerifyInteractionRequest,
+    request: VerifyInteractionRequest,
   ) -> anyhow::Result<VerifyInteractionResponse> {
-    Err(anyhow!(
-      "verify_interaction is only supported by TRANSPORT plugins, not Lua content-matcher plugins"
-    ))
+    let lua = self.runtime.lock().map_err(|_| anyhow!("Lua runtime mutex was poisoned"))?;
+    let verify_fn: Function = lua
+      .globals()
+      .get("verify_interaction")
+      .map_err(|_| anyhow!("Lua plugin does not define a global 'verify_interaction' function"))?;
+    let request_table = lua.create_table()?;
+    request_table.set("interaction_data", interaction_data_to_lua(&lua, &request.interaction_data)?)?;
+    request_table.set("config", struct_to_lua(&lua, &request.config)?)?;
+    request_table.set("pact", request.pact)?;
+    request_table.set("interaction_key", request.interaction_key)?;
+    let result: Table = verify_fn
+      .call(request_table)
+      .map_err(|err| anyhow!("Lua verify_interaction() function failed - {}", err))?;
+    lua_to_verify_interaction_response(&lua, result)
+  }
+
+  async fn verify_interaction_v2(
+    &self,
+    request: proto_v2::VerifyInteractionRequest,
+  ) -> anyhow::Result<VerifyInteractionResponse> {
+    let lua = self.runtime.lock().map_err(|_| anyhow!("Lua runtime mutex was poisoned"))?;
+    let verify_fn: Function = lua
+      .globals()
+      .get("verify_interaction")
+      .map_err(|_| anyhow!("Lua plugin does not define a global 'verify_interaction' function"))?;
+    let request_table = lua.create_table()?;
+    let interaction_data = request.interaction_data.as_ref().map(v2_interaction_data_to_v1);
+    request_table.set("interaction_data", interaction_data_to_lua(&lua, &interaction_data)?)?;
+    request_table.set("config", struct_to_lua(&lua, &request.config)?)?;
+    if let Some(interaction_contents) = &request.interaction_contents {
+      request_table.set("interaction_contents", interaction_contents_to_lua(&lua, interaction_contents)?)?;
+    }
+    request_table.set("test_context", struct_to_lua(&lua, &request.test_context)?)?;
+    let result: Table = verify_fn
+      .call(request_table)
+      .map_err(|err| anyhow!("Lua verify_interaction() function failed - {}", err))?;
+    lua_to_verify_interaction_response(&lua, result)
   }
 
   async fn update_catalogue(&self, request: Catalogue) -> anyhow::Result<()> {
@@ -1058,5 +1452,314 @@ mod tests {
     let verified_mismatch = &response.results["claims:verified"].mismatches[0];
     assert_eq!(verified_mismatch.expected.as_deref(), Some("true".as_bytes()));
     assert_eq!(verified_mismatch.actual.as_deref(), Some("false".as_bytes()));
+  }
+
+  fn transport_manifest(plugin_dir: &std::path::Path, plugin_interface_version: u8) -> PactPluginManifest {
+    PactPluginManifest {
+      plugin_dir: plugin_dir.to_string_lossy().to_string(),
+      plugin_interface_version,
+      name: "transport-test".to_string(),
+      version: "0.0.0".to_string(),
+      executable_type: "lua".to_string(),
+      minimum_required_version: None,
+      entry_point: "entry.lua".to_string(),
+      entry_points: HashMap::new(),
+      args: None,
+      dependencies: None,
+      plugin_config: HashMap::new(),
+    }
+  }
+
+  const TRANSPORT_PLUGIN_SCRIPT: &str = r#"
+    function start_mock_server(request)
+      START_MOCK_SERVER_REQUEST = request
+      if request.port == 0 then
+        return { error = "could not bind a mock server" }
+      end
+      return { details = { key = "mock-server-1", port = 12345, address = "127.0.0.1:12345" } }
+    end
+
+    function shutdown_mock_server(server_key)
+      SHUTDOWN_SERVER_KEY = server_key
+      return {
+        ok = false,
+        results = { { path = "/foo", error = "did not match", mismatches = { "simple string mismatch" } } }
+      }
+    end
+
+    function get_mock_server_results(server_key)
+      GET_RESULTS_SERVER_KEY = server_key
+      return { ok = true, results = {} }
+    end
+
+    function prepare_interaction_for_verification(request)
+      PREPARE_REQUEST = request
+      return {
+        interaction_data = {
+          body = { content_type = "application/json", contents = "prepared-body", content_type_hint = "TEXT" },
+          metadata = { path = "/foo", tag = { binary = "raw-bytes" } }
+        }
+      }
+    end
+
+    function verify_interaction(request)
+      VERIFY_REQUEST = request
+      if request.config ~= nil and request.config.fail == true then
+        return { error = "verification failed" }
+      end
+      return {
+        result = {
+          success = true,
+          response_data = { body = { content_type = "application/json", contents = "response-body" }, metadata = {} },
+          mismatches = { "a plain mismatch", { mismatch = "a table mismatch", path = "$.foo", expected = 1, actual = 2 } },
+          output = { "POST /foo", "200 OK" }
+        }
+      }
+    end
+  "#;
+
+  fn start_transport_plugin(plugin_interface_version: u8) -> LuaPactPlugin {
+    let plugin_dir = tempdir::TempDir::new("lua-transport-plugin-test").unwrap();
+    std::fs::write(plugin_dir.path().join("entry.lua"), TRANSPORT_PLUGIN_SCRIPT).unwrap();
+    let manifest = transport_manifest(plugin_dir.path(), plugin_interface_version);
+    // The script is fully read into the Lua VM by `start_lua_plugin`, so the tempdir doesn't
+    // need to outlive this call.
+    start_lua_plugin(&manifest, "test-instance".to_string()).unwrap()
+  }
+
+  #[tokio::test]
+  async fn start_mock_server_v1_round_trip() {
+    let plugin = start_transport_plugin(1);
+    let response = plugin.start_mock_server(StartMockServerRequest {
+      host_interface: "127.0.0.1".to_string(),
+      port: 8080,
+      tls: false,
+      pact: "{\"consumer\":{}}".to_string(),
+      test_context: None,
+    }).await.unwrap();
+    match response.response.unwrap() {
+      start_mock_server_response::Response::Details(details) => {
+        assert_eq!(details.key, "mock-server-1");
+        assert_eq!(details.port, 12345);
+        assert_eq!(details.address, "127.0.0.1:12345");
+      }
+      other => panic!("expected mock server details, got {:?}", other),
+    }
+  }
+
+  #[tokio::test]
+  async fn start_mock_server_v1_returns_the_lua_error() {
+    let plugin = start_transport_plugin(1);
+    let response = plugin.start_mock_server(StartMockServerRequest {
+      host_interface: "127.0.0.1".to_string(),
+      port: 0,
+      tls: false,
+      pact: "{}".to_string(),
+      test_context: None,
+    }).await.unwrap();
+    match response.response.unwrap() {
+      start_mock_server_response::Response::Error(err) => assert_eq!(err, "could not bind a mock server"),
+      other => panic!("expected an error response, got {:?}", other),
+    }
+  }
+
+  #[tokio::test]
+  async fn start_mock_server_v2_passes_structured_interactions() {
+    let plugin = start_transport_plugin(2);
+    let request = proto_v2::StartMockServerRequest {
+      host_interface: "127.0.0.1".to_string(),
+      port: 8080,
+      tls: false,
+      interactions: vec![proto_v2::InteractionContents {
+        interaction_type: "Synchronous/HTTP".to_string(),
+        plugin_configuration: None,
+        consumer: "test-consumer".to_string(),
+        provider: "test-provider".to_string(),
+      }],
+      test_context: None,
+    };
+    let response = plugin.start_mock_server_v2(request).await.unwrap();
+    assert!(matches!(response.response.unwrap(), start_mock_server_response::Response::Details(_)));
+
+    let lua = plugin.runtime.lock().unwrap();
+    let captured: Table = lua.globals().get("START_MOCK_SERVER_REQUEST").unwrap();
+    let interactions: Table = captured.get("interactions").unwrap();
+    let first: Table = interactions.get(1).unwrap();
+    assert_eq!(first.get::<String>("interaction_type").unwrap(), "Synchronous/HTTP");
+    assert_eq!(first.get::<String>("consumer").unwrap(), "test-consumer");
+  }
+
+  #[tokio::test]
+  async fn shutdown_and_get_mock_server_results_parse_mismatches() {
+    let plugin = start_transport_plugin(1);
+
+    let shutdown_response = plugin.shutdown_mock_server(ShutdownMockServerRequest {
+      server_key: "mock-server-1".to_string(),
+    }).await.unwrap();
+    assert!(!shutdown_response.ok);
+    assert_eq!(shutdown_response.results.len(), 1);
+    assert_eq!(shutdown_response.results[0].path, "/foo");
+    assert_eq!(shutdown_response.results[0].mismatches[0].mismatch, "simple string mismatch");
+
+    let results_response = plugin.get_mock_server_results(MockServerRequest {
+      server_key: "mock-server-1".to_string(),
+    }).await.unwrap();
+    assert!(results_response.ok);
+    assert!(results_response.results.is_empty());
+  }
+
+  #[tokio::test]
+  async fn prepare_interaction_for_verification_v1_round_trip() {
+    let plugin = start_transport_plugin(1);
+    let response = plugin.prepare_interaction_for_verification(VerificationPreparationRequest {
+      pact: "{}".to_string(),
+      interaction_key: "interaction-1".to_string(),
+      config: None,
+    }).await.unwrap();
+
+    match response.response.unwrap() {
+      verification_preparation_response::Response::InteractionData(data) => {
+        let body = data.body.unwrap();
+        assert_eq!(body.content, Some("prepared-body".as_bytes().to_vec()));
+        let metadata = data.metadata;
+        assert!(matches!(
+          metadata["path"].value,
+          Some(metadata_value::Value::NonBinaryValue(_))
+        ));
+        match &metadata["tag"].value {
+          Some(metadata_value::Value::BinaryValue(bytes)) => assert_eq!(bytes, b"raw-bytes"),
+          other => panic!("expected a binary metadata value, got {:?}", other),
+        }
+      }
+      other => panic!("expected interaction data, got {:?}", other),
+    }
+  }
+
+  #[tokio::test]
+  async fn prepare_interaction_for_verification_v2_passes_interaction_contents() {
+    let plugin = start_transport_plugin(2);
+    let request = proto_v2::VerificationPreparationRequest {
+      interaction_contents: Some(proto_v2::InteractionContents {
+        interaction_type: "Synchronous/HTTP".to_string(),
+        plugin_configuration: None,
+        consumer: "test-consumer".to_string(),
+        provider: "test-provider".to_string(),
+      }),
+      config: None,
+      test_context: None,
+    };
+    let response = plugin.prepare_interaction_for_verification_v2(request).await.unwrap();
+    assert!(matches!(
+      response.response.unwrap(),
+      verification_preparation_response::Response::InteractionData(_)
+    ));
+
+    let lua = plugin.runtime.lock().unwrap();
+    let captured: Table = lua.globals().get("PREPARE_REQUEST").unwrap();
+    let interaction_contents: Table = captured.get("interaction_contents").unwrap();
+    assert_eq!(interaction_contents.get::<String>("provider").unwrap(), "test-provider");
+  }
+
+  #[tokio::test]
+  async fn verify_interaction_v1_round_trip() {
+    let plugin = start_transport_plugin(1);
+    let mut metadata = HashMap::new();
+    metadata.insert("path".to_string(), MetadataValue {
+      value: Some(metadata_value::Value::NonBinaryValue(prost_types::Value {
+        kind: Some(prost_types::value::Kind::StringValue("/foo".to_string())),
+      })),
+    });
+    let response = plugin.verify_interaction(VerifyInteractionRequest {
+      interaction_data: Some(InteractionData {
+        body: Some(Body {
+          content_type: "application/json".to_string(),
+          content: Some("request-body".as_bytes().to_vec()),
+          content_type_hint: body::ContentTypeHint::Text as i32,
+        }),
+        metadata,
+      }),
+      config: None,
+      pact: "{}".to_string(),
+      interaction_key: "interaction-1".to_string(),
+    }).await.unwrap();
+
+    match response.response.unwrap() {
+      verify_interaction_response::Response::Result(result) => {
+        assert!(result.success);
+        assert_eq!(result.output, vec!["POST /foo".to_string(), "200 OK".to_string()]);
+        assert_eq!(result.mismatches.len(), 2);
+        match &result.mismatches[0].result {
+          Some(verification_result_item::Result::Error(err)) => assert_eq!(err, "a plain mismatch"),
+          other => panic!("expected an error mismatch, got {:?}", other),
+        }
+        match &result.mismatches[1].result {
+          Some(verification_result_item::Result::Mismatch(mismatch)) => {
+            assert_eq!(mismatch.mismatch, "a table mismatch");
+            assert_eq!(mismatch.expected, Some(b"1".to_vec()));
+          }
+          other => panic!("expected a mismatch, got {:?}", other),
+        }
+      }
+      other => panic!("expected a verification result, got {:?}", other),
+    }
+
+    let lua = plugin.runtime.lock().unwrap();
+    let captured: Table = lua.globals().get("VERIFY_REQUEST").unwrap();
+    let interaction_data: Table = captured.get("interaction_data").unwrap();
+    let metadata: Table = interaction_data.get("metadata").unwrap();
+    assert_eq!(metadata.get::<String>("path").unwrap(), "/foo");
+  }
+
+  #[tokio::test]
+  async fn verify_interaction_v1_returns_the_lua_error() {
+    let plugin = start_transport_plugin(1);
+    let mut config = HashMap::new();
+    config.insert("fail".to_string(), serde_json::Value::Bool(true));
+    let response = plugin.verify_interaction(VerifyInteractionRequest {
+      interaction_data: None,
+      config: Some(to_proto_struct(&config)),
+      pact: "{}".to_string(),
+      interaction_key: "interaction-1".to_string(),
+    }).await.unwrap();
+    match response.response.unwrap() {
+      verify_interaction_response::Response::Error(err) => assert_eq!(err, "verification failed"),
+      other => panic!("expected an error response, got {:?}", other),
+    }
+  }
+
+  #[tokio::test]
+  async fn verify_interaction_v2_converts_the_v2_interaction_data_and_contents() {
+    let plugin = start_transport_plugin(2);
+    let request = proto_v2::VerifyInteractionRequest {
+      interaction_data: Some(proto_v2::InteractionData {
+        body: Some(proto_v2::Body {
+          content_type: "application/json".to_string(),
+          content: Some("request-body".as_bytes().to_vec()),
+          content_type_hint: 0,
+        }),
+        metadata: HashMap::new(),
+      }),
+      config: None,
+      interaction_contents: Some(proto_v2::InteractionContents {
+        interaction_type: "Synchronous/HTTP".to_string(),
+        plugin_configuration: None,
+        consumer: "test-consumer".to_string(),
+        provider: "test-provider".to_string(),
+      }),
+      test_context: None,
+    };
+    let response = plugin.verify_interaction_v2(request).await.unwrap();
+    assert!(matches!(
+      response.response.unwrap(),
+      verify_interaction_response::Response::Result(_)
+    ));
+
+    let lua = plugin.runtime.lock().unwrap();
+    let captured: Table = lua.globals().get("VERIFY_REQUEST").unwrap();
+    let interaction_data: Table = captured.get("interaction_data").unwrap();
+    let body: Table = interaction_data.get("body").unwrap();
+    assert_eq!(body.get::<mlua::String>("contents").unwrap().to_str().unwrap(), "request-body");
+    let interaction_contents: Table = captured.get("interaction_contents").unwrap();
+    assert_eq!(interaction_contents.get::<String>("consumer").unwrap(), "test-consumer");
   }
 }

--- a/drivers/rust/driver/src/lua_plugin.rs
+++ b/drivers/rust/driver/src/lua_plugin.rs
@@ -666,11 +666,14 @@ fn interaction_contents_to_lua(lua: &Lua, contents: &proto_v2::InteractionConten
 /// V1 `InteractionData` and V2 `InteractionData` are structurally identical (same wire format);
 /// converting via an encode/decode round trip lets the rest of this module deal with a single
 /// (V1) type, matching the approach `plugin_manager.rs` uses in the other direction (see
-/// `to_proto_v2_interaction_data`).
-fn v2_interaction_data_to_v1(data: &proto_v2::InteractionData) -> InteractionData {
+/// `to_proto_v2_interaction_data`). Returns an error rather than panicking if the round trip
+/// ever fails (it shouldn't, given the identical wire format, but this data originates from a
+/// caller-supplied gRPC request, so a decode failure should be a recoverable error, not a
+/// crash).
+fn v2_interaction_data_to_v1(data: &proto_v2::InteractionData) -> anyhow::Result<InteractionData> {
   use prost::Message;
   InteractionData::decode(data.encode_to_vec().as_slice())
-    .expect("V1 and V2 InteractionData have identical wire format")
+    .map_err(|err| anyhow!("Failed to convert V2 InteractionData to V1 - {}", err))
 }
 
 /// Converts request/response metadata to a Lua table. Each value is either a plain Lua value
@@ -778,15 +781,15 @@ fn lua_to_start_mock_server_response(table: Table) -> anyhow::Result<StartMockSe
 /// into `MockServerResults`. Reuses [`lua_value_to_content_mismatches`] for each result's
 /// `mismatches` field, the same helper `match_contents` responses use.
 fn lua_to_mock_server_results(table: Table) -> anyhow::Result<MockServerResults> {
-  let ok: bool = table.get("ok").unwrap_or(true);
+  let ok: bool = table.get::<Option<bool>>("ok")?.unwrap_or(true);
   let mut results = vec![];
   let results_table: Option<Table> = table.get("results")?;
   if let Some(results_table) = results_table {
     for entry in results_table.sequence_values::<Table>() {
       let entry = entry?;
-      let path: String = entry.get("path").unwrap_or_default();
-      let error: String = entry.get("error").unwrap_or_default();
-      let mismatches_value: Value = entry.get("mismatches").unwrap_or(Value::Nil);
+      let path: String = entry.get::<Option<String>>("path")?.unwrap_or_default();
+      let error: String = entry.get::<Option<String>>("error")?.unwrap_or_default();
+      let mismatches_value: Value = entry.get("mismatches")?;
       results.push(MockServerResult {
         path: path.clone(),
         error,
@@ -867,7 +870,7 @@ fn lua_to_verify_interaction_response(lua: &Lua, table: Table) -> anyhow::Result
   let result_table = result_table
     .ok_or_else(|| anyhow!("Lua verify_interaction() must return either an 'error' or 'result' field"))?;
 
-  let success: bool = result_table.get("success").unwrap_or(false);
+  let success: bool = result_table.get::<Option<bool>>("success")?.unwrap_or(false);
   let response_data: Option<Value> = result_table.get("response_data")?;
   let response_data = lua_to_interaction_data(lua, response_data)?;
 
@@ -1138,7 +1141,9 @@ impl PluginInstance for LuaPactPlugin {
       .get("verify_interaction")
       .map_err(|_| anyhow!("Lua plugin does not define a global 'verify_interaction' function"))?;
     let request_table = lua.create_table()?;
-    let interaction_data = request.interaction_data.as_ref().map(v2_interaction_data_to_v1);
+    let interaction_data = request.interaction_data.as_ref()
+      .map(v2_interaction_data_to_v1)
+      .transpose()?;
     request_table.set("interaction_data", interaction_data_to_lua(&lua, &interaction_data)?)?;
     request_table.set("config", struct_to_lua(&lua, &request.config)?)?;
     if let Some(interaction_contents) = &request.interaction_contents {
@@ -1761,5 +1766,56 @@ mod tests {
     assert_eq!(body.get::<mlua::String>("contents").unwrap().to_str().unwrap(), "request-body");
     let interaction_contents: Table = captured.get("interaction_contents").unwrap();
     assert_eq!(interaction_contents.get::<String>("consumer").unwrap(), "test-consumer");
+  }
+
+  #[tokio::test]
+  async fn shutdown_mock_server_defaults_ok_to_true_when_the_field_is_absent() {
+    // Regression test: `Table::get::<bool>("ok")` converts a *missing* key's Lua nil straight
+    // to `false` (mlua's bool conversion, matching Lua's own nil-is-falsy semantics) rather than
+    // erroring - so a plain `.unwrap_or(true)` fallback was never reached, and an `ok`-less
+    // response used to silently report `ok = false` instead of the documented default of
+    // `true`. Reading as `Option<bool>` first lets a missing key correctly fall through to the
+    // `unwrap_or(true)` default, since `Option<T>` intercepts Lua nil before the inner
+    // conversion happens.
+    let plugin_dir = tempdir::TempDir::new("lua-transport-plugin-test").unwrap();
+    std::fs::write(
+      plugin_dir.path().join("entry.lua"),
+      r#"
+        function shutdown_mock_server(server_key)
+          return { results = {} }
+        end
+      "#,
+    ).unwrap();
+    let manifest = transport_manifest(plugin_dir.path(), 1);
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+
+    let response = plugin.shutdown_mock_server(ShutdownMockServerRequest {
+      server_key: "mock-server-1".to_string(),
+    }).await.unwrap();
+    assert!(response.ok, "expected 'ok' to default to true when the Lua script doesn't set it");
+  }
+
+  #[tokio::test]
+  async fn shutdown_mock_server_errors_on_a_wrong_typed_path_field() {
+    let plugin_dir = tempdir::TempDir::new("lua-transport-plugin-test").unwrap();
+    std::fs::write(
+      plugin_dir.path().join("entry.lua"),
+      r#"
+        function shutdown_mock_server(server_key)
+          return { ok = false, results = { { path = {}, error = "boom", mismatches = {} } } }
+        end
+      "#,
+    ).unwrap();
+    let manifest = transport_manifest(plugin_dir.path(), 1);
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+
+    let result = plugin.shutdown_mock_server(ShutdownMockServerRequest {
+      server_key: "mock-server-1".to_string(),
+    }).await;
+    assert!(
+      result.is_err(),
+      "expected a wrong-typed 'path' field (a table, not a string) to be a hard error, not silently default, got {:?}",
+      result
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Extends the embedded-Lua plugin support (previously `CONTENT_MATCHER`/`CONTENT_GENERATOR` only, added in #104) so a Lua plugin can also register a `TRANSPORT` catalogue entry.
- The driver calls `start_mock_server`/`shutdown_mock_server`/`get_mock_server_results`/`prepare_interaction_for_verification`/`verify_interaction` as same-named Lua globals at the right points in the test lifecycle, exactly as it would over gRPC for an `exec` plugin - the plugin itself remains responsible for whatever the transport actually requires (sockets, outbound calls, etc).
- Both V1 and V2 plugin-interface request shapes are supported, matching the gRPC driver's existing per-manifest dispatch.
- Implemented in parallel for both the Rust driver (`lua_plugin.rs`) and the JVM driver (`LuaPluginRpcClient.kt`).
- Docs updated in `docs/writing-plugin-guide.md` describing the new entry-point functions.

## Test plan
- [x] `cargo test --features lua` (Rust driver) - 31 tests pass, including 10 new transport tests
- [x] `cargo clippy --features lua --all-targets` - no new warnings
- [x] `./gradlew :core:test` (JVM driver) - 58 tests pass, including 8 new transport tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)