### PR TITLE
chore(docs): use neutral examples in the arrayContains section

### DIFF
--- a/docs/matching-rule-definition-expressions.md
+++ b/docs/matching-rule-definition-expressions.md
@@ -91,18 +91,18 @@ Configures an array-contains matching rule. Each expression defines a variant
 that must be found in the array. Matching is successful if each variant matches
 at least one item in the array. Order does not matter, and extra items are allowed.
 
-For example: `arrayContains(matching(equalTo, 'PUBLIC'))`
+For example: `arrayContains(matching(equalTo, 'HARDCOVER'))`
 
-Multiple required values: `arrayContains(matching(equalTo, 'PUBLIC'), matching(regex, 'PRIVATE.*', 'PRIVATE_LINK'))`
+Multiple required values: `arrayContains(matching(equalTo, 'HARDCOVER'), matching(regex, 'PAPER.*', 'PAPERBACK'))`
 
 With references (for complex object variants):
 `arrayContains(matching($'variant1'), matching($'variant2'))`
 
 Mixed inline and reference variants:
-`arrayContains(matching(equalTo, 'PUBLIC'), matching($'complexVariant'))`
+`arrayContains(matching(equalTo, 'HARDCOVER'), matching($'complexVariant'))`
 
 Can be composed with other expressions:
-`atLeast(2), eachValue(matching(type, 'example')), arrayContains(matching(equalTo, 'PUBLIC'))`
+`atLeast(2), eachValue(matching(type, 'example')), arrayContains(matching(equalTo, 'HARDCOVER'))`
 
 ## Composing expressions
 


### PR DESCRIPTION
> **Authorship disclosure: this is AI-generated.** The investigation, the code, the tests, and this description were all produced by an AI agent (Claude Opus) operating on behalf of @stan-is-hate. Please review with that in mind.

The `arrayContains` examples I added in #95 used string constants taken straight from my employer's product domain. They carry no meaning for readers of this document and shouldn't have gone upstream.

Swapped for neutral book-format values (exact before/after in the diff):

- the plain `equalTo` example now uses `'HARDCOVER'`
- the regex example now uses pattern `'PAPER.*'` with sample `'PAPERBACK'`

The regex example still demonstrates a prefix pattern against a matching sample, so it reads exactly the same way.

Docs only — no grammar change, no behaviour change, `matching-rule-definition.g4` untouched.