### PR TITLE
Field-level matchers and generators (proposal 006)

### DIFF
--- a/docs/lua-plugin-reference.md
+++ b/docs/lua-plugin-reference.md
@@ -18,7 +18,7 @@ compiled/`exec` plugin would send and receive, so the shapes are identical on ei
 - **Enum-like string values are `SCREAMING_CASE` or `PascalCase`,** matching the underlying protobuf enum name
   exactly - see each function's description for the exact allowed values (e.g. `content_type_hint` is one of
   `"DEFAULT"`/`"TEXT"`/`"BINARY"`; `entryType` is one of `"CONTENT_MATCHER"`/`"CONTENT_GENERATOR"`/`"TRANSPORT"`/
-  `"MATCHER"`/`"INTERACTION"`; `generate_content`'s `test_mode` is `"Consumer"`/`"Provider"`/`"Unknown"`).
+  `"MATCHER"`/`"GENERATOR"`/`"INTERACTION"`; `test_mode` is `"Consumer"`/`"Provider"`/`"Unknown"`).
 - **A missing/absent table field is equivalent to Lua `nil`** unless stated otherwise - you don't need to set keys
   you have nothing to put in.
 - **V1 vs V2 requests.** `pluginInterfaceVersion` in your `pact-plugin.json` manifest (1 or 2) is a static,
@@ -36,6 +36,8 @@ compiled/`exec` plugin would send and receive, so the shapes are identical on ei
 | [`configure_interaction(content_type, config)`](#configure_interactioncontent_type-config---table) | Yes, if you register a `CONTENT_MATCHER`/`CONTENT_GENERATOR` entry | Content-matcher plugins |
 | [`match_contents(request)`](#match_contentsrequest---table) | Yes, if you register a `CONTENT_MATCHER` entry | Content-matcher plugins |
 | [`generate_content(contents, generators, test_mode)`](#generate_contentcontents-generators-test_mode---table-optional) | No (passthrough default) | Content-generator plugins |
+| [`match_field(request)`](#match_fieldrequest---table) | Yes, if you register a `MATCHER` entry | Field-level matcher plugins |
+| [`generate_field(request)`](#generate_fieldrequest---table) | Yes, if you register a `GENERATOR` entry | Field-level generator plugins |
 | [`update_catalogue(catalogue)`](#update_cataloguecatalogue-optional) | No (no-op default) | Every plugin |
 | [`start_mock_server(request)`](#start_mock_serverrequest---table) | Yes, if you register a `TRANSPORT` entry | Transport plugins |
 | [`shutdown_mock_server(server_key)`](#shutdown_mock_serverserver_key---table-and-get_mock_server_resultsserver_key---table) | Yes, if you register a `TRANSPORT` entry | Transport plugins |
@@ -43,8 +45,14 @@ compiled/`exec` plugin would send and receive, so the shapes are identical on ei
 | [`prepare_interaction_for_verification(request)`](#prepare_interaction_for_verificationrequest---table) | Yes, if you register a `TRANSPORT` entry | Transport plugins |
 | [`verify_interaction(request)`](#verify_interactionrequest---table) | Yes, if you register a `TRANSPORT` entry | Transport plugins |
 
-A plugin can register both a `CONTENT_MATCHER`/`CONTENT_GENERATOR` entry and a `TRANSPORT` entry from the same
-`init` call, in which case it must define all the functions both roles require.
+A plugin can register entries for more than one role from the same `init` call - a `CONTENT_MATCHER`/
+`CONTENT_GENERATOR` entry and a `TRANSPORT` entry, say - in which case it must define all the functions each role
+requires. The three roles are independent:
+
+- a **content matcher/generator** owns a whole content type (`match_contents`/`generate_content`);
+- a **field matcher/generator** contributes one rule applied to a single *value* inside somebody else's content -
+  a field in a JSON body, a header, a message metadata value (`match_field`/`generate_field`);
+- a **transport** carries a whole interaction (the mock-server and verification functions).
 
 ---
 
@@ -63,15 +71,28 @@ Called once, immediately after your script is loaded (before any other function)
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `entryType` | string | Yes | One of `"CONTENT_MATCHER"`, `"CONTENT_GENERATOR"`, `"TRANSPORT"`, `"MATCHER"`, `"INTERACTION"`. Note the `camelCase` - this is the one exception to the snake_case convention. |
-| `key` | string | Yes | Your plugin's catalogue key for this entry (typically your plugin name). |
-| `values` | table (string -> string) | No | Free-form metadata. For a `CONTENT_MATCHER`/`CONTENT_GENERATOR` entry, convention is a `content-types` key whose value is a semicolon-separated list of MIME types you handle, each one matched as a regex **anchored at both ends** against an actual content type - escape any regex metacharacter (most commonly `+`, as in a `+json` structured syntax suffix) for a literal match. |
+| `entryType` | string | Yes | One of `"CONTENT_MATCHER"`, `"CONTENT_GENERATOR"`, `"TRANSPORT"`, `"MATCHER"`, `"GENERATOR"`, `"INTERACTION"`. Note the `camelCase` - this is the one exception to the snake_case convention. |
+| `key` | string | Yes | Your plugin's catalogue key for this entry. For a content matcher/generator or a transport, typically your plugin name. For a `MATCHER`/`GENERATOR` entry the key **is** the rule name a test writes, so pick the name of the rule rather than the name of your plugin. |
+| `values` | table (string -> string) | No | Free-form metadata. For a `CONTENT_MATCHER`/`CONTENT_GENERATOR` entry, convention is a `content-types` key whose value is a semicolon-separated list of MIME types you handle, each one matched as a regex **anchored at both ends** against an actual content type - escape any regex metacharacter (most commonly `+`, as in a `+json` structured syntax suffix) for a literal match. For a `MATCHER`/`GENERATOR` entry, a `config-key` key names the values key a single positional argument in a rule definition expression maps to. |
 
 ```lua
 function init(implementation, version)
   return {
     { entryType = "CONTENT_MATCHER", key = "jwt", values = { ["content-types"] = "application/jwt;application/jwt\\+json" } },
     { entryType = "CONTENT_GENERATOR", key = "jwt", values = { ["content-types"] = "application/jwt;application/jwt\\+json" } }
+  }
+end
+```
+
+A field-level plugin registers a `MATCHER` and/or a `GENERATOR` entry instead. Both can share one key - the entry
+type is what tells them apart - so the same name works as a matching rule and as a generator:
+
+```lua
+function init(implementation, version)
+  local params = { ["config-key"] = "brand" }
+  return {
+    { entryType = "MATCHER", key = "creditcard", values = params },
+    { entryType = "GENERATOR", key = "creditcard", values = params }
   }
 end
 ```
@@ -163,6 +184,61 @@ Called to generate contents using any defined generators. If you don't define th
 | `test_mode` | string | One of `"Consumer"`, `"Provider"`, `"Unknown"`. |
 
 **Return value**: a [`Body`](#body-table), or `nil`.
+
+---
+
+### `match_field(request) -> table`
+
+Called to apply your plugin's matching rule to a single value. Unlike `match_contents`, you see the one value and
+its path, not the document that contains it - a rule that needs the surrounding document is a content matcher, not
+a field matcher.
+
+**Parameters** (`request`)
+
+| Field | Type | Description |
+|---|---|---|
+| `key` | string | The catalogue key of the rule being applied - the `key` you registered the `MATCHER` entry under. Only useful if one plugin registers several rules. |
+| `rule` | table | The rule as stored in the Pact file: `{ type = "...", values = {...} }` - a [`MatchingRules`](#matchingrules-table) rule table. Always present, even with no `values`. |
+| `path` | string | Where the value lives, as a matching-rule expression (e.g. `"$.card.number"`). |
+| `mismatch_type` | string | Which part of the interaction the value came from: `"body"`, `"header"`, `"metadata"`, `"query"`, `"path"`, `"status"`. |
+| `expected` | [field value](#field-value) | The example value from the Pact file. |
+| `actual` | [field value](#field-value) | The value received. |
+| `plugin_configuration` | table or nil | A [`PluginConfiguration`](#pluginconfiguration-table) - anything your plugin persisted into the Pact file. |
+| `test_context` | table or nil | Context data from the test framework. |
+
+**Return value**: one of
+
+- `{ error = "..." }` - the rule itself could not be applied (e.g. it was configured with a brand this plugin
+  doesn't know). This is the test author's mistake rather than the provider's, and fails the test outright rather
+  than being reported as a mismatch.
+- `{ mismatches = { ... } }` - an **array** (not a path-keyed table, unlike `match_contents`) whose entries are
+  each a plain string or a [`ContentMismatch`](#contentmismatch-table) table. A mismatch that doesn't set its own
+  `path` is reported against the request's `path`. An empty or absent array means the value matched.
+
+---
+
+### `generate_field(request) -> table`
+
+Called to generate a single value, replacing the example value from the Pact file. A generator is a pure function
+of its request: everything it needs arrives in the request or is fetched with an explicit
+[host function](#host-functions-available-to-your-script) call.
+
+**Parameters** (`request`)
+
+| Field | Type | Description |
+|---|---|---|
+| `key` | string | The catalogue key of the generator being applied. See `match_field`. |
+| `generator` | table | The generator as stored in the Pact file: `{ type = "...", values = {...} }` - a [`Generator`](#generator-table) table. Always present, even with no `values`. |
+| `path` | string | Where the value lives, as a matching-rule expression. |
+| `example_value` | [field value](#field-value) | The example value from the Pact file that the generated value replaces. |
+| `plugin_configuration` | table or nil | A [`PluginConfiguration`](#pluginconfiguration-table). |
+| `test_context` | table or nil | Context data from the test framework. |
+| `test_mode` | string | One of `"Consumer"`, `"Provider"`, `"Unknown"`. |
+
+**Return value**: one of
+
+- `{ error = "..." }` - the value could not be generated.
+- `{ value = ... }` - the generated [field value](#field-value).
 
 ---
 
@@ -331,7 +407,8 @@ Used for request/response/message contents throughout (`configure_interaction`, 
 ### `MatchingRules` table
 
 The `rules` field of a `match_contents` request: a table keyed by matching-rule expression path (e.g. `"$"`,
-`"$.body.field"`), where each value is an array of rule tables:
+`"$.body.field"`), where each value is an array of rule tables. `match_field`'s `rule` field is a single one of
+these tables rather than a path-keyed table of arrays, since it is applied to exactly one value:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -340,12 +417,35 @@ The `rules` field of a `match_contents` request: a table keyed by matching-rule 
 
 ### `Generator` table
 
-Each value in the `generators` table passed to `generate_content`:
+Each value in the `generators` table passed to `generate_content`, and `generate_field`'s `generator` field:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `type` | string | Yes | The generator type (e.g. `"RandomInt"`, `"Uuid"`). |
 | `values` | table or nil | No | Generator-specific configuration data. |
+
+### Field value
+
+A single value being matched or generated, used for `match_field`'s `expected`/`actual`, and `generate_field`'s
+`example_value` and returned `value`. Not a table shape of its own - it's whatever plain Lua value the value
+actually is:
+
+| Value | Arrives as | Notes |
+|---|---|---|
+| null | `nil` | |
+| boolean | boolean | |
+| string | string | |
+| whole number | integer | `math.type(v) == "integer"`. |
+| number with a fractional part | float | `math.type(v) == "float"`. |
+| bytes | `{ binary = "..." }` | A wrapper table whose `binary` field is a Lua string of raw bytes - the same convention the [metadata table](#metadata-table) uses. |
+| map or list | table | For a rule applied to a collection rather than a scalar. |
+
+The integer/float distinction is preserved in both directions, deliberately: rules like `integer`, `decimal` and
+`type` are built on it. So `math.type()` tells you whether the value in the Pact file was `100` or `100.0`, and a
+number you return keeps whichever subtype you gave it.
+
+A table is read as a binary value if it has a `binary` key, and as a map or list otherwise. That means a plain map
+of your own that happens to have a `binary` key would be misread - name the key something else.
 
 ### `PluginConfiguration` table
 
@@ -413,10 +513,48 @@ The driver registers these as Lua globals before loading your script:
 | `rsa_validate(tokenParts, algorithm, publicKeyPem)` | Verifies a 3-part token (`{header, payload, signature}`) against an RSA public key PEM. Only `"RS512"` is supported for `algorithm`. Returns a boolean. |
 | `b64_decode_no_pad(data)` | Decodes URL-safe base64 (with or without padding), returns the raw bytes as a Lua string. |
 
-These exist specifically to support the JWT reference plugin. If your plugin needs different cryptographic,
-encoding, or networking primitives, either implement them in pure Lua or pull in a
+The RSA and base64 functions exist specifically to support the JWT reference plugin. If your plugin needs different
+cryptographic, encoding, or networking primitives, either implement them in pure Lua or pull in a
 [pure-Lua LuaRocks package](writing-plugin-guide.md#luarocks-support) that provides them - packages with compiled C
 extensions are not supported.
+
+### Calling back into another capability
+
+These four let your script delegate to a capability it doesn't implement itself - one the host Pact framework
+provides (the standard Pact matching rules and generators), or one another loaded plugin registered - instead of
+reimplementing it. Each takes a catalogue entry key naming the capability to invoke, and the driver resolves that
+key the same way it resolves any other.
+
+| Function | Description |
+|---|---|
+| `host_compare_contents(entry_key, request)` | Invokes a content matcher. `request` and the returned table are shaped exactly like [`match_contents`](#match_contentsrequest---table)'s, so you can pass the request you were given straight in and its result straight back out. |
+| `host_generate_content(entry_key, contents, generators, test_mode)` | Invokes a content generator. Same arguments and return value as [`generate_content`](#generate_contentcontents-generators-test_mode---table-optional). |
+| `host_match_field(entry_key, request)` | Invokes a field-level matching rule. Same request and return shapes as [`match_field`](#match_fieldrequest---table). |
+| `host_generate_field(entry_key, request)` | Invokes a field-level generator. Same request and return shapes as [`generate_field`](#generate_fieldrequest---table). |
+
+The two field-level ones are how a content matcher applies a standard Pact rule to one value inside the content it
+owns - the plugin keeps ownership of parsing and traversing its content type, and hands off the actual comparison
+of a leaf value.
+
+An `entry_key` is either the bare name of the capability (`"type"`, `"creditcard"`) or its full catalogue key
+(`"matcher/v2-type"`, `"plugin/creditcard/matcher/creditcard"`). The bare name is the usual choice: core matching
+rules are registered under a key with the Pact specification version they were introduced in prefixed to the name
+(`v2-type`, `v3-date`), and resolving a bare name finds those without you having to know which version that was.
+A key that matches nothing, or matches more than one capability, is an error rather than a silent no-op.
+
+```lua
+function match_contents(request)
+  -- Compare one claim inside a JWT with the core date matcher, rather than parsing dates here
+  local result = host_match_field("date", {
+    rule = { type = "date", values = { format = "yyyy-MM-dd" } },
+    path = "$.claims.iat",
+    mismatch_type = "body",
+    expected = expected_claims.iat,
+    actual = actual_claims.iat
+  })
+  ...
+end
+```
 
 Lua's built-in `print(...)` is also redirected into the same per-instance log file as `logger(...)`, rather than
 the driver's own real stdout - see [Output and logging](writing-plugin-guide.md#output-and-logging).

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -478,10 +478,20 @@ WASM plugin support at all.
 
 ## Sequencing
 
-1. ⬜ Proto: `GENERATOR` entry type, `FieldValue`, the four request/response messages, the two `PactPlugin` RPCs and
-   the two `PluginHost` RPCs. Regenerate the checked-in Rust bindings (`PACT_PLUGIN_BUILD_PROTOBUFS`).
+1. ✅ Proto: `GENERATOR` entry type, `FieldValue`, the four request/response messages, the two `PactPlugin` RPCs and
+   the two `PluginHost` RPCs, with the checked-in Rust bindings regenerated. The Rust driver's `PluginHost` service
+   answers the two new RPCs with `unimplemented` until step 2; the JVM driver needs no change for this, since
+   gRPC-Java's generated base class already answers an unimplemented method that way.
 2. ⬜ Rust driver: `field.rs`, the two `core_capabilities` traits + registries, catalogue lookups, `PluginHost`
    service methods, `grpc_plugin`/`PluginInstance` methods.
+
+   One trap here: the driver's internal catalogue representation is the **V1** proto's `EntryType`
+   (`CatalogueEntryType::to_proto_type`, and the byte-level transcode of V2 catalogue entries into V1
+   `CatalogueEntry` messages in `grpc_plugin.rs`), while `GENERATOR` only exists in V2. The raw `i32` survives the
+   transcode, but prost's generated `entry.r#type()` accessor maps an unrecognised `5` to the default
+   (`ContentMatcher`) silently, so the inbound path must read the raw field. The clean fix is to stop treating a
+   generated proto enum as the driver's own type - `CatalogueEntryType` should be the source of truth - rather than
+   adding `GENERATOR` to the frozen V1 contract.
 3. ⬜ JVM driver: the same surface (`FieldMatcher.kt`, `FieldGenerator.kt`, `CoreCapabilities.kt`,
    `PluginHostServer.kt`, `PluginRpcClient.kt`).
 4. ⬜ Lua runtime in both drivers: `match_field`/`generate_field` invocation, `host_match_field`/

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -99,8 +99,10 @@ The **rule name is the catalogue key**. A rule named `creditcard` resolves throu
   same short name. Key components are compared whole, never as substrings;
 - failing that, the name is matched against the core catalogue's versioned naming convention - the Pact
   specification version a rule was introduced in, prefixed to its name - so `type` resolves to `core/matcher/v2-type`
-  and `date` to `core/matcher/v3-date` without a caller having to know which version introduced what. Naming an entry
-  directly always wins over this fallback: a plugin registering its own `matcher/date` takes `date`, and a caller
+  and `date` to `core/matcher/v3-date` without a caller having to know which version introduced what. This applies
+  only to `MATCHER` and `GENERATOR` entries: content matchers, content generators and transports are registered
+  under plain names (`xml`, `json`, `grpc`), where a leading `v<n>-` would be part of the name. Naming an entry
+  directly always wins over the fallback: a plugin registering its own `matcher/date` takes `date`, and a caller
   that specifically wants the core rule asks for `v3-date`;
 - a name matching more than one entry of the expected type is a hard error naming the candidates, never a silent
   pick;

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -532,8 +532,10 @@ WASM plugin support at all.
    (`ContentMatcher`) silently, so the inbound path must read the raw field. The clean fix is to stop treating a
    generated proto enum as the driver's own type - `CatalogueEntryType` should be the source of truth - rather than
    adding `GENERATOR` to the frozen V1 contract.
-3. ⬜ JVM driver: the same surface (`FieldMatcher.kt`, `FieldGenerator.kt`, `CoreCapabilities.kt`,
-   `PluginHostServer.kt`, `PluginRpcClient.kt`).
+3. ✅ JVM driver: the same surface, in `Field.kt` (`FieldValue`, `FieldContext`, `FieldMatcher`/`FieldGenerator`),
+   `CoreCapabilities.kt`, `CatalogueManager.resolveCapabilityEntry`, `PluginHostServer.kt` and
+   `PluginRpcClient.kt`. No blocking wrapper is needed here - the JVM driver talks to plugins over blocking gRPC
+   stubs, so the synchronous matching path calls straight through.
 4. ⬜ Lua runtime in both drivers: `match_field`/`generate_field` invocation, `host_match_field`/
    `host_generate_field` host functions, conversions in `lua_plugin.rs` / `LuaConversions.kt`.
 5. ✅ Reference plugin: [`plugins/creditcard`](../../plugins/creditcard), written against this design. Cannot run

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -1,7 +1,7 @@
 # Field-level matchers and generators (Draft)
 
 > [!NOTE]
-> **Implementation phase:** Phase 3 (new functionality). Requires [005](./005_Plugin_capability_negotiation_and_versioning.md) to be finalised. Design in parallel with [007](./007_Driver_plugin_callback_model.md); data model decisions in these two proposals must be kept consistent. See the [proposals README](./README.md) for the full delivery order.
+> **Implementation phase:** Phase 3 (new functionality). Requires [005](./005_Plugin_capability_negotiation_and_versioning.md) to be finalised. Designed in parallel with [007](./007_Driver_plugin_callback_model.md), and re-uses 007's registry, resolver and callback plumbing rather than introducing its own. Required by [009](./009_Host_provided_core_matching_and_generation.md). See the [proposals README](./README.md) for the full delivery order.
 
 ## Summary
 
@@ -17,34 +17,487 @@ generation logic for a specific field, key, header, token, or nested value.
 Without an explicit field-level API, plugin authors either cannot express these use cases at all or are pushed into
 whole-content plugins that are broader and more complex than the problem requires.
 
-## Recommended direction
+Concretely, today `CatalogueEntry.EntryType.MATCHER` can be registered by a plugin and stored in the catalogue, and
+that is all that happens - nothing in either driver ever looks a `MATCHER` entry up or calls the plugin that owns it.
+There is also no entry type at all for a field-level generator.
 
-- Define dedicated field-level matcher and generator operations rather than overloading whole-content APIs.
-- Keep the API binary-safe and context-aware:
-  - do not assume all values can be represented as JSON;
-  - include the matching path or location being evaluated;
-  - include the selected matcher/generator entry and any associated values;
-  - include plugin configuration and any mode/context needed for generation.
-- Align the mismatch/result model with existing Pact mismatch reporting so results can be surfaced consistently across
-  drivers and UIs.
+## Worked example: a credit card number
+
+The design below is derived from a reference plugin, [`plugins/creditcard`](../../plugins/creditcard), written in Lua
+(the second Lua plugin in this repository, after [`plugins/jwt`](../../plugins/jwt)). It provides one matching rule
+and one generator, both named `creditcard`:
+
+- **the matcher** asserts that the actual value is a plausible credit card number: digits only (with `-`/space
+  separators tolerated), a valid [Luhn](https://en.wikipedia.org/wiki/Luhn_algorithm) check digit, a length in range,
+  and - if the rule is configured with a `brand` - the IIN prefix and length of that brand;
+- **the generator** produces a fresh, Luhn-valid number of the same brand on every test run.
+
+This is a deliberately small example that is nonetheless not expressible with any core matching rule: `regex` can
+check the shape of a card number but not its check digit, and `type` only gets you "it's a string". It exercises
+every part of the interface - rule configuration values, an example value, a value-level mismatch, and a generator
+paired with a matcher under the same name - without needing binary values or document context, which keeps it honest
+about which parts of the design are load-bearing.
+
+A consumer test asserting on a JSON body would express it as:
+
+```json
+{
+  "card": {
+    "number": "matching(creditcard, 'visa', '4111111111111111')",
+    "expiry": "matching(regex, '\\d{2}/\\d{2}', '04/28')"
+  }
+}
+```
+
+which is persisted into the Pact file as an ordinary matching rule whose name happens to be provided by a plugin:
+
+```json
+"matchingRules": {
+  "body": {
+    "$.card.number": {
+      "combine": "AND",
+      "matchers": [ { "match": "creditcard", "brand": "visa" } ]
+    }
+  }
+}
+```
+
+## Design
+
+### 1. Catalogue entries
+
+A field-level matcher is a `MATCHER` catalogue entry (already defined, never previously used):
+`plugin/creditcard/matcher/creditcard`.
+
+A field-level generator needs a new entry type, `GENERATOR = 5`, added to `CatalogueEntry.EntryType` in
+`proto/plugin_v2.proto` and to `CatalogueEntryType` in both drivers:
+`plugin/creditcard/generator/creditcard`.
+
+Reusing `MATCHER` for both operations was considered and rejected: a separate type keeps
+`catalogue_manager::resolve_capability`'s `expected_type` check meaningful (it is what stops a callback for a
+generator resolving to an unrelated matcher of the same name), and lets a matcher and its paired generator share one
+name, which is what a plugin author actually wants.
+
+Unlike `CONTENT_MATCHER`/`CONTENT_GENERATOR`, these entries have no required `values` key - there is no content type
+to advertise. One optional convention is defined:
+
+| Key | Meaning |
+|---|---|
+| `config-key` | The name of the values key that a single positional config argument in a matching rule definition expression maps to (see [3](#3-declaring-a-plugin-rule-in-a-test)). Defaults to `value`. |
+
+The `creditcard` plugin registers `config-key = "brand"`, which is what makes `matching(creditcard, 'visa', '4111…')`
+resolve to `{ "match": "creditcard", "brand": "visa" }`.
+
+### 2. Naming and resolution
+
+The **rule name is the catalogue key**. A rule named `creditcard` resolves through the existing
+`catalogue_manager::resolve_capability` (`CatalogueManager.resolveCapability` on the JVM) with an expected type of
+`MATCHER`/`GENERATOR` - the same resolver 007 already uses for callbacks, with the same behaviour:
+
+- resolves by suffix against the full catalogue key, so a user can write `creditcard/matcher/creditcard` to
+  disambiguate if two plugins ever register the same short name;
+- a name matching more than one entry of the expected type is a hard error naming the candidates, never a silent
+  pick;
+- a name matching nothing is a hard error at match/generate time.
+
+Core rule names always win: the host resolves `type`, `regex`, `equality` and the rest of the standard set from its
+own matching engine before it ever consults the catalogue, so a plugin cannot shadow a standard rule. (Once
+[009](./009_Host_provided_core_matching_and_generation.md) registers the standard set as `CORE` entries, those become
+visible in the catalogue too - as `core/matcher/type` etc. - which is what lets a *plugin* call back for them, but
+does not change how the host resolves its own rules.)
+
+### 3. Declaring a plugin rule in a test
+
+Two forms, both existing mechanisms extended to accept a name the host does not recognise:
+
+**Matching rule definition expression.** `matching(NAME, [CONFIG,] EXAMPLE)` where `NAME` is not one of the built-in
+rule names. `CONFIG` is optional and is stored under the key the catalogue entry's `config-key` value names
+(defaulting to `value`). The grammar in [`matching-rule-definition.g4`](../matching-rule-definition.g4) gains one
+alternative in the `matchingRule` production for this; nothing else changes.
+
+**JSON form.** The existing `pact:matcher:type` mechanism already carries arbitrary attributes, and needs no change
+at all beyond the host accepting an unrecognised type:
+
+```json
+{ "pact:matcher:type": "creditcard", "brand": "visa", "value": "4111111111111111" }
+```
+
+Generators are declared the same way, by name, via `pact:generator:type`:
+
+```json
+{ "pact:matcher:type": "creditcard", "pact:generator:type": "creditcard", "brand": "visa", "value": "4111111111111111" }
+```
+
+Whether a matching rule should *implicitly* attach the same-named generator when one exists (the way `datetime`
+implies a date-time generator today) is left open - see [Open questions](#open-questions). The explicit form above is
+the design; an implicit one would be a convenience layered on top of it.
+
+### 4. Model representation and the Pact file
+
+Both the matching rule and the generator are stored in the Pact file exactly as any other rule is - the name in the
+`match`/`type` field, its configuration as sibling keys:
+
+```json
+"matchingRules": { "body": { "$.card.number": { "matchers": [ { "match": "creditcard", "brand": "visa" } ] } } },
+"generators":    { "body": { "$.card.number": { "type": "creditcard", "brand": "visa" } } }
+```
+
+This requires a carrier in the models, in `pact_models` and in Pact-JVM's model module:
+
+```rust
+MatchingRule::Plugin { name: String, values: Value }
+Generator::Plugin { name: String, values: Value }
+```
+
+with these properties:
+
+- `MatchingRule::create` falls through to `Plugin { name, values }` only for a rule name it does not recognise -
+  a malformed *known* rule (e.g. `regex` with no `regex` field) still errors exactly as it does today, so the
+  fallback cannot mask a real parse error. `Generator::from_map` does the same for an unrecognised `type` (today it
+  logs a warning and drops the generator silently, which is worse than either alternative).
+- `to_json` round-trips: `{ "match": name, ...values }` / `{ "type": name, ...values }`. There is no marker in the
+  JSON saying "this is a plugin rule" - by design, since which plugin (if any) provides a name is a property of the
+  running catalogue, not of the file.
+- `name()`/`values()` return the plugin name and its values map, which means the existing content-matcher path in
+  `content.rs` forwards a plugin field rule to a content matcher plugin unchanged, with no code change. A protobuf
+  or CSV plugin receiving `{ type: "creditcard", values: { brand: "visa" } }` in its `rules` map can then delegate
+  it back to the `creditcard` plugin through the 007 callback (see [7](#7-callbacks-and-host-provided-rules)).
+- `can_cascade()` is `false`: a plugin rule applies to the value at its path, not to that value's children.
+
+A typo'd core rule name becomes a `Plugin` rule that fails resolution at match time with
+`No catalogue entry found for key 'reges'`, which is an acceptable trade for not needing a second syntax.
+
+**Pact file plugin metadata.** A field-level rule never goes through `configure_interaction`, which is where the
+`plugins` entry in the Pact file metadata is written today. So the host must record the providing plugin (name and
+version, from the resolved catalogue entry's manifest) in the Pact metadata when it serialises a `Plugin` rule or
+generator. Without this, provider verification has no way to know it needs to load the `creditcard` plugin before it
+can interpret the file. Consumer tests must load the plugin explicitly (`usingPlugin("creditcard")` or equivalent)
+before the rule can be resolved at all.
+
+### 5. Operation shape
+
+Two new RPCs on `PactPlugin`, and their `PluginHost` counterparts for the callback direction:
+
+```proto
+// A single value being matched or generated. Binary-safe: follows the same oneof pattern as
+// MetadataValue rather than assuming everything is representable as JSON.
+message FieldValue {
+  oneof value {
+    google.protobuf.Value nonBinaryValue = 1;
+    bytes binaryValue = 2;
+  }
+}
+
+message MatchFieldRequest {
+  // Catalogue entry key of the rule being applied, e.g. "creditcard"
+  string key = 1;
+  // The rule as stored in the Pact file: its name and configured values
+  MatchingRule rule = 2;
+  // Path to the value being matched, as per the documented Pact matching rule expressions
+  string path = 3;
+  // Which part of the interaction the value came from: body, header, query, metadata, path, status
+  string mismatchType = 4;
+  // Expected value from the Pact file
+  FieldValue expected = 5;
+  // Actual value received
+  FieldValue actual = 6;
+  // Additional data added to the Pact/Interaction by the plugin
+  PluginConfiguration pluginConfiguration = 7;
+  // Context data provided by the test framework (carries testRunId for log correlation)
+  google.protobuf.Struct testContext = 8;
+}
+
+message MatchFieldResponse {
+  // Set if the match could not be performed at all. If set, mismatches is ignored and the
+  // verification is marked as failed.
+  string error = 1;
+  // Mismatches found. Empty means the value matched. A mismatch with an empty path is
+  // reported against the request's path.
+  repeated ContentMismatch mismatches = 2;
+}
+
+message GenerateFieldRequest {
+  string key = 1;
+  // The generator as stored in the Pact file: its name and configured values
+  Generator generator = 2;
+  string path = 3;
+  // The example value from the Pact file that the generated value replaces
+  FieldValue exampleValue = 4;
+  PluginConfiguration pluginConfiguration = 5;
+  google.protobuf.Struct testContext = 6;
+  // Consumer or provider side, reusing the enum already defined for content generation
+  GenerateContentRequest.TestMode testMode = 7;
+}
+
+message GenerateFieldResponse {
+  string error = 1;
+  FieldValue value = 2;
+}
+
+service PactPlugin {
+  // ... existing RPCs ...
+
+  // Apply a plugin-provided matching rule to a single value. Required for any plugin that
+  // registers a MATCHER catalogue entry.
+  rpc MatchField(MatchFieldRequest) returns (MatchFieldResponse);
+  // Apply a plugin-provided generator to a single value. Required for any plugin that
+  // registers a GENERATOR catalogue entry.
+  rpc GenerateField(GenerateFieldRequest) returns (GenerateFieldResponse);
+}
+```
+
+Notes on specific choices:
+
+- **`rule`/`generator` carry the whole rule, not just its values**, so one plugin can register several related rules
+  and dispatch on `rule.type` internally, and so the request is self-describing in a log.
+- **`ContentMismatch` is reused verbatim** for results, per this proposal's original direction - a field mismatch and
+  a content mismatch are the same thing at different granularity, and every driver, reporter and UI already
+  understands the type. `expected`/`actual` on it are bytes, so a binary value survives being reported.
+- **No `allow_unexpected_keys`**: that is a whole-content concept.
+- **Capability classification** ([005](./005_Plugin_capability_negotiation_and_versioning.md)): no new capability
+  strings. A plugin declares it provides a field rule by registering the catalogue entry, and implementing the
+  matching RPC is then part of that entry's contract. In the other direction, host-provided rules appear in
+  `hostCapabilities` automatically, since the driver already derives that list from its core catalogue entries as
+  `<entry_type>/<key>` - `matcher/type`, `generator/date`, and so on, once 009 registers them.
+
+### 6. Context available to the plugin
+
+A field-level call sees the value, its path, the rule's own configuration, the plugin's stored configuration, and the
+test context. It deliberately does **not** see the surrounding document, sibling values, or the rest of the
+interaction.
+
+This is the answer to the proposal's original open question, and the reasoning is: shipping the enclosing document
+would mean serialising it per field (potentially per element of a large collection), and would need a document model
+in the request that is neither binary-safe nor transport-neutral - reintroducing exactly the problem the `oneof`
+value model exists to avoid. A rule that genuinely needs to reason about more than one value is a *content* matcher,
+which is already supported, and which can now delegate individual fields back down to field rules. The dividing line
+is: **field rules see one value; content matchers see the document.**
+
+Generators are pure functions of `(generator config, example value, testContext, testMode)`. They may vary their
+output between calls (that is the point of a generator), but they must not depend on hidden host state: anything the
+host knows that a generator needs - the current time, provider state values, the mock server URL - arrives in
+`testContext`, or is fetched explicitly through a 007 callback. This keeps a generator reproducible from what is in
+the request, which matters for both drivers and for any future in-process runtime.
+
+### 7. Callbacks and host-provided rules
+
+Both operations are added to the `PluginHost` service as well, so a plugin can invoke a field rule it does not own -
+the host's standard `type`/`regex`/`date` implementations from
+[009](./009_Host_provided_core_matching_and_generation.md), or another plugin's rule:
+
+```proto
+message HostMatchFieldRequest {
+  string entryKey = 1;
+  MatchFieldRequest request = 2;
+}
+
+message HostGenerateFieldRequest {
+  string entryKey = 1;
+  GenerateFieldRequest request = 2;
+}
+
+service PluginHost {
+  // ... Log, CompareContents, GenerateContent ...
+  rpc MatchField(HostMatchFieldRequest) returns (MatchFieldResponse);
+  rpc GenerateField(HostGenerateFieldRequest) returns (GenerateFieldResponse);
+}
+```
+
+No new plumbing is required: this is 007's mechanism with two more capability shapes. The same `resolve_capability`
+resolver, the same `pact-call-chain-id` cycle detection and `pact-deadline-ms` propagation, the same CORE-or-forward
+dispatch.
+
+This is what makes the "plugin owns a content type, delegates most fields to the host" story work: a protobuf plugin
+matching a `CreditCard` message can apply `matcher/type` to most fields through the host and only implement what is
+actually protobuf-specific, and can hand a field carrying a `{ "match": "creditcard" }` rule straight to the
+`creditcard` plugin without knowing it exists.
+
+### 8. Driver-side model
+
+Mirroring `content.rs`'s `ContentMatcher`/`ContentGenerator`, a new `field.rs` module in the Rust driver (and
+`FieldMatcher.kt`/`FieldGenerator.kt` on the JVM):
+
+```rust
+/// A single value being matched or generated - the driver-side counterpart of the proto FieldValue.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FieldValue {
+  /// A JSON-like value
+  Json(serde_json::Value),
+  /// Raw bytes
+  Binary(Bytes)
+}
+
+pub struct FieldMatcher { pub catalogue_entry: CatalogueEntry }
+
+impl FieldMatcher {
+  pub fn is_core(&self) -> bool;
+
+  pub async fn match_field(
+    &self,
+    rule: &MatchingRule,
+    path: &DocPath,
+    category: &str,
+    expected: &FieldValue,
+    actual: &FieldValue,
+    plugin_config: Option<PluginInteractionConfig>,
+    context: &HashMap<String, Value>
+  ) -> Result<(), Vec<ContentMismatch>>;
+}
+
+pub struct FieldGenerator { pub catalogue_entry: CatalogueEntry }
+
+impl FieldGenerator {
+  pub fn is_core(&self) -> bool;
+
+  pub async fn generate_field(
+    &self,
+    generator: &Generator,
+    path: &DocPath,
+    example: &FieldValue,
+    plugin_config: Option<PluginInteractionConfig>,
+    context: &HashMap<String, Value>,
+    mode: TestMode
+  ) -> anyhow::Result<FieldValue>;
+}
+
+/// Look up a field matcher/generator by rule name (not by content type, unlike find_content_matcher)
+pub fn find_field_matcher(name: &str) -> Option<FieldMatcher>;
+pub fn find_field_generator(name: &str) -> Option<FieldGenerator>;
+```
+
+`is_core()` dispatches exactly as `content.rs` does after 007: to a handler registered in `core_capabilities`, or to
+the owning plugin over gRPC on a fresh call chain. The two new traits and their registration functions follow the
+established shape:
+
+```rust
+#[async_trait]
+pub trait CoreFieldMatcher: Send + Sync {
+  async fn match_field(&self, request: MatchFieldRequest) -> anyhow::Result<MatchFieldResponse>;
+}
+
+#[async_trait]
+pub trait CoreFieldGenerator: Send + Sync {
+  async fn generate_field(&self, request: GenerateFieldRequest) -> anyhow::Result<GenerateFieldResponse>;
+}
+
+pub fn register_core_field_matcher(key: &str, handler: Arc<dyn CoreFieldMatcher>);
+pub fn register_core_field_generator(key: &str, handler: Arc<dyn CoreFieldGenerator>);
+```
+
+These four functions are the entire remaining requirement of
+[009](./009_Host_provided_core_matching_and_generation.md) step 2.
+
+### 9. Host framework integration
+
+The work outside this repository, stated explicitly because it is most of the delivery risk:
+
+1. `pact_models` / Pact-JVM model: the `Plugin` carrier variants from [4](#4-model-representation-and-the-pact-file),
+   their JSON round-trip, and the definition-expression parser change.
+2. `pact_matching` / Pact-JVM matching engine: a dispatch arm that resolves a `Plugin` rule through
+   `pact_plugin_driver::field::find_field_matcher` and calls it, and the equivalent for generators in generator
+   application. Both crates already depend on the driver, so no new dependency edge is created.
+3. Recording the providing plugin in the Pact file's `plugins` metadata when a `Plugin` rule or generator is
+   serialised (see [4](#4-model-representation-and-the-pact-file)).
+
+One known implementation hazard: parts of the matching engines are synchronous (Rust's `Matches` trait, for
+instance) while the driver's plugin calls are async. The field API is async for consistency with the rest of the
+driver; hosts with a synchronous matching path will need the same bridging they already use elsewhere, and this
+should be confirmed early rather than discovered during implementation.
+
+### 10. Lua transport
+
+A Lua plugin defines two more optional globals, required only if it registers the corresponding catalogue entry.
+Table shapes mirror the proto fields, following the existing conventions in the
+[Lua plugin reference](../lua-plugin-reference.md) - `snake_case` keys, and a field value that is either a plain Lua
+value or a `{ binary = "..." }` wrapper, exactly as metadata values already work:
+
+```lua
+-- request: { key, rule = { type, values }, path, mismatch_type, expected, actual,
+--            plugin_configuration, test_context }
+-- returns: { mismatches = { <ContentMismatch table>, ... } } or { error = "..." }
+function match_field(request) end
+
+-- request: { key, generator = { type, values }, path, example_value,
+--            plugin_configuration, test_context, test_mode }
+-- returns: { value = <any> } or { error = "..." }
+function generate_field(request) end
+```
+
+and gains two host functions alongside `host_compare_contents`/`host_generate_content`:
+
+```lua
+host_match_field(entry_key, request)     -- -> { error = "...", mismatches = { ... } }
+host_generate_field(entry_key, request)  -- -> { error = "...", value = ... }
+```
+
+Both are async host functions resolving through the same `resolve_capability` path as their content-level
+equivalents, with no call-chain ID or cycle detection needed - the same reasoning as in 007's Lua section.
+
+### WASM transport
+
+Out of scope for this design pass. The operation shape is transport-neutral by construction (the `oneof` value model
+and reused message types exist precisely so it can cross a linear-memory boundary as serialised protobuf), so the
+WASM mapping is the mechanical one 007 describes, to be filled in when [003](./003_Support_WASM_plugins.md) lands
+WASM plugin support at all.
+
+## Sequencing
+
+1. ⬜ Proto: `GENERATOR` entry type, `FieldValue`, the four request/response messages, the two `PactPlugin` RPCs and
+   the two `PluginHost` RPCs. Regenerate the checked-in Rust bindings (`PACT_PLUGIN_BUILD_PROTOBUFS`).
+2. ⬜ Rust driver: `field.rs`, the two `core_capabilities` traits + registries, catalogue lookups, `PluginHost`
+   service methods, `grpc_plugin`/`PluginInstance` methods.
+3. ⬜ JVM driver: the same surface (`FieldMatcher.kt`, `FieldGenerator.kt`, `CoreCapabilities.kt`,
+   `PluginHostServer.kt`, `PluginRpcClient.kt`).
+4. ⬜ Lua runtime in both drivers: `match_field`/`generate_field` invocation, `host_match_field`/
+   `host_generate_field` host functions, conversions in `lua_plugin.rs` / `LuaConversions.kt`.
+5. ✅ Reference plugin: [`plugins/creditcard`](../../plugins/creditcard), written against this design. Cannot run
+   until steps 1-4 land.
+6. ⬜ Host framework integration ([9](#9-host-framework-integration)), and an example consumer/provider pair under
+   `examples/creditcard` once it can actually execute.
+7. ⬜ Docs: the Lua reference and plugin writing guide gain the two new functions and the `MATCHER`/`GENERATOR`
+   entry types.
 
 ## Non-goals for this proposal
 
 - Redesigning whole-content matcher/generator flows.
-- Defining a general-purpose callback bus between plugins and the host.
-- Solving plugin runtime/version negotiation on its own.
+- Defining a general-purpose callback bus between plugins and the host (see [007](./007_Driver_plugin_callback_model.md)).
+- Solving plugin runtime/version negotiation on its own (see [005](./005_Plugin_capability_negotiation_and_versioning.md)).
+- Giving field-level plugins access to the surrounding document (see [6](#6-context-available-to-the-plugin)).
+- Rules whose semantics are collection-wide (`arrayContains`, `eachKey`/`eachValue`, `atLeast`/`atMost`). These stay
+  core: they are structural rules the matching engine has to interpret itself in order to know *which* values to
+  match, and a plugin cannot participate in that decision through a one-value-at-a-time interface.
 
-## WASM compatibility
+## Resolved questions
 
-For gRPC plugins, field-level matching and generation operations will be new RPCs in the plugin service. For WASM plugins, the same operations will be exported WASM functions that the host calls into. The data types used must be representable in both forms.
-
-In practice this means:
-- value types should follow the existing `oneof` pattern (see `MetadataValue` in the current proto) rather than assuming JSON encoding;
-- path expressions should use the existing Pact matching rule expression format already used throughout the interface;
-- mismatch results should reuse the existing `ContentMismatch` type rather than introducing a parallel structure.
+- **What value model should be used for binary-safe field-level matching and generation?** A `FieldValue` `oneof` of
+  `google.protobuf.Value` or `bytes`, the same shape as the existing `MetadataValue`. Kept as its own message rather
+  than reusing `MetadataValue` because the name would be actively misleading in this context; the two can be
+  unified later if a third use appears. In Lua, the existing metadata convention carries over unchanged: a plain
+  value, or `{ binary = "..." }`.
+- **How much of the surrounding document context should be visible to a field-level plugin call?** None. See
+  [6](#6-context-available-to-the-plugin) - the line between a field rule and a content matcher is exactly that a
+  field rule sees one value.
+- **Should field-level generators be pure functions, or can they depend on host-provided context?** Pure functions of
+  the request, where the request includes `testContext` and `testMode`. No hidden host state; anything the host knows
+  is passed in or fetched through an explicit 007 callback.
+- **How is a plugin rule named and resolved?** The rule name *is* the catalogue key, resolved through 007's existing
+  `resolve_capability` with its suffix matching, ambiguity detection and clear errors. Core rule names are resolved
+  by the host first and cannot be shadowed.
+- **Do field-level generators need their own catalogue entry type?** Yes - `GENERATOR = 5`. Reusing `MATCHER` would
+  weaken the expected-type check that stops a callback dispatching to the wrong capability shape.
+- **Do the new operations need new capability strings under 005?** No. Registering the catalogue entry is the
+  declaration; host-provided rules already surface in `hostCapabilities` via the driver's existing
+  `<entry_type>/<key>` derivation from core catalogue entries.
 
 ## Open questions
 
-- What value model should be used for binary-safe field-level matching and generation?
-- How much of the surrounding document context should be visible to a field-level plugin call?
-- Should field-level generators be pure functions, or can they depend on host-provided context?
+- **Should a matching rule implicitly attach the same-named generator when the catalogue has one?** It would match
+  how `datetime` behaves today and remove a line of boilerplate, but the definition-expression parser lives in
+  `pact_models`, which has no visibility of the catalogue - so the resolution would have to happen in a later host
+  layer that does. Explicit declaration is the design; this is a possible convenience on top.
+- **Pact file portability.** A Pact file containing a plugin rule cannot be interpreted by an implementation that
+  cannot load the plugin. The `plugins` metadata entry makes the requirement explicit and diagnosable, but there is
+  no graceful degradation (no "fall back to `type` if the plugin is unavailable"). Is that acceptable, or should a
+  plugin rule be able to declare a core fallback rule for readers that cannot resolve it?
+- **Synchronous host matching paths.** See [9](#9-host-framework-integration) - needs confirming against
+  `pact_matching`'s and Pact-JVM's actual call paths before step 6.

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -187,12 +187,18 @@ before the rule can be resolved at all.
 Two new RPCs on `PactPlugin`, and their `PluginHost` counterparts for the callback direction:
 
 ```proto
-// A single value being matched or generated. Binary-safe: follows the same oneof pattern as
-// MetadataValue rather than assuming everything is representable as JSON.
+// A single value being matched or generated. Each type Pact's matching rules discriminate has its
+// own arm - see "Value model" below for why this is not a google.protobuf.Value.
 message FieldValue {
   oneof value {
-    google.protobuf.Value nonBinaryValue = 1;
-    bytes binaryValue = 2;
+    google.protobuf.NullValue nullValue = 1;
+    bool booleanValue = 2;
+    string stringValue = 3;
+    int64 integerValue = 4;
+    double decimalValue = 5;
+    bytes binaryValue = 6;
+    // A map or list, for a rule applied to a collection rather than a scalar
+    google.protobuf.Value structuredValue = 7;
   }
 }
 
@@ -253,6 +259,21 @@ service PactPlugin {
   rpc GenerateField(GenerateFieldRequest) returns (GenerateFieldResponse);
 }
 ```
+
+**Value model.** The first draft of this proposal reused the `MetadataValue` shape - a `oneof` of
+`google.protobuf.Value` or `bytes`. That is wrong here, and the difference matters: `google.protobuf.Value` has a
+single number type (a double), so `100` and `100.0` are indistinguishable once a value crosses the interface, for
+every plugin implementation. The rules that would break are exactly the ones whose job is to check a value's runtime
+type - `integer` and `decimal` could never tell their two cases apart, and `type` would wrongly pass an actual
+decimal against an expected whole number. Under [009](./009_Host_provided_core_matching_and_generation.md) those are
+*host* handlers being called *by* a plugin, so the host cannot recover what the boundary erased.
+
+Hence an explicit arm per type. Metadata can afford the loose model because nothing type-checks a metadata value;
+a matching interface cannot.
+
+The one accepted imprecision: numbers nested inside `structuredValue` still follow JSON semantics. A rule applied to
+a collection only needs its shape and size - the values inside it are matched by their own field-level calls, at
+their own paths, where they arrive under the scalar arms.
 
 Notes on specific choices:
 
@@ -327,12 +348,22 @@ Mirroring `content.rs`'s `ContentMatcher`/`ContentGenerator`, a new `field.rs` m
 
 ```rust
 /// A single value being matched or generated - the driver-side counterpart of the proto FieldValue.
+/// serde_json::Value already distinguishes a whole number from a decimal, so the driver-side type
+/// stays simple; it is the conversion to the proto form that keeps the distinction on the wire.
 #[derive(Clone, Debug, PartialEq)]
 pub enum FieldValue {
   /// A JSON-like value
   Json(serde_json::Value),
   /// Raw bytes
   Binary(Bytes)
+}
+
+/// Where a value sits and what is known about it, shared by matching and generation
+pub struct FieldContext {
+  pub path: DocPath,
+  pub category: String,
+  pub plugin_config: Option<PluginInteractionConfig>,
+  pub test_context: HashMap<String, Value>
 }
 
 pub struct FieldMatcher { pub catalogue_entry: CatalogueEntry }
@@ -343,12 +374,9 @@ impl FieldMatcher {
   pub async fn match_field(
     &self,
     rule: &MatchingRule,
-    path: &DocPath,
-    category: &str,
     expected: &FieldValue,
     actual: &FieldValue,
-    plugin_config: Option<PluginInteractionConfig>,
-    context: &HashMap<String, Value>
+    context: &FieldContext
   ) -> Result<(), Vec<ContentMismatch>>;
 }
 
@@ -360,17 +388,17 @@ impl FieldGenerator {
   pub async fn generate_field(
     &self,
     generator: &Generator,
-    path: &DocPath,
     example: &FieldValue,
-    plugin_config: Option<PluginInteractionConfig>,
-    context: &HashMap<String, Value>,
-    mode: TestMode
+    mode: TestMode,
+    context: &FieldContext
   ) -> anyhow::Result<FieldValue>;
 }
 
-/// Look up a field matcher/generator by rule name (not by content type, unlike find_content_matcher)
-pub fn find_field_matcher(name: &str) -> Option<FieldMatcher>;
-pub fn find_field_generator(name: &str) -> Option<FieldGenerator>;
+/// Look up a field matcher/generator by rule name (not by content type, unlike
+/// find_content_matcher). Returns a descriptive error rather than None, since "no such rule",
+/// "ambiguous rule" and "that name is a generator, not a matcher" all need to reach the user.
+pub fn find_field_matcher(name: &str) -> anyhow::Result<FieldMatcher>;
+pub fn find_field_generator(name: &str) -> anyhow::Result<FieldGenerator>;
 ```
 
 Both operations also need a blocking wrapper, because every Rust host that applies a matching rule does so from a
@@ -490,8 +518,12 @@ WASM plugin support at all.
    the two `PluginHost` RPCs, with the checked-in Rust bindings regenerated. The Rust driver's `PluginHost` service
    answers the two new RPCs with `unimplemented` until step 2; the JVM driver needs no change for this, since
    gRPC-Java's generated base class already answers an unimplemented method that way.
-2. ⬜ Rust driver: `field.rs`, the two `core_capabilities` traits + registries, catalogue lookups, `PluginHost`
-   service methods, `grpc_plugin`/`PluginInstance` methods.
+2. ✅ Rust driver: `field.rs` (`FieldValue`, `FieldContext`, `FieldMatcher`/`FieldGenerator` and their blocking
+   wrappers), the two `core_capabilities` traits + registries, catalogue lookups via
+   `catalogue_manager::resolve_capability_entry`, the `PluginHost` service methods, and the
+   `grpc_plugin`/`PluginInstance` methods (V2-only - a V1 plugin gets a clear error, since the operations do not
+   exist on that interface). `proto_v2` had to become a public module: the embedding framework needs those types to
+   implement `CoreFieldMatcher`/`CoreFieldGenerator`.
 
    One trap here: the driver's internal catalogue representation is the **V1** proto's `EntryType`
    (`CatalogueEntryType::to_proto_type`, and the byte-level transcode of V2 catalogue entries into V1
@@ -523,11 +555,12 @@ WASM plugin support at all.
 
 ## Resolved questions
 
-- **What value model should be used for binary-safe field-level matching and generation?** A `FieldValue` `oneof` of
-  `google.protobuf.Value` or `bytes`, the same shape as the existing `MetadataValue`. Kept as its own message rather
-  than reusing `MetadataValue` because the name would be actively misleading in this context; the two can be
-  unified later if a third use appears. In Lua, the existing metadata convention carries over unchanged: a plain
-  value, or `{ binary = "..." }`.
+- **What value model should be used for binary-safe field-level matching and generation?** A `FieldValue` `oneof`
+  with an explicit arm per type Pact's matching rules discriminate - null, boolean, string, integer, decimal, bytes,
+  and a `google.protobuf.Value` for collections. Not the `MetadataValue` shape this proposal originally specified:
+  see [5](#5-operation-shape) for why a single JSON-ish value type breaks the type-checking rules. In Lua, the
+  existing metadata convention carries over for the scalar/binary split (a plain value, or `{ binary = "..." }`),
+  with Lua 5.4's own integer/float distinction (`math.type`) carrying the numeric one.
 - **How much of the surrounding document context should be visible to a field-level plugin call?** None. See
   [6](#6-context-available-to-the-plugin) - the line between a field rule and a content matcher is exactly that a
   field rule sees one value.

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -550,8 +550,14 @@ WASM plugin support at all.
    consumer test until step 6.
 6. ⬜ Host framework integration ([9](#9-host-framework-integration)), and an example consumer/provider pair under
    `examples/creditcard` once it can actually execute.
-7. ⬜ Docs: the Lua reference and plugin writing guide gain the two new functions and the `MATCHER`/`GENERATOR`
-   entry types.
+
+   Blocked on releasing the drivers first: this step lands in `pact-reference` and Pact-JVM, which consume the
+   drivers as published dependencies, so there is nothing for them to build against until steps 1-5 ship in a
+   driver release.
+7. ✅ Docs: the [Lua reference](../lua-plugin-reference.md) and [plugin writing guide](../writing-plugin-guide.md)
+   gain the two new functions, the `MATCHER`/`GENERATOR` entry types and the field value shape. They also gain
+   007's `host_compare_contents`/`host_generate_content`, which had never been documented - leaving those out
+   while documenting their field-level counterparts would have made the set look arbitrary.
 
 ## Non-goals for this proposal
 

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -94,8 +94,14 @@ The **rule name is the catalogue key**. A rule named `creditcard` resolves throu
 `catalogue_manager::resolve_capability` (`CatalogueManager.resolveCapability` on the JVM) with an expected type of
 `MATCHER`/`GENERATOR` - the same resolver 007 already uses for callbacks, with the same behaviour:
 
-- resolves by suffix against the full catalogue key, so a user can write `creditcard/matcher/creditcard` to
-  disambiguate if two plugins ever register the same short name;
+- a bare name (`creditcard`) matches the entry's key; a caller can also name more of the catalogue key
+  (`matcher/creditcard`, `plugin/creditcard/matcher/creditcard`) to disambiguate if two plugins ever register the
+  same short name. Key components are compared whole, never as substrings;
+- failing that, the name is matched against the core catalogue's versioned naming convention - the Pact
+  specification version a rule was introduced in, prefixed to its name - so `type` resolves to `core/matcher/v2-type`
+  and `date` to `core/matcher/v3-date` without a caller having to know which version introduced what. Naming an entry
+  directly always wins over this fallback: a plugin registering its own `matcher/date` takes `date`, and a caller
+  that specifically wants the core rule asks for `v3-date`;
 - a name matching more than one entry of the expected type is a hard error naming the candidates, never a silent
   pick;
 - a name matching nothing is a hard error at match/generate time.
@@ -103,7 +109,7 @@ The **rule name is the catalogue key**. A rule named `creditcard` resolves throu
 Core rule names always win: the host resolves `type`, `regex`, `equality` and the rest of the standard set from its
 own matching engine before it ever consults the catalogue, so a plugin cannot shadow a standard rule. (Once
 [009](./009_Host_provided_core_matching_and_generation.md) registers the standard set as `CORE` entries, those become
-visible in the catalogue too - as `core/matcher/type` etc. - which is what lets a *plugin* call back for them, but
+visible in the catalogue too - as `core/matcher/v2-type` etc. - which is what lets a *plugin* call back for them, but
 does not change how the host resolves its own rules.)
 
 ### 3. Declaring a plugin rule in a test
@@ -258,7 +264,7 @@ Notes on specific choices:
   strings. A plugin declares it provides a field rule by registering the catalogue entry, and implementing the
   matching RPC is then part of that entry's contract. In the other direction, host-provided rules appear in
   `hostCapabilities` automatically, since the driver already derives that list from its core catalogue entries as
-  `<entry_type>/<key>` - `matcher/type`, `generator/date`, and so on, once 009 registers them.
+  `<entry_type>/<key>` - `matcher/v2-type`, `generator/v3-date`, and so on, once 009 registers them.
 
 ### 6. Context available to the plugin
 
@@ -308,7 +314,7 @@ resolver, the same `pact-call-chain-id` cycle detection and `pact-deadline-ms` p
 dispatch.
 
 This is what makes the "plugin owns a content type, delegates most fields to the host" story work: a protobuf plugin
-matching a `CreditCard` message can apply `matcher/type` to most fields through the host and only implement what is
+matching a `CreditCard` message can apply `matcher/v2-type` to most fields through the host and only implement what is
 actually protobuf-specific, and can hand a field carrying a `{ "match": "creditcard" }` rule straight to the
 `creditcard` plugin without knowing it exists.
 

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -536,10 +536,18 @@ WASM plugin support at all.
    `CoreCapabilities.kt`, `CatalogueManager.resolveCapabilityEntry`, `PluginHostServer.kt` and
    `PluginRpcClient.kt`. No blocking wrapper is needed here - the JVM driver talks to plugins over blocking gRPC
    stubs, so the synchronous matching path calls straight through.
-4. ⬜ Lua runtime in both drivers: `match_field`/`generate_field` invocation, `host_match_field`/
+4. ✅ Lua runtime in both drivers: `match_field`/`generate_field` invocation, `host_match_field`/
    `host_generate_field` host functions, conversions in `lua_plugin.rs` / `LuaConversions.kt`.
-5. ✅ Reference plugin: [`plugins/creditcard`](../../plugins/creditcard), written against this design. Cannot run
-   until steps 1-4 land.
+
+   The JVM driver needed a fix one level down, in `LuaJavaEngine`. luajava's `toObject` returns every Lua number
+   as a `Double` and every Lua string as a Java `String`, so a whole number came back as a decimal and a binary
+   value was truncated at its first NUL byte - the two things `FieldValue`'s per-type arms exist to prevent.
+   Reading the stack directly (`isInteger`/`toInteger`, and `toBuffer` for a `{ binary = ... }` wrapper) fixes
+   both, for the existing metadata path as well as for field values. The Rust driver needed no equivalent: mlua
+   distinguishes `Value::Integer` from `Value::Number`, and its strings are byte-safe.
+5. ✅ Reference plugin: [`plugins/creditcard`](../../plugins/creditcard), written against this design. Now runs -
+   both drivers' test suites load it and exercise its rule and generator end to end - but cannot be reached from a
+   consumer test until step 6.
 6. ⬜ Host framework integration ([9](#9-host-framework-integration)), and an example consumer/provider pair under
    `examples/creditcard` once it can actually execute.
 7. ⬜ Docs: the Lua reference and plugin writing guide gain the two new functions and the `MATCHER`/`GENERATOR`

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -365,6 +365,9 @@ pub fn find_field_matcher(name: &str) -> Option<FieldMatcher>;
 pub fn find_field_generator(name: &str) -> Option<FieldGenerator>;
 ```
 
+Both operations also need a blocking wrapper, because every Rust host that applies a matching rule does so from a
+synchronous call path - see [9](#9-host-framework-integration) for why that bridge belongs in the driver.
+
 `is_core()` dispatches exactly as `content.rs` does after 007: to a handler registered in `core_capabilities`, or to
 the owning plugin over gRPC on a fresh call chain. The two new traits and their registration functions follow the
 established shape:
@@ -399,10 +402,43 @@ The work outside this repository, stated explicitly because it is most of the de
 3. Recording the providing plugin in the Pact file's `plugins` metadata when a `Plugin` rule or generator is
    serialised (see [4](#4-model-representation-and-the-pact-file)).
 
-One known implementation hazard: parts of the matching engines are synchronous (Rust's `Matches` trait, for
-instance) while the driver's plugin calls are async. The field API is async for consistency with the rest of the
-driver; hosts with a synchronous matching path will need the same bridging they already use elsewhere, and this
-should be confirmed early rather than discovered during implementation.
+**Calling an async driver from a synchronous matching path (Rust only).** The JVM driver talks to plugins over
+blocking gRPC stubs (`PactPluginBlockingStub`), so Pact-JVM has nothing to solve here. In Rust, rule application is
+synchronous - `match_values` -> `Matches::matches_with` - and the V2 matching engine's `execute_request_plan`/
+`execute_response_plan`/`execute_message_plan` are synchronous end to end, while the driver's plugin calls are async.
+
+Two approaches do **not** work at that call site:
+
+- `Handle::current().block_on(fut)` panics. Body matching is reached from the async `compare_bodies`, so the thread
+  is already inside a runtime context, and tokio's `enter_runtime` guard raises *"Cannot start a runtime from within
+  a runtime"*.
+- `task::block_in_place(|| Handle::current().block_on(fut))` is tokio's documented way to re-enter a runtime, but
+  panics on a `current_thread` runtime. Pact has `current_thread` call sites that reach matching - `pact_consumer`'s
+  `check_requests_match` drives `match_request` on one - so this would work under the verifier, the FFI and the HTTP
+  mock server and panic elsewhere.
+
+What does work is the bridge `pact_matching` already uses twice for multipart bodies (`binary_utils.rs`:
+`match_mime_multipart`, `parse_multipart_body`): run the future on a separate thread with its own runtime, and
+receive the result over a channel with a timeout. Two refinements over that existing code:
+
+- It calls `Handle::try_current()` *inside* the spawned thread. Tokio's runtime context is a thread-local that
+  `std::thread::spawn` does not inherit, so that call always returns `Err` and the "reuse the host runtime" branch
+  never actually runs. Capture the handle before spawning if reuse is the intent.
+- Reusing the host runtime is only safe when it is a multi-thread one anyway. A plugin's tonic `Channel` spawns its
+  connection task on whichever runtime was current when the plugin was loaded; if that is a `current_thread` runtime
+  whose only thread is the one now blocked inside sync matching, the connection cannot progress and the call hangs
+  until the timeout.
+
+So the driver should own a dedicated runtime for plugin calls and expose blocking wrappers next to the async
+operations, rather than leaving each host to build its own bridge:
+
+```rust
+pub fn match_field_blocking(/* same arguments as match_field */) -> Result<(), Vec<ContentMismatch>>;
+pub fn generate_field_blocking(/* same arguments as generate_field */) -> anyhow::Result<FieldValue>;
+```
+
+The wrapper's timeout should come from the existing deadline (`call_chain::default_deadline_ms`) rather than being a
+second, unrelated number.
 
 ### 10. Lua transport
 
@@ -488,6 +524,10 @@ WASM plugin support at all.
 - **Do the new operations need new capability strings under 005?** No. Registering the catalogue entry is the
   declaration; host-provided rules already surface in `hostCapabilities` via the driver's existing
   `<entry_type>/<key>` derivation from core catalogue entries.
+- **How does a synchronous Rust matching path call an async plugin operation?** Through a blocking wrapper the
+  driver owns, backed by its own runtime - not `Handle::block_on` (panics: the thread is already inside a runtime)
+  and not `block_in_place` (panics on the `current_thread` runtimes some Pact entry points use). See
+  [9](#9-host-framework-integration). The JVM driver is unaffected, since it uses blocking gRPC stubs.
 
 ## Open questions
 
@@ -499,5 +539,3 @@ WASM plugin support at all.
   cannot load the plugin. The `plugins` metadata entry makes the requirement explicit and diagnosable, but there is
   no graceful degradation (no "fall back to `type` if the plugin is unavailable"). Is that acceptable, or should a
   plugin rule be able to declare a core fallback rule for readers that cannot resolve it?
-- **Synchronous host matching paths.** See [9](#9-host-framework-integration) - needs confirming against
-  `pact_matching`'s and Pact-JVM's actual call paths before step 6.

--- a/docs/proposals/009_Host_provided_core_matching_and_generation.md
+++ b/docs/proposals/009_Host_provided_core_matching_and_generation.md
@@ -39,7 +39,8 @@ and generator set (`type`, `regex`, `equality`, `date`/`time`, etc. — the same
 catalogue) as `CatalogueEntryProviderType::CORE` entries, each with a registered handler implementing the relevant
 trait from 007 (a content-level `CoreContentMatcher`/`CoreContentGenerator`, or the field-level equivalent 006 defines).
 A plugin that wants standard behaviour for a field it doesn't want to reimplement calls back through the mechanism 007
-already defines, naming the catalogue key for the standard rule it wants (e.g. `matcher/type`, `matcher/regex`).
+already defines, naming the catalogue key for the standard rule it wants (e.g. `matcher/v2-type`,
+`matcher/v2-regex`, or just `type`/`regex` - see [006](./006_Field_level_matchers_and_generators.md#2-naming-and-resolution)).
 
 No new protocol messages, transports, or dependency-inversion mechanism are needed beyond what 006 and 007 already
 define. This proposal's remaining job is narrower than originally scoped: registering the existing standard matcher/

--- a/docs/writing-plugin-guide.md
+++ b/docs/writing-plugin-guide.md
@@ -136,12 +136,21 @@ See the [JWT plugin](../plugins/jwt) for a complete, working reference implement
 
 ### Scope
 
-A Lua plugin can register any combination of `CONTENT_MATCHER`/`CONTENT_GENERATOR` and `TRANSPORT` catalogue
-entries from its `init` function - the same way an `exec` (gRPC) plugin does. For a content-matcher/generator
-plugin, only `compareContents`, `configureInteraction`, and `generateContent` are ever called (see
-[Content Matchers and Generators](content-matcher-design.md)); a Lua plugin gets full provider-verification support
-for free through `compareContents`/`generateContent` alone, since the core verifier makes the real request to the
-provider and then reuses ordinary content matching to compare the actual response against the expected one.
+A Lua plugin can register any combination of `CONTENT_MATCHER`/`CONTENT_GENERATOR`, `MATCHER`/`GENERATOR` and
+`TRANSPORT` catalogue entries from its `init` function - the same way an `exec` (gRPC) plugin does. For a
+content-matcher/generator plugin, only `compareContents`, `configureInteraction`, and `generateContent` are ever
+called (see [Content Matchers and Generators](content-matcher-design.md)); a Lua plugin gets full
+provider-verification support for free through `compareContents`/`generateContent` alone, since the core verifier
+makes the real request to the provider and then reuses ordinary content matching to compare the actual response
+against the expected one.
+
+A `MATCHER`/`GENERATOR`-registered plugin is a smaller thing than a content matcher: rather than owning a whole
+content type, it contributes one matching rule and/or generator that applies to a single *value* inside somebody
+else's content - a field in a JSON body, a header, a message metadata value. It defines `match_field` and/or
+`generate_field` and nothing else; `configure_interaction`/`match_contents` belong to content matchers, and a
+field-level plugin never owns the content its value appears in. See the
+[credit card plugin](../plugins/creditcard) for a complete reference implementation, and
+[proposal 006](proposals/006_Field_level_matchers_and_generators.md) for the design.
 
 For a `TRANSPORT`-registered plugin, the mock-server (`start_mock_server`/`shutdown_mock_server`/
 `get_mock_server_results`) and provider-verification (`prepare_interaction_for_verification`/`verify_interaction`)
@@ -224,6 +233,28 @@ field-by-field reference of every function and table shape mentioned below, see 
 - **`update_catalogue(catalogue)` (optional)** - called whenever another plugin loads and the combined catalogue
   changes. If you don't define this function, it's a no-op.
 
+If your plugin registers a `MATCHER` or `GENERATOR` catalogue entry, it defines these instead. Note that for these
+entries the catalogue `key` **is** the name of the rule a test writes, not your plugin's name, and a `MATCHER` and
+a `GENERATOR` entry can share one key - the entry type is what tells them apart.
+
+- **`match_field(request) -> table`** - called to apply your matching rule to a single value. `request` has `key`,
+  `rule` (`{ type = "...", values = {...} }`), `path` (a matching-rule expression like `"$.card.number"`),
+  `mismatch_type` (which part of the interaction the value came from: `"body"`, `"header"`, and so on),
+  `expected`/`actual` (the values themselves), `plugin_configuration` and `test_context`. Return one of:
+  - `{ error = "..." }` - the rule itself couldn't be applied, e.g. it was misconfigured. That's the test author's
+    mistake rather than the provider's, so it fails the test outright rather than being reported as a mismatch.
+  - `{ mismatches = { ... } }` - an array (not a path-keyed table, unlike `match_contents`) of mismatch strings or
+    tables. A mismatch that doesn't set its own `path` is reported against the request's `path`. Empty or absent
+    means the value matched.
+- **`generate_field(request) -> table`** - called to generate a value replacing the example one in the Pact file.
+  `request` has `key`, `generator` (`{ type = "...", values = {...} }`), `path`, `example_value`,
+  `plugin_configuration`, `test_context` and `test_mode`. Return `{ value = ... }` or `{ error = "..." }`.
+
+A value crossing this boundary is a plain Lua value - `nil`, boolean, string, number, or table - except for raw
+bytes, which are wrapped as `{ binary = "..." }` the same way a binary metadata value is. Lua 5.4's integer/float
+distinction is preserved in both directions, so `math.type(v)` tells you whether the Pact file held `100` or
+`100.0`; rules like `integer`, `decimal` and `type` depend on that.
+
 If your plugin registers a `TRANSPORT` catalogue entry, it must also define these functions. Each is called with
 either a V1-shaped or a V2-shaped request table, never both, depending on your manifest's `pluginInterfaceVersion`
 (the same static, per-plugin-instance choice the driver makes for a gRPC transport plugin) - a V2 request replaces
@@ -269,6 +300,14 @@ The driver registers a few host (native) functions as Lua globals before loading
   decoding primitives, since Lua has no built-in crypto support. These exist specifically to support the JWT
   reference plugin; if your plugin needs different cryptographic or encoding primitives, either implement them in
   pure Lua or pull in a [LuaRocks package](#luarocks-support) that provides them.
+- **`host_compare_contents(entry_key, request)`**, **`host_generate_content(entry_key, contents, generators,
+  test_mode)`**, **`host_match_field(entry_key, request)`**, **`host_generate_field(entry_key, request)`** - call
+  back into a capability your plugin doesn't implement itself: one the host Pact framework provides (the standard
+  Pact matching rules and generators), or one another loaded plugin registered. Each takes a catalogue entry key
+  naming what to invoke, and otherwise has the same request and return shapes as the plugin function of the same
+  name, so you can pass a request straight through and return its result unchanged. The field-level pair is how a
+  content matcher applies a standard Pact rule to one value inside the content it owns, instead of reimplementing
+  the rule.
 
 ### Vendoring dependencies (preferred)
 

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
@@ -3,6 +3,7 @@ package io.pact.plugins.jvm.core
 import au.com.dius.pact.core.model.ContentType
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.pact.plugin.Plugin
+import io.pact.plugin.v2.PluginV2
 import java.lang.IllegalArgumentException
 
 private val logger = KotlinLogging.logger {}
@@ -19,9 +20,20 @@ object CatalogueManager {
    */
   fun registerPluginEntries(name: String, catalogueList: List<Plugin.CatalogueEntry>) {
     catalogueList.forEach {
-      val type = CatalogueEntryType.fromEntry(it.type)
-      val key = "plugin/$name/${type}/${it.key}"
-      catalogue[key] = CatalogueEntry(type, CatalogueEntryProviderType.PLUGIN, name, it.key, it.valuesMap)
+      // Deliberately reading the raw field rather than the generated `type` accessor: that accessor
+      // is generated against the V1 enum and reports anything it doesn't recognise as UNRECOGNIZED,
+      // which fromEntry maps to CONTENT_MATCHER - silently registering a V2-only entry type, a
+      // GENERATOR say, as a content matcher.
+      val type = CatalogueEntryType.fromEntryValue(it.typeValue)
+      if (type == null) {
+        logger.warn {
+          "Ignoring catalogue entry '${it.key}' from plugin '$name': ${it.typeValue} is not a " +
+            "catalogue entry type this driver understands"
+        }
+      } else {
+        val key = "plugin/$name/${type}/${it.key}"
+        catalogue[key] = CatalogueEntry(type, CatalogueEntryProviderType.PLUGIN, name, it.key, it.valuesMap)
+      }
     }
 
     logger.debug { "Updated catalogue entries:\n${catalogue.keys.joinToString("\n")}" }
@@ -172,7 +184,13 @@ private fun ContentType.matches(type: String) = this.getBaseType().orEmpty().mat
  * Type of entry in the catalogue
  */
 enum class CatalogueEntryType {
-  CONTENT_MATCHER, CONTENT_GENERATOR, TRANSPORT, MATCHER, INTERACTION;
+  CONTENT_MATCHER, CONTENT_GENERATOR, TRANSPORT, MATCHER, INTERACTION,
+
+  /**
+   * Generator for a content field/value. Only representable on the V2 plugin interface - the V1
+   * EntryType enum has no equivalent. See proposal 006 (Field-level matchers and generators).
+   */
+  GENERATOR;
 
   override fun toString(): String {
     return when (this) {
@@ -181,12 +199,21 @@ enum class CatalogueEntryType {
       TRANSPORT -> "transport"
       MATCHER -> "matcher"
       INTERACTION -> "interaction"
+      GENERATOR -> "generator"
     }
   }
 
   /**
-   * Convert this entry type to the matching Protobuf type
+   * Convert this entry type to the matching Protobuf type.
+   *
+   * This maps to the *V1* enum, which cannot represent every entry type: GENERATOR has no V1
+   * equivalent and is reported as MATCHER. Use [toEntryValue] instead, which returns the wire
+   * value and is lossless for both interface versions.
    */
+  @Deprecated(
+    message = "Use toEntryValue, which can represent entry types that only exist on the V2 interface",
+    replaceWith = ReplaceWith("toEntryValue()")
+  )
   fun toEntry(): Plugin.CatalogueEntry.EntryType {
     return when (this) {
       CONTENT_MATCHER -> Plugin.CatalogueEntry.EntryType.CONTENT_MATCHER
@@ -194,13 +221,45 @@ enum class CatalogueEntryType {
       TRANSPORT -> Plugin.CatalogueEntry.EntryType.TRANSPORT
       MATCHER -> Plugin.CatalogueEntry.EntryType.MATCHER
       INTERACTION -> Plugin.CatalogueEntry.EntryType.INTERACTION
+      GENERATOR -> Plugin.CatalogueEntry.EntryType.MATCHER
     }
   }
+
+  /**
+   * The V2 Protobuf enum for this entry type. V2 is the canonical source of the wire values: it
+   * mirrors V1 for the entry types both versions share, and adds the ones V1 never had.
+   */
+  private fun toEntryV2(): PluginV2.CatalogueEntry.EntryType {
+    return when (this) {
+      CONTENT_MATCHER -> PluginV2.CatalogueEntry.EntryType.CONTENT_MATCHER
+      CONTENT_GENERATOR -> PluginV2.CatalogueEntry.EntryType.CONTENT_GENERATOR
+      TRANSPORT -> PluginV2.CatalogueEntry.EntryType.TRANSPORT
+      MATCHER -> PluginV2.CatalogueEntry.EntryType.MATCHER
+      INTERACTION -> PluginV2.CatalogueEntry.EntryType.INTERACTION
+      GENERATOR -> PluginV2.CatalogueEntry.EntryType.GENERATOR
+    }
+  }
+
+  /**
+   * The Protobuf enum value for this entry type, for setting the `type` field of a CatalogueEntry
+   * message with `setTypeValue`. Lossless for every entry type, including those a V1 plugin will
+   * not recognise - a V1 plugin decodes an unknown value as UNRECOGNIZED and ignores the entry,
+   * which is the correct outcome, whereas mapping it onto some other V1 type would have the plugin
+   * act on an entry that is not what it thinks it is.
+   */
+  fun toEntryValue(): Int = toEntryV2().number
+
+  /**
+   * The Protobuf enum value name for this entry type, e.g. "CONTENT_MATCHER". This is the form a
+   * Lua plugin uses in the catalogue entries returned from its `init` function.
+   */
+  fun toEntryName(): String = toEntryV2().name
 
   companion object {
     /**
      * Return the corresponding entry type from the given string value
      */
+    @JvmStatic
     fun fromString(type: String): CatalogueEntryType {
       return when (type) {
         "content-matcher" -> CONTENT_MATCHER
@@ -208,6 +267,7 @@ enum class CatalogueEntryType {
         "interaction" -> INTERACTION
         "matcher" -> MATCHER
         "transport" -> TRANSPORT
+        "generator" -> GENERATOR
         else -> throw IllegalArgumentException("'$type' is not a valid CatalogueEntryType value")
       }
     }
@@ -215,6 +275,11 @@ enum class CatalogueEntryType {
     /**
      * Return the catalogue entry type from the corresponding Protobuf entry type
      */
+    @Deprecated(
+      message = "Use fromEntryValue, which can represent entry types that only exist on the V2 interface",
+      replaceWith = ReplaceWith("fromEntryValue(type?.number ?: 0)")
+    )
+    @JvmStatic
     fun fromEntry(type: Plugin.CatalogueEntry.EntryType?): CatalogueEntryType {
       return if (type != null) {
         when (type) {
@@ -228,6 +293,35 @@ enum class CatalogueEntryType {
       } else {
         CONTENT_MATCHER
       }
+    }
+
+    /**
+     * The entry type for a Protobuf enum value, or null if the value is not one this driver
+     * understands (an entry type added by a later interface version). Deliberately not defaulting
+     * to CONTENT_MATCHER the way the generated V1 accessor does: silently mis-typing an entry is
+     * worse than ignoring one.
+     */
+    @JvmStatic
+    fun fromEntryValue(value: Int): CatalogueEntryType? {
+      return when (PluginV2.CatalogueEntry.EntryType.forNumber(value)) {
+        PluginV2.CatalogueEntry.EntryType.CONTENT_MATCHER -> CONTENT_MATCHER
+        PluginV2.CatalogueEntry.EntryType.CONTENT_GENERATOR -> CONTENT_GENERATOR
+        PluginV2.CatalogueEntry.EntryType.TRANSPORT -> TRANSPORT
+        PluginV2.CatalogueEntry.EntryType.MATCHER -> MATCHER
+        PluginV2.CatalogueEntry.EntryType.INTERACTION -> INTERACTION
+        PluginV2.CatalogueEntry.EntryType.GENERATOR -> GENERATOR
+        else -> null
+      }
+    }
+
+    /**
+     * The entry type for a Protobuf enum value name, e.g. "CONTENT_MATCHER", or null if the name is
+     * not one this driver understands.
+     */
+    @JvmStatic
+    fun fromEntryName(name: String): CatalogueEntryType? {
+      val entryType = PluginV2.CatalogueEntry.EntryType.values().find { it.name == name }
+      return if (entryType != null) fromEntryValue(entryType.number) else null
     }
   }
 }

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
@@ -105,6 +105,20 @@ object CatalogueManager {
    * check [findContentMatcher]/[findContentGenerator] already do.
    */
   fun resolveCapability(entryKey: String, expectedType: CatalogueEntryType): ResolvedCapability {
+    val entry = resolveCapabilityEntry(entryKey, expectedType)
+    return when (entry.providerType) {
+      CatalogueEntryProviderType.CORE -> ResolvedCapability.Core(entry.key)
+      CatalogueEntryProviderType.PLUGIN -> ResolvedCapability.Plugin(entry.pluginName)
+    }
+  }
+
+  /**
+   * Resolve a catalogue entry key to the entry itself, using the same two-pass matching
+   * [resolveCapability] documents. Callers that need the entry rather than a dispatch target -
+   * [findFieldMatcher] and [findFieldGenerator], which wrap it in a matcher/generator - use this
+   * directly.
+   */
+  fun resolveCapabilityEntry(entryKey: String, expectedType: CatalogueEntryType): CatalogueEntry {
     val named = catalogue.entries.filter { namesCatalogueKey(it.key, entryKey) }.map { it.key to it.value }
     val candidates = if (named.any { (_, entry) -> entry.type == expectedType }) {
       named
@@ -126,10 +140,7 @@ object CatalogueManager {
       else -> throw PactCatalogueEntryAmbiguousException(entryKey, ofExpectedType.map { it.first }.sorted())
     }
 
-    return when (entry.providerType) {
-      CatalogueEntryProviderType.CORE -> ResolvedCapability.Core(entry.key)
-      CatalogueEntryProviderType.PLUGIN -> ResolvedCapability.Plugin(entry.pluginName)
-    }
+    return entry
   }
 
   /**

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
@@ -62,12 +62,18 @@ object CatalogueManager {
   fun coreEntries() = catalogue.values.filter { it.providerType == CatalogueEntryProviderType.CORE }
 
   /**
-   * Lookup entry by key. Entries are keyed by <core|plugin>/<plugin-name>?/<entry-type>/<entry-key>
+   * Lookup entry by key. Entries are keyed by <core|plugin>/<plugin-name>?/<entry-type>/<entry-key>,
+   * and are matched the same way [resolveCapability] matches them: by name first - the whole
+   * catalogue key, or a trailing run of its `/`-separated components - then against the core
+   * catalogue's versioned naming convention.
+   *
+   * Unlike [resolveCapability], this takes the first match when more than one entry matches. Prefer
+   * [resolveCapability] wherever the expected entry type is known and a deterministic answer
+   * matters.
    */
   fun lookupEntry(key: String): CatalogueEntry? {
-    return catalogue[key] ?: catalogue.entries.firstOrNull {
-      it.key.endsWith(key)
-    }?.value
+    return catalogue.entries.firstOrNull { namesCatalogueKey(it.key, key) }?.value
+      ?: catalogue.entries.firstOrNull { namesVersionedCoreKey(it.value, key) }?.value
   }
 
   /**
@@ -212,9 +218,16 @@ private val VERSION_PREFIX = Regex("^v\\d+$")
  * Only the whole name after the version prefix counts, so `type` names `v2-type` but not
  * `v3-content-type` or `v2-min-type` - those are the `content-type` and `min-type` rules.
  *
+ * The convention only applies to matching rules and generators. Content matchers, content
+ * generators and transports are registered under plain names (`xml`, `json`, `grpc`), so a leading
+ * `v<n>-` there is part of the name rather than a version, and stripping it would be wrong.
+ *
  * Must stay consistent with `catalogue_manager::names_versioned_core_key` in the Rust driver.
  */
 internal fun namesVersionedCoreKey(entry: CatalogueEntry, entryKey: String): Boolean {
+  if (entry.type != CatalogueEntryType.MATCHER && entry.type != CatalogueEntryType.GENERATOR) {
+    return false
+  }
   val separator = entry.key.indexOf('-')
   if (separator <= 0) return false
   return entry.key.substring(separator + 1) == entryKey &&

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
@@ -78,23 +78,36 @@ object CatalogueManager {
    * functions ([LuaPactPlugin]) - so there is exactly one place that decides "who provides this
    * entry". See proposal 007 ("One resolver, multiple call directions").
    *
-   * `entryKey` is matched by suffix against the full catalogue key (e.g. a plugin passing `"xml"`
-   * matches `"core/content-matcher/xml"`) - the same lookup [lookupEntry] does, except unlike
-   * [lookupEntry] this does not just take the first hit if more than one entry matches the
-   * suffix. A short, unqualified `entryKey` could otherwise coincidentally match more than one
-   * entry of the *same* `expectedType` (e.g. a plugin registering its own `content-matcher/xml`
-   * alongside a host-registered core `content-matcher/xml`); silently picking one (in whatever
-   * order the backing map iterates) would make the dispatch target depend on registration order
-   * rather than being deterministic. `expectedType` still guards against the *wrong* capability
-   * shape (a content-generator registered under the same name as an unrelated content-matcher),
-   * mirroring the explicit `type` check [findContentMatcher]/[findContentGenerator] already do.
+   * `entryKey` is matched against the catalogue in two passes:
+   *
+   * 1. by name - the whole catalogue key (`core/content-matcher/xml`) or a trailing run of its
+   *    components (`content-matcher/xml`, `xml`), compared component by component;
+   * 2. failing that, against the core catalogue's versioned naming convention, so `type` resolves
+   *    to `v2-type` and `date` to `v3-date`.
+   *
+   * Naming an entry directly always wins over the versioned fallback: if a plugin registers its
+   * own `matcher/date`, `date` resolves to that plugin, and a caller that specifically wants the
+   * core rule asks for `v3-date`.
+   *
+   * Unlike [lookupEntry], this does not just take the first hit when more than one entry matches.
+   * A short, unqualified `entryKey` can still match more than one entry of the *same*
+   * `expectedType` (a plugin registering its own `content-matcher/xml` alongside a host-registered
+   * core `content-matcher/xml`); silently picking one (in whatever order the backing map iterates)
+   * would make the dispatch target depend on registration order rather than being deterministic.
+   * `expectedType` still guards against the *wrong* capability shape (a content-generator
+   * registered under the same name as an unrelated content-matcher), mirroring the explicit `type`
+   * check [findContentMatcher]/[findContentGenerator] already do.
    */
   fun resolveCapability(entryKey: String, expectedType: CatalogueEntryType): ResolvedCapability {
-    val exact = catalogue[entryKey]
-    val candidates = if (exact != null) {
-      listOf(entryKey to exact)
+    val named = catalogue.entries.filter { namesCatalogueKey(it.key, entryKey) }.map { it.key to it.value }
+    val candidates = if (named.any { (_, entry) -> entry.type == expectedType }) {
+      named
     } else {
-      catalogue.entries.filter { it.key.endsWith(entryKey) }.map { it.key to it.value }
+      val versioned = catalogue.entries
+        .filter { namesVersionedCoreKey(it.value, entryKey) }
+        .map { it.key to it.value }
+      // Keep any wrong-typed direct matches for the diagnostic below if the fallback finds nothing
+      if (versioned.isEmpty()) named else versioned
     }
 
     val ofExpectedType = candidates.filter { (_, entry) -> entry.type == expectedType }
@@ -166,6 +179,46 @@ object CatalogueManager {
 
     logger.debug { "Removed all catalogue entries for plugin $name" }
   }
+}
+
+/**
+ * Does `entryKey` name this catalogue key? Either the whole key (`core/content-matcher/xml`), or a
+ * trailing run of its `/`-separated components (`content-matcher/xml`, or just `xml`).
+ *
+ * Components are compared whole, never as substrings: `"type"` does not name
+ * `core/matcher/v2-type`. That distinction is the point - the core catalogue prefixes the Pact
+ * specification version a matcher was introduced in to its name, so a substring match would let an
+ * unqualified name collide with a versioned core key it has nothing to do with (a plugin's own
+ * `matcher/date` against `core/matcher/v3-date`, say). The versioned form is handled deliberately
+ * by [namesVersionedCoreKey] instead, as a fallback rather than a coincidence.
+ *
+ * Must stay consistent with `catalogue_manager::names_catalogue_key` in the Rust driver.
+ */
+internal fun namesCatalogueKey(catalogueKey: String, entryKey: String): Boolean {
+  val keyParts = catalogueKey.split('/')
+  val queryParts = entryKey.split('/')
+  return queryParts.size <= keyParts.size &&
+    keyParts.subList(keyParts.size - queryParts.size, keyParts.size) == queryParts
+}
+
+private val VERSION_PREFIX = Regex("^v\\d+$")
+
+/**
+ * Does `entryKey` name this entry under the core catalogue's versioned naming convention - the Pact
+ * specification version the rule was introduced in, prefixed to its name (`v2-type`, `v3-date`,
+ * `v4-not-empty`)? This is what lets a caller ask for `type` and get `v2-type` without having to
+ * know which specification version introduced it.
+ *
+ * Only the whole name after the version prefix counts, so `type` names `v2-type` but not
+ * `v3-content-type` or `v2-min-type` - those are the `content-type` and `min-type` rules.
+ *
+ * Must stay consistent with `catalogue_manager::names_versioned_core_key` in the Rust driver.
+ */
+internal fun namesVersionedCoreKey(entry: CatalogueEntry, entryKey: String): Boolean {
+  val separator = entry.key.indexOf('-')
+  if (separator <= 0) return false
+  return entry.key.substring(separator + 1) == entryKey &&
+    VERSION_PREFIX.matches(entry.key.substring(0, separator))
 }
 
 /**

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CoreCapabilities.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CoreCapabilities.kt
@@ -1,6 +1,7 @@
 package io.pact.plugins.jvm.core
 
 import io.pact.plugin.Plugin
+import io.pact.plugin.v2.PluginV2
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -20,6 +21,28 @@ fun interface CoreContentGenerator {
 }
 
 /**
+ * A host-provided handler for the `MatchField` capability shape - one of the standard Pact matching
+ * rules applied to a single value. Implemented by the embedding Pact framework and registered via
+ * [CoreCapabilityRegistry.registerFieldMatcher]. See proposals 006 (Field-level matchers and
+ * generators) and 009 (Host-provided core matching and generation).
+ *
+ * The request and response are the V2 interface types: field-level operations were introduced in V2
+ * and have no V1 equivalent.
+ */
+fun interface CoreFieldMatcher {
+  fun matchField(request: PluginV2.MatchFieldRequest): PluginV2.MatchFieldResponse
+}
+
+/**
+ * A host-provided handler for the `GenerateField` capability shape - one of the standard Pact
+ * generators applied to a single value. Implemented by the embedding Pact framework and registered
+ * via [CoreCapabilityRegistry.registerFieldGenerator]. See [CoreFieldMatcher].
+ */
+fun interface CoreFieldGenerator {
+  fun generateField(request: PluginV2.GenerateFieldRequest): PluginV2.GenerateFieldResponse
+}
+
+/**
  * Registry of host-provided ("core") capability handlers, keyed by catalogue entry key.
  *
  * This mirrors [PluginHostServer]'s instance registry, generalised from a single lookup to one
@@ -36,6 +59,8 @@ fun interface CoreContentGenerator {
 object CoreCapabilityRegistry {
   private val contentMatchers = ConcurrentHashMap<String, CoreContentMatcher>()
   private val contentGenerators = ConcurrentHashMap<String, CoreContentGenerator>()
+  private val fieldMatchers = ConcurrentHashMap<String, CoreFieldMatcher>()
+  private val fieldGenerators = ConcurrentHashMap<String, CoreFieldGenerator>()
 
   /**
    * Register a handler for a host-provided content matcher capability, keyed by the catalogue
@@ -77,5 +102,47 @@ object CoreCapabilityRegistry {
    */
   fun deregisterContentGenerator(key: String) {
     contentGenerators.remove(key)
+  }
+
+  /**
+   * Register a handler for a host-provided field matching rule, keyed by the catalogue entry key
+   * (e.g. `"v2-type"` for the `core/matcher/v2-type` entry). Replaces any handler previously
+   * registered under the same key.
+   */
+  fun registerFieldMatcher(key: String, handler: CoreFieldMatcher) {
+    fieldMatchers[key] = handler
+  }
+
+  /**
+   * Register a handler for a host-provided field generator, keyed by the catalogue entry key
+   * (e.g. `"v3-date"` for the `core/generator/v3-date` entry). Replaces any handler previously
+   * registered under the same key.
+   */
+  fun registerFieldGenerator(key: String, handler: CoreFieldGenerator) {
+    fieldGenerators[key] = handler
+  }
+
+  /**
+   * Look up a registered core field matcher handler by catalogue entry key.
+   */
+  fun fieldMatcher(key: String): CoreFieldMatcher? = fieldMatchers[key]
+
+  /**
+   * Look up a registered core field generator handler by catalogue entry key.
+   */
+  fun fieldGenerator(key: String): CoreFieldGenerator? = fieldGenerators[key]
+
+  /**
+   * Remove a registered core field matcher handler. Mainly useful for tests.
+   */
+  fun deregisterFieldMatcher(key: String) {
+    fieldMatchers.remove(key)
+  }
+
+  /**
+   * Remove a registered core field generator handler. Mainly useful for tests.
+   */
+  fun deregisterFieldGenerator(key: String) {
+    fieldGenerators.remove(key)
   }
 }

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/Field.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/Field.kt
@@ -1,0 +1,340 @@
+package io.pact.plugins.jvm.core
+
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.generators.Generator
+import au.com.dius.pact.core.model.matchingrules.MatchingRule
+import au.com.dius.pact.core.support.Json.toJson
+import au.com.dius.pact.core.support.json.JsonValue
+import com.google.protobuf.ByteString
+import com.google.protobuf.NullValue
+import com.google.protobuf.Struct
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.pact.plugin.v2.PluginV2
+import io.pact.plugins.jvm.core.Utils.jsonToValue
+import io.pact.plugins.jvm.core.Utils.toProtoStruct
+import io.pact.plugins.jvm.core.Utils.valueToJson
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Support for matching and generating individual field/element values.
+ *
+ * This is the field-level counterpart of [ContentMatcher]: where a content matcher owns a whole
+ * content type, a field matcher applies one matching rule to one value inside somebody else's
+ * content - a field in a JSON body, a header, a message metadata value. See proposal 006
+ * (Field-level matchers and generators) for the design.
+ *
+ * The proto types used here are the V2 interface ones. Field-level operations were introduced in V2
+ * and have no V1 equivalent, so a V1 plugin cannot provide them.
+ */
+
+/**
+ * A single value being matched or generated at the field/element level.
+ *
+ * Each type Pact's matching rules discriminate is its own case, rather than everything sharing one
+ * JSON-ish value type. A `google.protobuf.Value` carries a single number type (a double), which
+ * would make `integer` and `decimal` indistinguishable and `type` wrong between a whole number and
+ * a decimal - and those are exactly the rules whose job is to check a value's runtime type.
+ */
+sealed class FieldValue {
+  /** A null value */
+  object Null : FieldValue()
+
+  /** A boolean */
+  data class Bool(val value: Boolean) : FieldValue()
+
+  /** A string */
+  data class Text(val value: String) : FieldValue()
+
+  /** A whole number */
+  data class Integer(val value: Long) : FieldValue()
+
+  /** A number with a fractional part */
+  data class Decimal(val value: Double) : FieldValue()
+
+  /** Raw bytes, for a value that is not representable as text */
+  data class Binary(val value: ByteArray) : FieldValue() {
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (javaClass != other?.javaClass) return false
+      return value.contentEquals((other as Binary).value)
+    }
+
+    override fun hashCode(): Int = value.contentHashCode()
+  }
+
+  /** A map or list, for a rule applied to a collection rather than a scalar */
+  data class Structured(val value: JsonValue) : FieldValue()
+
+  /** Convert to the protobuf form sent to a plugin or core handler */
+  fun toProto(): PluginV2.FieldValue {
+    val builder = PluginV2.FieldValue.newBuilder()
+    when (this) {
+      is Null -> builder.nullValue = NullValue.NULL_VALUE
+      is Bool -> builder.booleanValue = value
+      is Text -> builder.stringValue = value
+      is Integer -> builder.integerValue = value
+      is Decimal -> builder.decimalValue = value
+      is Binary -> builder.binaryValue = ByteString.copyFrom(value)
+      is Structured -> builder.structuredValue = jsonToValue(value)
+    }
+    return builder.build()
+  }
+
+  companion object {
+    /**
+     * Convert from the protobuf form returned by a plugin or core handler. An unset value is
+     * treated as null, matching how an absent `oneof` reads everywhere else in the interface.
+     */
+    @JvmStatic
+    fun fromProto(value: PluginV2.FieldValue): FieldValue {
+      return when (value.valueCase) {
+        PluginV2.FieldValue.ValueCase.BOOLEANVALUE -> Bool(value.booleanValue)
+        PluginV2.FieldValue.ValueCase.STRINGVALUE -> Text(value.stringValue)
+        PluginV2.FieldValue.ValueCase.INTEGERVALUE -> Integer(value.integerValue)
+        PluginV2.FieldValue.ValueCase.DECIMALVALUE -> Decimal(value.decimalValue)
+        PluginV2.FieldValue.ValueCase.BINARYVALUE -> Binary(value.binaryValue.toByteArray())
+        PluginV2.FieldValue.ValueCase.STRUCTUREDVALUE -> Structured(valueToJson(value.structuredValue))
+        else -> Null
+      }
+    }
+
+    /**
+     * Convert from a Pact JSON value, keeping whole numbers whole.
+     */
+    @JvmStatic
+    fun fromJson(value: JsonValue): FieldValue {
+      return when (value) {
+        is JsonValue.Null -> Null
+        is JsonValue.True -> Bool(true)
+        is JsonValue.False -> Bool(false)
+        is JsonValue.StringValue -> Text(value.asString()!!)
+        is JsonValue.Integer -> Integer(value.toBigInteger().toLong())
+        is JsonValue.Decimal -> Decimal(value.toBigDecimal().toDouble())
+        else -> Structured(value)
+      }
+    }
+  }
+}
+
+/**
+ * Where a value sits and what is known about it, shared by matching and generation.
+ */
+data class FieldContext @JvmOverloads constructor(
+  /** Path to the value, as a Pact matching rule expression (`$.card.number`) */
+  val path: String,
+  /**
+   * Part of the interaction the value came from: `body`, `header`, `metadata`, `query`, `path`,
+   * `status`. Only affects how a mismatch is reported; generation ignores it.
+   */
+  val category: String = "body",
+  /** Plugin configuration persisted into the Pact file for this interaction */
+  val pluginConfiguration: PluginConfiguration? = null,
+  /** Context data provided by the test framework */
+  val testContext: Map<String, JsonValue> = emptyMap()
+)
+
+/** Which side of the test a generator is running on */
+enum class FieldTestMode {
+  CONSUMER, PROVIDER, UNKNOWN;
+
+  fun toProto(): PluginV2.GenerateContentRequest.TestMode = when (this) {
+    CONSUMER -> PluginV2.GenerateContentRequest.TestMode.Consumer
+    PROVIDER -> PluginV2.GenerateContentRequest.TestMode.Provider
+    UNKNOWN -> PluginV2.GenerateContentRequest.TestMode.Unknown
+  }
+}
+
+/**
+ * Find the field-level matching rule with the given name. The name is resolved against the
+ * catalogue the same way any other capability key is - see [CatalogueManager.resolveCapability] - so
+ * `creditcard` finds a plugin's own rule and `type` finds the core `v2-type` rule. Throws if the
+ * name matches nothing, matches more than one rule, or names something that is not a matching rule.
+ */
+fun findFieldMatcher(name: String): FieldMatcher =
+  FieldMatcher(CatalogueManager.resolveCapabilityEntry(name, CatalogueEntryType.MATCHER))
+
+/**
+ * Find the field-level generator with the given name. See [findFieldMatcher].
+ */
+fun findFieldGenerator(name: String): FieldGenerator =
+  FieldGenerator(CatalogueManager.resolveCapabilityEntry(name, CatalogueEntryType.GENERATOR))
+
+/**
+ * Matching rule for a single field/element value, provided by a plugin or by a handler the host
+ * framework registered (see [CoreFieldMatcher]).
+ */
+data class FieldMatcher(val catalogueEntry: CatalogueEntry) {
+  /** If this is a matching rule provided by the core framework rather than a plugin */
+  val isCore: Boolean
+    get() = catalogueEntry.providerType == CatalogueEntryProviderType.CORE
+
+  /** Catalogue entry key for this matching rule */
+  val catalogueEntryKey: String
+    get() = if (isCore) "core/matcher/${catalogueEntry.key}"
+      else "plugin/${catalogueEntry.pluginName}/matcher/${catalogueEntry.key}"
+
+  /** Name of the plugin that provides this matching rule */
+  val pluginName: String
+    get() = catalogueEntry.pluginName
+
+  /**
+   * Apply this matching rule to a single value.
+   *
+   * The context carries where the value lives and which part of the interaction it came from; both
+   * are echoed back on any mismatch that does not place itself. An empty result means the value
+   * matched.
+   */
+  fun matchField(
+    rule: MatchingRule,
+    expected: FieldValue,
+    actual: FieldValue,
+    context: FieldContext
+  ): List<ContentMismatch> {
+    val request = PluginV2.MatchFieldRequest.newBuilder()
+      .setKey(catalogueEntry.key)
+      .setRule(toProtoMatchingRule(rule))
+      .setPath(context.path)
+      .setMismatchType(context.category)
+      .setExpected(expected.toProto())
+      .setActual(actual.toProto())
+      .setTestContext(toProtoStruct(context.testContext))
+      .also { builder ->
+        if (context.pluginConfiguration != null) {
+          builder.pluginConfiguration = toProtoPluginConfiguration(context.pluginConfiguration)
+        }
+      }
+      .build()
+
+    val response = try {
+      if (isCore) {
+        val handler = CoreCapabilityRegistry.fieldMatcher(catalogueEntry.key)
+          ?: throw PactCoreCapabilityNotFoundException(catalogueEntry.key)
+        handler.matchField(request)
+      } else {
+        val plugin = DefaultPluginManager.lookupPlugin(pluginName, null)
+          ?: throw PactPluginNotFoundException(pluginName, null)
+        logger.debug { "Sending MatchField request to plugin $pluginName" }
+        val chainId = CallChain.newCallChainId()
+        val deadlineMs = CallChain.defaultDeadlineMs()
+        plugin.withRpcClient { client -> client.matchFieldWithChain(request, chainId, deadlineMs) }
+      }
+    } catch (ex: Exception) {
+      logger.error(ex) { "Field-level match call failed" }
+      return listOf(mismatchFor(ex.message ?: ex.toString(), context))
+    }
+
+    return when {
+      response.error.isNotEmpty() -> listOf(mismatchFor(response.error, context))
+      else -> response.mismatchesList.map {
+        ContentMismatch(
+          expected = it.expected.toByteArray(),
+          actual = it.actual.toByteArray(),
+          mismatch = it.mismatch,
+          // A mismatch that does not place itself is reported against the value being matched
+          path = it.path.ifEmpty { context.path },
+          diff = it.diff.ifEmpty { null },
+          type = it.mismatchType.ifEmpty { context.category }
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Generator for a single field/element value. See [FieldMatcher].
+ */
+data class FieldGenerator(val catalogueEntry: CatalogueEntry) {
+  /** If this is a generator provided by the core framework rather than a plugin */
+  val isCore: Boolean
+    get() = catalogueEntry.providerType == CatalogueEntryProviderType.CORE
+
+  /** Catalogue entry key for this generator */
+  val catalogueEntryKey: String
+    get() = if (isCore) "core/generator/${catalogueEntry.key}"
+      else "plugin/${catalogueEntry.pluginName}/generator/${catalogueEntry.key}"
+
+  /** Name of the plugin that provides this generator */
+  val pluginName: String
+    get() = catalogueEntry.pluginName
+
+  /**
+   * Generate a single value, replacing the example value from the Pact interaction.
+   */
+  fun generateField(
+    generator: Generator,
+    example: FieldValue,
+    mode: FieldTestMode,
+    context: FieldContext
+  ): FieldValue {
+    val request = PluginV2.GenerateFieldRequest.newBuilder()
+      .setKey(catalogueEntry.key)
+      .setGenerator(toProtoGenerator(generator))
+      .setPath(context.path)
+      .setExampleValue(example.toProto())
+      .setTestContext(toProtoStruct(context.testContext))
+      .setTestMode(mode.toProto())
+      .also { builder ->
+        if (context.pluginConfiguration != null) {
+          builder.pluginConfiguration = toProtoPluginConfiguration(context.pluginConfiguration)
+        }
+      }
+      .build()
+
+    val response = if (isCore) {
+      val handler = CoreCapabilityRegistry.fieldGenerator(catalogueEntry.key)
+        ?: throw PactCoreCapabilityNotFoundException(catalogueEntry.key)
+      handler.generateField(request)
+    } else {
+      val plugin = DefaultPluginManager.lookupPlugin(pluginName, null)
+        ?: throw PactPluginNotFoundException(pluginName, null)
+      logger.debug { "Sending GenerateField request to plugin $pluginName" }
+      val chainId = CallChain.newCallChainId()
+      val deadlineMs = CallChain.defaultDeadlineMs()
+      plugin.withRpcClient { client -> client.generateFieldWithChain(request, chainId, deadlineMs) }
+    }
+
+    if (response.error.isNotEmpty()) {
+      throw PactFieldGenerationException(catalogueEntry.key, response.error)
+    }
+    if (!response.hasValue()) {
+      throw PactFieldGenerationException(catalogueEntry.key, "the generator returned no value")
+    }
+    return FieldValue.fromProto(response.value)
+  }
+}
+
+private fun mismatchFor(message: String, context: FieldContext) = ContentMismatch(
+  expected = null,
+  actual = null,
+  mismatch = message,
+  path = context.path,
+  type = context.category
+)
+
+private fun toProtoMatchingRule(rule: MatchingRule): PluginV2.MatchingRule {
+  val builder = PluginV2.MatchingRule.newBuilder()
+  return builder
+    .setType(rule.name)
+    .setValues(builder.valuesBuilder.putAllFields(rule.attributes.entries.associate {
+      it.key to jsonToValue(it.value)
+    }.toMutableMap()))
+    .build()
+}
+
+private fun toProtoGenerator(generator: Generator): PluginV2.Generator {
+  val values = Struct.newBuilder()
+  generator.toMap(PactSpecVersion.V4).forEach { (key, value) ->
+    values.putFields(key, jsonToValue(toJson(value)))
+  }
+  return PluginV2.Generator.newBuilder()
+    .setType(generator.type)
+    .setValues(values)
+    .build()
+}
+
+private fun toProtoPluginConfiguration(config: PluginConfiguration): PluginV2.PluginConfiguration =
+  PluginV2.PluginConfiguration.newBuilder()
+    .setInteractionConfiguration(toProtoStruct(config.interactionConfiguration))
+    .setPactConfiguration(toProtoStruct(config.pactConfiguration))
+    .build()

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/Library.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/Library.kt
@@ -15,6 +15,9 @@ class PactPluginValidationForInteractionException(val name: String, val error: S
 class PactPluginInteractionVerificationException(val name: String, val error: String) :
   RuntimeException("Plugin $name failed to run the verification for the interaction: $error")
 
+class PactFieldGenerationException(val key: String, val error: String) :
+  RuntimeException("Field generator '$key' failed: $error")
+
 class PactCoreCapabilityNotFoundException(val key: String) :
   RuntimeException("No core capability handler registered for '$key'")
 

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaConversions.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaConversions.kt
@@ -2,17 +2,23 @@ package io.pact.plugins.jvm.core
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.BytesValue
+import com.google.protobuf.NullValue
+import com.google.protobuf.Struct
 import io.pact.plugin.Plugin
+import io.pact.plugin.v2.PluginV2
+import io.pact.plugins.jvm.core.Utils.fromProtoValue
 import io.pact.plugins.jvm.core.Utils.mapToProtoStruct
 import io.pact.plugins.jvm.core.Utils.structToMap
+import io.pact.plugins.jvm.core.Utils.toProtoValue
 import java.nio.ByteBuffer
 
 /**
- * Shared Body/MatchingRules/PluginConfiguration/CompareContents <-> Lua conversions, used by both
- * [LuaPluginRpcClient] (the driver calling into a plugin's own `match_contents`/`generate_content`)
- * and [LuaPactPlugin]'s `host_compare_contents`/`host_generate_content` host functions (a plugin
- * calling back into a host-provided or another plugin's capability - see proposal 007). Both
- * directions use the same Lua table shapes, so the same conversions apply either way.
+ * Shared Body/MatchingRules/PluginConfiguration/CompareContents/field <-> Lua conversions, used by
+ * both [LuaPluginRpcClient] (the driver calling into a plugin's own `match_contents`/
+ * `generate_content`/`match_field`/`generate_field`) and [LuaPactPlugin]'s `host_*` host functions
+ * (a plugin calling back into a host-provided or another plugin's capability - see proposals 006
+ * and 007). Both directions use the same Lua table shapes, so the same conversions apply either
+ * way.
  */
 
 // ---- Body <-> Lua ----
@@ -250,10 +256,257 @@ internal fun luaToGenerateRequest(contents: Any?, generators: Any?, testMode: St
   val builder = Plugin.GenerateContentRequest.newBuilder()
   luaToBody(contents)?.let { builder.contents = it }
   builder.putAllGenerators(luaToGenerators(generators))
-  builder.testMode = when (testMode) {
-    "Consumer" -> Plugin.GenerateContentRequest.TestMode.Consumer
-    "Provider" -> Plugin.GenerateContentRequest.TestMode.Provider
-    else -> Plugin.GenerateContentRequest.TestMode.Unknown
+  builder.testMode = luaToTestMode(testMode)
+  return builder.build()
+}
+
+/** The test mode name a Lua script sees. */
+internal fun testModeToLua(testMode: Plugin.GenerateContentRequest.TestMode?): String = when (testMode) {
+  Plugin.GenerateContentRequest.TestMode.Consumer -> "Consumer"
+  Plugin.GenerateContentRequest.TestMode.Provider -> "Provider"
+  else -> "Unknown"
+}
+
+/** Reverse of [testModeToLua]. Anything unrecognised (including a missing value) is `Unknown`,
+ * rather than an error - the mode is context for the plugin, not a contract. */
+internal fun luaToTestMode(testMode: String?): Plugin.GenerateContentRequest.TestMode = when (testMode) {
+  "Consumer" -> Plugin.GenerateContentRequest.TestMode.Consumer
+  "Provider" -> Plugin.GenerateContentRequest.TestMode.Provider
+  else -> Plugin.GenerateContentRequest.TestMode.Unknown
+}
+
+// ---- MatchField / GenerateField <-> Lua ----
+//
+// The field-level messages exist only on the V2 interface (proposal 006), while the conversions
+// above are written against the V1 message types. `PluginConfiguration` and `ContentMismatch` are
+// identical between the two, so those conversions are reused through the small mappers below
+// rather than being duplicated.
+
+/**
+ * Converts a single field value to a plain Lua value, following the convention message metadata
+ * values already use (see `LuaPluginRpcClient.metadataToLua`): everything crosses as a plain value
+ * except binary data, which arrives as a `{ binary = <string> }` wrapper so a script can tell a
+ * string of text from a blob of bytes.
+ *
+ * A whole number crosses as a `Long`, which luajava pushes as a real Lua integer, so `math.type()`
+ * in the script reports `"integer"`. That distinction is what the `integer`, `decimal` and `type`
+ * rules are built on - see [FieldValue] and `LuaJavaEngine.readValue` for the other direction.
+ */
+internal fun fieldValueToLua(value: PluginV2.FieldValue?): Any? = when (value?.valueCase) {
+  null, PluginV2.FieldValue.ValueCase.NULLVALUE, PluginV2.FieldValue.ValueCase.VALUE_NOT_SET -> null
+  PluginV2.FieldValue.ValueCase.BOOLEANVALUE -> value.booleanValue
+  PluginV2.FieldValue.ValueCase.STRINGVALUE -> value.stringValue
+  PluginV2.FieldValue.ValueCase.INTEGERVALUE -> value.integerValue
+  PluginV2.FieldValue.ValueCase.DECIMALVALUE -> value.decimalValue
+  PluginV2.FieldValue.ValueCase.BINARYVALUE -> mapOf("binary" to ByteBuffer.wrap(value.binaryValue.toByteArray()))
+  PluginV2.FieldValue.ValueCase.STRUCTUREDVALUE -> fromProtoValue(value.structuredValue)
+}
+
+/** Reverse of [fieldValueToLua]. A map is a binary wrapper if it has a `binary` key, and a
+ * map or list otherwise - the same test `LuaPluginRpcClient.luaToMetadata` applies. */
+internal fun luaToFieldValue(value: Any?): PluginV2.FieldValue {
+  val builder = PluginV2.FieldValue.newBuilder()
+  when (value) {
+    null -> builder.nullValue = NullValue.NULL_VALUE
+    is Boolean -> builder.booleanValue = value
+    is String -> builder.stringValue = value
+    // Long is what a Lua integer arrives as; Int/Short/Byte for a value the host built directly
+    is Long, is Int, is Short, is Byte -> builder.integerValue = (value as Number).toLong()
+    is Number -> builder.decimalValue = value.toDouble()
+    is ByteBuffer -> builder.binaryValue = ByteString.copyFrom(luaContentToByteArray(value))
+    is Map<*, *> -> {
+      val binary = value["binary"]
+      if (binary != null) {
+        builder.binaryValue = ByteString.copyFrom(luaContentToByteArray(binary))
+      } else {
+        builder.structuredValue = toProtoValue(value)
+      }
+    }
+    else -> builder.structuredValue = toProtoValue(value)
   }
   return builder.build()
+}
+
+/**
+ * Converts a matching rule or a generator - each is a name plus optional configured values - into
+ * the `{ type = "...", values = { ... } }` map a script already sees for the rules and generators
+ * passed to `match_contents`/`generate_content`. Always a map, even with no values, so a script
+ * can read `rule.values` without checking `rule` first.
+ */
+private fun typedValuesToLua(type: String, values: Struct?): Map<String, Any?> =
+  mapOf("type" to type, "values" to values?.let { structToMap(it) })
+
+internal fun matchingRuleToLua(rule: PluginV2.MatchingRule?): Map<String, Any?> =
+  typedValuesToLua(rule?.type ?: "", if (rule != null && rule.hasValues()) rule.values else null)
+
+internal fun fieldGeneratorToLua(generator: PluginV2.Generator?): Map<String, Any?> =
+  typedValuesToLua(generator?.type ?: "", if (generator != null && generator.hasValues()) generator.values else null)
+
+private fun luaToMatchingRule(value: Any?): PluginV2.MatchingRule {
+  @Suppress("UNCHECKED_CAST")
+  val map = value as? Map<String, Any?>
+    ?: throw IllegalStateException("Expected a 'rule' table from Lua, got $value")
+  val builder = PluginV2.MatchingRule.newBuilder().setType(map["type"] as? String ?: "")
+  @Suppress("UNCHECKED_CAST")
+  (map["values"] as? Map<String, Any?>)?.let { builder.values = mapToProtoStruct(it) }
+  return builder.build()
+}
+
+private fun luaToFieldGenerator(value: Any?): PluginV2.Generator {
+  @Suppress("UNCHECKED_CAST")
+  val map = value as? Map<String, Any?>
+    ?: throw IllegalStateException("Expected a 'generator' table from Lua, got $value")
+  val builder = PluginV2.Generator.newBuilder().setType(map["type"] as? String ?: "")
+  @Suppress("UNCHECKED_CAST")
+  (map["values"] as? Map<String, Any?>)?.let { builder.values = mapToProtoStruct(it) }
+  return builder.build()
+}
+
+/** V2's `PluginConfiguration` carries the same two `Struct` fields as the V1 message
+ * [pluginConfigurationToLua] converts, so the field-level requests reuse that conversion. */
+internal fun v2PluginConfigurationToLua(config: PluginV2.PluginConfiguration?): Map<String, Any?>? {
+  if (config == null) return null
+  val builder = Plugin.PluginConfiguration.newBuilder()
+  if (config.hasInteractionConfiguration()) builder.interactionConfiguration = config.interactionConfiguration
+  if (config.hasPactConfiguration()) builder.pactConfiguration = config.pactConfiguration
+  return pluginConfigurationToLua(builder.build())
+}
+
+/** Reverse of [v2PluginConfigurationToLua]. */
+internal fun luaToV2PluginConfiguration(value: Any?): PluginV2.PluginConfiguration? {
+  val config = luaToPluginConfiguration(value) ?: return null
+  val builder = PluginV2.PluginConfiguration.newBuilder()
+  if (config.hasInteractionConfiguration()) builder.interactionConfiguration = config.interactionConfiguration
+  if (config.hasPactConfiguration()) builder.pactConfiguration = config.pactConfiguration
+  return builder.build()
+}
+
+/** See [v2PluginConfigurationToLua] - `ContentMismatch` is likewise identical between the two
+ * interfaces, so [luaValueToContentMismatches] is reused for the V2-only field messages. */
+private fun v1ContentMismatchToV2(mismatch: Plugin.ContentMismatch): PluginV2.ContentMismatch {
+  val builder = PluginV2.ContentMismatch.newBuilder()
+    .setMismatch(mismatch.mismatch)
+    .setPath(mismatch.path)
+    .setDiff(mismatch.diff)
+    .setMismatchType(mismatch.mismatchType)
+  if (mismatch.hasExpected()) builder.expected = mismatch.expected
+  if (mismatch.hasActual()) builder.actual = mismatch.actual
+  return builder.build()
+}
+
+/** Reverse of [v1ContentMismatchToV2]. */
+private fun v2ContentMismatchToV1(mismatch: PluginV2.ContentMismatch): Plugin.ContentMismatch {
+  val builder = Plugin.ContentMismatch.newBuilder()
+    .setMismatch(mismatch.mismatch)
+    .setPath(mismatch.path)
+    .setDiff(mismatch.diff)
+    .setMismatchType(mismatch.mismatchType)
+  if (mismatch.hasExpected()) builder.expected = mismatch.expected
+  if (mismatch.hasActual()) builder.actual = mismatch.actual
+  return builder.build()
+}
+
+/** Builds the request map a plugin's own `match_field(request)` function receives. */
+internal fun matchFieldRequestToLua(request: PluginV2.MatchFieldRequest): Map<String, Any?> = mapOf(
+  "key" to request.key,
+  "rule" to matchingRuleToLua(if (request.hasRule()) request.rule else null),
+  "path" to request.path,
+  "mismatch_type" to request.mismatchType,
+  "expected" to fieldValueToLua(if (request.hasExpected()) request.expected else null),
+  "actual" to fieldValueToLua(if (request.hasActual()) request.actual else null),
+  "plugin_configuration" to v2PluginConfigurationToLua(
+    if (request.hasPluginConfiguration()) request.pluginConfiguration else null
+  ),
+  "test_context" to if (request.hasTestContext()) structToMap(request.testContext) else null
+)
+
+/** Reverse of [matchFieldRequestToLua] - the map a script builds when calling
+ * `host_match_field(entry_key, request)` is the same shape its own `match_field` receives, so it
+ * can forward the request it was given after adjusting whatever it needs to. */
+internal fun luaToMatchFieldRequest(map: Map<String, Any?>): PluginV2.MatchFieldRequest {
+  val builder = PluginV2.MatchFieldRequest.newBuilder()
+    .setKey(map["key"] as? String ?: "")
+    .setRule(luaToMatchingRule(map["rule"]))
+    .setPath(map["path"] as? String ?: "")
+    .setMismatchType(map["mismatch_type"] as? String ?: "")
+    .setExpected(luaToFieldValue(map["expected"]))
+    .setActual(luaToFieldValue(map["actual"]))
+  luaToV2PluginConfiguration(map["plugin_configuration"])?.let { builder.pluginConfiguration = it }
+  @Suppress("UNCHECKED_CAST")
+  (map["test_context"] as? Map<String, Any?>)?.let { builder.testContext = mapToProtoStruct(it) }
+  return builder.build()
+}
+
+/**
+ * Parses the map a plugin's `match_field` function returns: `{ error = "..." }`, or
+ * `{ mismatches = { ... } }` where each entry is a mismatch table or a bare description string
+ * (the same leniency `match_contents` responses get - see [luaValueToContentMismatches]). An
+ * absent or empty list means the value matched.
+ */
+internal fun luaToMatchFieldResponse(result: Map<String, Any?>, path: String): PluginV2.MatchFieldResponse {
+  val error = result["error"] as? String
+  if (error != null) {
+    return PluginV2.MatchFieldResponse.newBuilder().setError(error).build()
+  }
+  return PluginV2.MatchFieldResponse.newBuilder()
+    .addAllMismatches(luaValueToContentMismatches(path, result["mismatches"]).map { v1ContentMismatchToV2(it) })
+    .build()
+}
+
+/** Reverse of [luaToMatchFieldResponse], so a script can return the result of a `host_match_field`
+ * call straight through as its own response. */
+internal fun matchFieldResponseToLua(response: PluginV2.MatchFieldResponse): Map<String, Any?> {
+  if (response.error.isNotEmpty()) {
+    return mapOf("error" to response.error)
+  }
+  return mapOf("mismatches" to response.mismatchesList.map { contentMismatchToLua(v2ContentMismatchToV1(it)) })
+}
+
+/** Builds the request map a plugin's own `generate_field(request)` function receives. */
+internal fun generateFieldRequestToLua(request: PluginV2.GenerateFieldRequest): Map<String, Any?> = mapOf(
+  "key" to request.key,
+  "generator" to fieldGeneratorToLua(if (request.hasGenerator()) request.generator else null),
+  "path" to request.path,
+  "example_value" to fieldValueToLua(if (request.hasExampleValue()) request.exampleValue else null),
+  "plugin_configuration" to v2PluginConfigurationToLua(
+    if (request.hasPluginConfiguration()) request.pluginConfiguration else null
+  ),
+  "test_context" to if (request.hasTestContext()) structToMap(request.testContext) else null,
+  "test_mode" to testModeToLua(
+    Plugin.GenerateContentRequest.TestMode.forNumber(request.testModeValue)
+  )
+)
+
+/** Reverse of [generateFieldRequestToLua] - the map a script passes to
+ * `host_generate_field(entry_key, request)`. */
+internal fun luaToGenerateFieldRequest(map: Map<String, Any?>): PluginV2.GenerateFieldRequest {
+  val builder = PluginV2.GenerateFieldRequest.newBuilder()
+    .setKey(map["key"] as? String ?: "")
+    .setGenerator(luaToFieldGenerator(map["generator"]))
+    .setPath(map["path"] as? String ?: "")
+    .setExampleValue(luaToFieldValue(map["example_value"]))
+    .setTestModeValue(luaToTestMode(map["test_mode"] as? String).number)
+  luaToV2PluginConfiguration(map["plugin_configuration"])?.let { builder.pluginConfiguration = it }
+  @Suppress("UNCHECKED_CAST")
+  (map["test_context"] as? Map<String, Any?>)?.let { builder.testContext = mapToProtoStruct(it) }
+  return builder.build()
+}
+
+/** Parses the map a plugin's `generate_field` function returns: `{ value = ... }` or
+ * `{ error = "..." }`. */
+internal fun luaToGenerateFieldResponse(result: Map<String, Any?>): PluginV2.GenerateFieldResponse {
+  val error = result["error"] as? String
+  if (error != null) {
+    return PluginV2.GenerateFieldResponse.newBuilder().setError(error).build()
+  }
+  return PluginV2.GenerateFieldResponse.newBuilder().setValue(luaToFieldValue(result["value"])).build()
+}
+
+/** Reverse of [luaToGenerateFieldResponse], so a script can return the result of a
+ * `host_generate_field` call straight through as its own response. */
+internal fun generateFieldResponseToLua(response: PluginV2.GenerateFieldResponse): Map<String, Any?> {
+  if (response.error.isNotEmpty()) {
+    return mapOf("error" to response.error)
+  }
+  return mapOf("value" to fieldValueToLua(if (response.hasValue()) response.value else null))
 }

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPactPlugin.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPactPlugin.kt
@@ -2,6 +2,7 @@ package io.pact.plugins.jvm.core
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.pact.plugin.Plugin
+import io.pact.plugin.v2.PluginV2
 import io.pact.plugins.jvm.core.lua.LuaEngine
 import io.pact.plugins.jvm.core.lua.LuaJavaEngine
 import org.bouncycastle.asn1.pkcs.RSAPublicKey as Pkcs1RsaPublicKey
@@ -37,6 +38,12 @@ private val logger = KotlinLogging.logger {}
  * - `generate_content(contents, generators, test_mode)` (optional; passthrough default)
  * - `update_catalogue(catalogue)` (optional; no-op default)
  *
+ * A plugin that contributes a single matching rule or generator applied to one *value* inside
+ * somebody else's content - rather than owning a whole content type - registers a `MATCHER` or
+ * `GENERATOR` catalogue entry and defines these instead (proposal 006):
+ * - `match_field(request) -> table` - `{ mismatches = { ... } }` or `{ error = "..." }`
+ * - `generate_field(request) -> table` - `{ value = ... }` or `{ error = "..." }`
+ *
  * A Lua plugin that registers a `TRANSPORT` catalogue entry (instead of, or as well as, a
  * `CONTENT_MATCHER`/`CONTENT_GENERATOR` one) must also define these functions. The plugin
  * itself is responsible for whatever the transport actually requires (opening sockets, making
@@ -56,6 +63,9 @@ private val logger = KotlinLogging.logger {}
  *   `match_contents` itself, so a result can be returned straight through.
  * - `host_generate_content(entry_key, contents, generators, test_mode) -> body` - same arguments
  *   and return shape as `generate_content` itself.
+ * - `host_match_field(entry_key, request) -> table` - the field-level equivalent, so a content
+ *   matcher can apply a standard Pact rule to one value inside the content it owns.
+ * - `host_generate_field(entry_key, request) -> table`
  */
 class LuaPactPlugin(
   override val manifest: PactPluginManifest,
@@ -179,6 +189,20 @@ class LuaPactPlugin(
       val request = luaToGenerateRequest(args.getOrNull(1), args.getOrNull(2), args.getOrNull(3) as? String)
       bodyToLua(callHostGenerateContent(args[0] as String, request).let { if (it.hasContents()) it.contents else null })
     }
+
+    // The field-level equivalents (proposal 006, "Lua transport"): let a plugin that owns a
+    // content type delegate one value inside it to a standard Pact rule - or to another plugin's
+    // rule - instead of reimplementing it. Cycle-free for the same reason as the two above.
+    engine.registerFunction("host_match_field") { args ->
+      @Suppress("UNCHECKED_CAST")
+      val request = luaToMatchFieldRequest(args[1] as Map<String, Any?>)
+      matchFieldResponseToLua(callHostMatchField(args[0] as String, request))
+    }
+    engine.registerFunction("host_generate_field") { args ->
+      @Suppress("UNCHECKED_CAST")
+      val request = luaToGenerateFieldRequest(args[1] as Map<String, Any?>)
+      generateFieldResponseToLua(callHostGenerateField(args[0] as String, request))
+    }
   }
 
   /**
@@ -227,6 +251,54 @@ class LuaPactPlugin(
         val chainId = CallChain.newCallChainId()
         val deadlineMs = CallChain.defaultDeadlineMs()
         plugin.withRpcClient { client -> client.generateContentWithChain(request, chainId, deadlineMs) }
+      }
+    }
+  }
+
+  /**
+   * Resolve [entryKey] to a field-level matching rule and dispatch to it. See
+   * [callHostCompareContents]; backs the `host_match_field` Lua host function.
+   */
+  private fun callHostMatchField(
+    entryKey: String,
+    request: PluginV2.MatchFieldRequest
+  ): PluginV2.MatchFieldResponse {
+    return when (val resolved = CatalogueManager.resolveCapability(entryKey, CatalogueEntryType.MATCHER)) {
+      is ResolvedCapability.Core -> {
+        val handler = CoreCapabilityRegistry.fieldMatcher(resolved.key)
+          ?: throw PactCoreCapabilityNotFoundException(resolved.key)
+        handler.matchField(request)
+      }
+      is ResolvedCapability.Plugin -> {
+        val plugin = DefaultPluginManager.lookupPlugin(resolved.pluginName, null)
+          ?: throw PactPluginNotFoundException(resolved.pluginName, null)
+        val chainId = CallChain.newCallChainId()
+        val deadlineMs = CallChain.defaultDeadlineMs()
+        plugin.withRpcClient { client -> client.matchFieldWithChain(request, chainId, deadlineMs) }
+      }
+    }
+  }
+
+  /**
+   * Resolve [entryKey] to a field-level generator and dispatch to it. See
+   * [callHostCompareContents]; backs the `host_generate_field` Lua host function.
+   */
+  private fun callHostGenerateField(
+    entryKey: String,
+    request: PluginV2.GenerateFieldRequest
+  ): PluginV2.GenerateFieldResponse {
+    return when (val resolved = CatalogueManager.resolveCapability(entryKey, CatalogueEntryType.GENERATOR)) {
+      is ResolvedCapability.Core -> {
+        val handler = CoreCapabilityRegistry.fieldGenerator(resolved.key)
+          ?: throw PactCoreCapabilityNotFoundException(resolved.key)
+        handler.generateField(request)
+      }
+      is ResolvedCapability.Plugin -> {
+        val plugin = DefaultPluginManager.lookupPlugin(resolved.pluginName, null)
+          ?: throw PactPluginNotFoundException(resolved.pluginName, null)
+        val chainId = CallChain.newCallChainId()
+        val deadlineMs = CallChain.defaultDeadlineMs()
+        plugin.withRpcClient { client -> client.generateFieldWithChain(request, chainId, deadlineMs) }
       }
     }
   }

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPluginRpcClient.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPluginRpcClient.kt
@@ -88,14 +88,31 @@ class LuaPluginRpcClient(private val engine: LuaEngine) : PactPluginRpcClient {
     }
     val contents = bodyToLua(if (request.hasContents()) request.contents else null)
     val generators = request.generatorsMap.mapValues { (_, g) -> generatorToLua(g) }
-    val testMode = when (request.testMode) {
-      Plugin.GenerateContentRequest.TestMode.Consumer -> "Consumer"
-      Plugin.GenerateContentRequest.TestMode.Provider -> "Provider"
-      else -> "Unknown"
-    }
-    val result = engine.callFunction("generate_content", listOf(contents, generators, testMode))
+    val result = engine.callFunction(
+      "generate_content",
+      listOf(contents, generators, testModeToLua(request.testMode))
+    )
     luaToBody(result)?.let { builder.contents = it }
     return builder.build()
+  }
+
+  /**
+   * `match_field` and `generate_field` are optional globals - a plugin only defines them if it
+   * registered a `MATCHER` or `GENERATOR` catalogue entry (proposal 006). Reaching here without
+   * one is a real error (the driver resolved an entry the plugin registered), so [LuaEngine] is
+   * left to report the missing function rather than the call being silently treated as a match.
+   */
+  override fun matchField(request: PluginV2.MatchFieldRequest): PluginV2.MatchFieldResponse {
+    val result = engine.callFunction("match_field", listOf(matchFieldRequestToLua(request)))
+    @Suppress("UNCHECKED_CAST")
+    return luaToMatchFieldResponse(result as? Map<String, Any?> ?: emptyMap(), request.path)
+  }
+
+  /** See [matchField]. */
+  override fun generateField(request: PluginV2.GenerateFieldRequest): PluginV2.GenerateFieldResponse {
+    val result = engine.callFunction("generate_field", listOf(generateFieldRequestToLua(request)))
+    @Suppress("UNCHECKED_CAST")
+    return luaToGenerateFieldResponse(result as? Map<String, Any?> ?: emptyMap())
   }
 
   override fun startMockServer(request: Plugin.StartMockServerRequest): Plugin.StartMockServerResponse {

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPluginRpcClient.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPluginRpcClient.kt
@@ -24,11 +24,16 @@ class LuaPluginRpcClient(private val engine: LuaEngine) : PactPluginRpcClient {
     val entries = items.map { item ->
       @Suppress("UNCHECKED_CAST")
       val map = item as Map<String, Any?>
-      val entryType = Plugin.CatalogueEntry.EntryType.valueOf(map["entryType"] as String)
+      val entryTypeName = map["entryType"] as String
+      // Not Plugin.CatalogueEntry.EntryType.valueOf: that is the V1 enum, which throws on an entry
+      // type only the V2 interface has (GENERATOR), even though the message field itself carries
+      // the value fine.
+      val entryType = CatalogueEntryType.fromEntryName(entryTypeName)
+        ?: throw IllegalArgumentException("Unknown catalogue entry type '$entryTypeName'")
       @Suppress("UNCHECKED_CAST")
       val values = (map["values"] as? Map<String, Any?>)?.mapValues { it.value.toString() } ?: emptyMap()
       Plugin.CatalogueEntry.newBuilder()
-        .setType(entryType)
+        .setTypeValue(entryType.toEntryValue())
         .setKey(map["key"] as String)
         .putAllValues(values)
         .build()
@@ -38,8 +43,15 @@ class LuaPluginRpcClient(private val engine: LuaEngine) : PactPluginRpcClient {
 
   override fun updateCatalogue(request: Plugin.Catalogue) {
     if (!engine.hasFunction("update_catalogue")) return
-    val entries = request.catalogueList.map { entry ->
-      mapOf("entryType" to entry.type.name, "key" to entry.key, "values" to entry.valuesMap)
+    // An entry type this driver doesn't understand is skipped rather than passed to the script as
+    // some other type it isn't - see CatalogueManager.registerPluginEntries.
+    val entries = request.catalogueList.mapNotNull { entry ->
+      val entryType = CatalogueEntryType.fromEntryValue(entry.typeValue)
+      if (entryType == null) {
+        null
+      } else {
+        mapOf("entryType" to entryType.toEntryName(), "key" to entry.key, "values" to entry.valuesMap)
+      }
     }
     engine.callFunction("update_catalogue", listOf(entries))
   }

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginHostServer.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginHostServer.kt
@@ -166,6 +166,68 @@ internal class PluginHostGrpcService : PluginHostGrpc.PluginHostImplBase() {
       responseObserver.onError(statusFor(ex).asRuntimeException())
     }
   }
+
+  override fun matchField(
+    request: PluginV2.HostMatchFieldRequest,
+    responseObserver: StreamObserver<PluginV2.MatchFieldResponse>
+  ) {
+    val (chainId, deadlineMs) = callChainContext()
+    try {
+      if (CallChain.isExpired(deadlineMs)) {
+        throw PactCallChainDeadlineExceededException(chainId)
+      }
+      CallChain.pushCall(chainId, request.entryKey).use {
+        // No conversion here, unlike the content-level callbacks: the field-level messages exist
+        // only on the V2 interface, so they are already the shape the handler expects
+        val response = when (val resolved = CatalogueManager.resolveCapability(request.entryKey, CatalogueEntryType.MATCHER)) {
+          is ResolvedCapability.Core -> {
+            val handler = CoreCapabilityRegistry.fieldMatcher(resolved.key)
+              ?: throw PactCoreCapabilityNotFoundException(resolved.key)
+            handler.matchField(request.request)
+          }
+          is ResolvedCapability.Plugin -> {
+            val plugin = DefaultPluginManager.lookupPlugin(resolved.pluginName, null)
+              ?: throw PactPluginNotFoundException(resolved.pluginName, null)
+            plugin.withRpcClient { client -> client.matchFieldWithChain(request.request, chainId, deadlineMs) }
+          }
+        }
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+      }
+    } catch (ex: Exception) {
+      responseObserver.onError(statusFor(ex).asRuntimeException())
+    }
+  }
+
+  override fun generateField(
+    request: PluginV2.HostGenerateFieldRequest,
+    responseObserver: StreamObserver<PluginV2.GenerateFieldResponse>
+  ) {
+    val (chainId, deadlineMs) = callChainContext()
+    try {
+      if (CallChain.isExpired(deadlineMs)) {
+        throw PactCallChainDeadlineExceededException(chainId)
+      }
+      CallChain.pushCall(chainId, request.entryKey).use {
+        val response = when (val resolved = CatalogueManager.resolveCapability(request.entryKey, CatalogueEntryType.GENERATOR)) {
+          is ResolvedCapability.Core -> {
+            val handler = CoreCapabilityRegistry.fieldGenerator(resolved.key)
+              ?: throw PactCoreCapabilityNotFoundException(resolved.key)
+            handler.generateField(request.request)
+          }
+          is ResolvedCapability.Plugin -> {
+            val plugin = DefaultPluginManager.lookupPlugin(resolved.pluginName, null)
+              ?: throw PactPluginNotFoundException(resolved.pluginName, null)
+            plugin.withRpcClient { client -> client.generateFieldWithChain(request.request, chainId, deadlineMs) }
+          }
+        }
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+      }
+    } catch (ex: Exception) {
+      responseObserver.onError(statusFor(ex).asRuntimeException())
+    }
+  }
 }
 
 /** Map a callback dispatch failure to the appropriate gRPC status code. */

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginManager.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginManager.kt
@@ -1096,7 +1096,7 @@ object DefaultPluginManager: PluginManager {
     CatalogueManager.entries().forEach { (_, entry) ->
       requestBuilder.addCatalogue(Plugin.CatalogueEntry.newBuilder()
         .setKey(entry.key)
-        .setType(entry.type.toEntry())
+        .setTypeValue(entry.type.toEntryValue())
         .putAllValues(entry.values)
         .build())
     }

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginRpcClient.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/PluginRpcClient.kt
@@ -94,6 +94,44 @@ interface PactPluginRpcClient {
   ): Plugin.VerificationPreparationResponse
   fun verifyInteraction(request: Plugin.VerifyInteractionRequest): Plugin.VerifyInteractionResponse
 
+  /**
+   * Apply a plugin-provided matching rule to a single value (see proposal 006). Field-level
+   * operations exist only on the V2 interface, so the default reports that this plugin cannot
+   * provide them - the same shape as the other V2-only operations here.
+   */
+  fun matchField(request: PluginV2.MatchFieldRequest): PluginV2.MatchFieldResponse =
+    throw UnsupportedOperationException(
+      "Field-level matching rules require the V2 plugin interface, and this plugin uses V1"
+    )
+
+  /**
+   * Apply a plugin-provided matching rule to a single value, propagating call-chain cycle detection
+   * and deadline metadata. See [compareContentsWithChain] for the default/override split.
+   */
+  fun matchFieldWithChain(
+    request: PluginV2.MatchFieldRequest,
+    chainId: String,
+    deadlineMs: Long
+  ): PluginV2.MatchFieldResponse = matchField(request)
+
+  /**
+   * Apply a plugin-provided generator to a single value (see proposal 006). See [matchField].
+   */
+  fun generateField(request: PluginV2.GenerateFieldRequest): PluginV2.GenerateFieldResponse =
+    throw UnsupportedOperationException(
+      "Field-level generators require the V2 plugin interface, and this plugin uses V1"
+    )
+
+  /**
+   * Apply a plugin-provided generator to a single value, propagating call-chain cycle detection and
+   * deadline metadata. See [matchFieldWithChain].
+   */
+  fun generateFieldWithChain(
+    request: PluginV2.GenerateFieldRequest,
+    chainId: String,
+    deadlineMs: Long
+  ): PluginV2.GenerateFieldResponse = generateField(request)
+
   fun startMockServerV2(request: PluginV2.StartMockServerRequest): Plugin.StartMockServerResponse =
     throw UnsupportedOperationException("V2 interface not supported by this plugin")
   fun prepareInteractionForVerificationV2(
@@ -292,4 +330,22 @@ class PactPluginV2RpcClient(
     request: PluginV2.VerifyInteractionRequest
   ): Plugin.VerifyInteractionResponse =
     convertMessage(stub.verifyInteraction(request), Plugin.VerifyInteractionResponse.parser())
+
+  override fun matchField(request: PluginV2.MatchFieldRequest): PluginV2.MatchFieldResponse =
+    stub.matchField(request)
+
+  override fun matchFieldWithChain(
+    request: PluginV2.MatchFieldRequest,
+    chainId: String,
+    deadlineMs: Long
+  ): PluginV2.MatchFieldResponse = stub.withChainContext(chainId, deadlineMs).matchField(request)
+
+  override fun generateField(request: PluginV2.GenerateFieldRequest): PluginV2.GenerateFieldResponse =
+    stub.generateField(request)
+
+  override fun generateFieldWithChain(
+    request: PluginV2.GenerateFieldRequest,
+    chainId: String,
+    deadlineMs: Long
+  ): PluginV2.GenerateFieldResponse = stub.withChainContext(chainId, deadlineMs).generateField(request)
 }

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/lua/LuaJavaEngine.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/lua/LuaJavaEngine.kt
@@ -2,6 +2,7 @@ package io.pact.plugins.jvm.core.lua
 
 import party.iroiro.luajava.JFunction
 import party.iroiro.luajava.Lua
+import party.iroiro.luajava.Lua.LuaType
 import party.iroiro.luajava.LuaException
 import party.iroiro.luajava.lua54.Lua54
 import java.io.File
@@ -27,7 +28,9 @@ class LuaJavaEngine : LuaEngine {
   override fun registerFunction(name: String, function: (args: List<Any?>) -> Any?) {
     lua.push(JFunction { l ->
       val argCount = l.getTop()
-      val args = (1..argCount).map { i -> normalize(l.toObject(i)) }
+      // Read through the Lua instance the call arrived on, not this engine's own: for a call made
+      // from a coroutine they are different stacks.
+      val args = (1..argCount).map { i -> readValue(l, i) }
       when (val result = function(args)) {
         null -> 0
         else -> {
@@ -75,7 +78,7 @@ class LuaJavaEngine : LuaEngine {
       }
     }
     lua.pCall(args.size, 1)
-    val result = normalize(lua.toObject(-1))
+    val result = readValue(lua, -1)
     lua.pop(1)
     return result
   }
@@ -83,24 +86,70 @@ class LuaJavaEngine : LuaEngine {
   override fun close() {
     lua.close()
   }
+}
 
-  /**
-   * `toObject` converts a Lua array-like table (keys `1.0, 2.0, ..., n.0`) into a
-   * `Map<Double, Any?>` rather than a `List`, since Lua does not distinguish arrays from
-   * maps. Recursively normalises such sequential maps into `List`s, and stringifies other
-   * map keys, so callers can treat results as ordinary JSON-shaped Kotlin values.
-   */
-  private fun normalize(value: Any?): Any? = when (value) {
-    is Map<*, *> -> {
-      val size = value.size
-      val isSequence = size > 0 && (1..size).all { i -> value.containsKey(i.toDouble()) }
-      if (isSequence) {
-        (1..size).map { i -> normalize(value[i.toDouble()]) }
-      } else {
-        value.entries.associate { (k, v) -> k.toString() to normalize(v) }
-      }
+/**
+ * Converts the value at [index] on [lua]'s stack into a plain JVM value.
+ *
+ * This is `toObject`'s job, but `toObject` returns every Lua number as a `Double`, losing Lua
+ * 5.4's integer/float distinction. Callers depend on that distinction: a whole number has to stay
+ * whole for the `integer`, `decimal` and `type` matching rules to mean anything, which is why the
+ * field-level `FieldValue` has an arm per scalar type in the first place (proposal 006, section 5).
+ * The reverse direction needs no such handling - luajava already pushes a `Long` as a Lua integer,
+ * so the distinction survives the trip *into* a script.
+ *
+ * Reading the stack directly rather than post-processing `toObject`'s result also fixes it for a
+ * number nested anywhere inside a table, not just a scalar return value.
+ */
+private fun readValue(lua: Lua, index: Int): Any? = when (lua.type(index)) {
+  LuaType.NIL, LuaType.NONE, null -> null
+  LuaType.BOOLEAN -> lua.toBoolean(index)
+  LuaType.NUMBER -> if (lua.isInteger(index)) lua.toInteger(index) else lua.toNumber(index)
+  LuaType.STRING -> lua.toString(index)
+  LuaType.TABLE -> readTable(lua, index)
+  // Userdata, functions, threads: not values a plugin passes across this boundary, but leave them
+  // to luajava rather than dropping them
+  else -> lua.toObject(index)
+}
+
+/** The key the driver wraps binary (non-text) values under when they cross into Lua. */
+private const val BINARY_KEY = "binary"
+
+/**
+ * Reads the table at [index] by walking it with `next`.
+ *
+ * Lua does not distinguish arrays from maps, so a table whose keys are exactly `1..n` becomes a
+ * `List` and anything else a `Map` with stringified keys - what callers already expect from the
+ * `toObject`-plus-normalise this replaced.
+ */
+private fun readTable(lua: Lua, index: Int): Any? {
+  // `next` needs an absolute index: it pushes and pops around the table, moving a relative one
+  val tableIndex = if (index < 0) lua.getTop() + 1 + index else index
+  val entries = linkedMapOf<Any?, Any?>()
+
+  lua.pushNil()
+  while (lua.next(tableIndex) != 0) {
+    // The key is now at -2 and the value at -1. The key is read through readValue rather than
+    // `toString`, which would coerce a number key to a string *in place* on the stack and break
+    // the `next` that follows.
+    val key = readValue(lua, -2)
+    entries[key] = if (key == BINARY_KEY && lua.type(-1) == LuaType.STRING) {
+      // The driver's convention for a value that is bytes rather than text - a binary message
+      // metadata value, or a binary FieldValue - is a `{ binary = "..." }` wrapper (see
+      // LuaConversions.fieldValueToLua). Read those bytes as bytes: a Lua string is an arbitrary
+      // byte array, and `toString` would truncate it at the first NUL.
+      lua.toBuffer(-1)
+    } else {
+      readValue(lua, -1)
     }
-    is List<*> -> value.map { normalize(it) }
-    else -> value
+    lua.pop(1)
+  }
+
+  val size = entries.size
+  val isSequence = size > 0 && (1..size).all { entries.containsKey(it.toLong()) }
+  return if (isSequence) {
+    (1..size).map { entries[it.toLong()] }
+  } else {
+    entries.entries.associate { (key, value) -> key.toString() to value }
   }
 }

--- a/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/CatalogueManagerSpec.groovy
+++ b/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/CatalogueManagerSpec.groovy
@@ -44,6 +44,75 @@ class CatalogueManagerSpec extends Specification {
     CatalogueManager.INSTANCE.removePluginEntries('CatalogueManagerSpec')
   }
 
+  def 'entry type protobuf values and names round trip'() {
+    expect:
+    CatalogueEntryType.fromEntryValue(type.toEntryValue()) == type
+    CatalogueEntryType.fromEntryName(type.toEntryName()) == type
+    // The toString form round-trips too - it is what catalogue keys are built from
+    CatalogueEntryType.fromString(type.toString()) == type
+
+    where:
+    type << CatalogueEntryType.values()
+  }
+
+  def 'entry type conversions return null for values this driver does not understand'() {
+    expect:
+    CatalogueEntryType.fromEntryValue(99) == null
+    CatalogueEntryType.fromEntryName('NOT_AN_ENTRY_TYPE') == null
+  }
+
+  def 'entry types shared with V1 keep their V1 wire values'() {
+    // The wire values come from the V2 enum, but the driver publishes one catalogue to every
+    // running plugin, V1 ones included - so the values V1 knows about must not shift.
+    expect:
+    CatalogueEntryType.CONTENT_MATCHER.toEntryValue() == Plugin.CatalogueEntry.EntryType.CONTENT_MATCHER.number
+    CatalogueEntryType.CONTENT_GENERATOR.toEntryValue() == Plugin.CatalogueEntry.EntryType.CONTENT_GENERATOR.number
+    CatalogueEntryType.TRANSPORT.toEntryValue() == Plugin.CatalogueEntry.EntryType.TRANSPORT.number
+    CatalogueEntryType.MATCHER.toEntryValue() == Plugin.CatalogueEntry.EntryType.MATCHER.number
+    CatalogueEntryType.INTERACTION.toEntryValue() == Plugin.CatalogueEntry.EntryType.INTERACTION.number
+  }
+
+  def 'registers a generator entry under its own entry type'() {
+    given:
+    // GENERATOR only exists on the V2 enum. This is exactly the case where the generated V1 `type`
+    // accessor would report UNRECOGNIZED, which fromEntry maps to CONTENT_MATCHER.
+    def generatorEntry = Plugin.CatalogueEntry.newBuilder()
+      .setTypeValue(CatalogueEntryType.GENERATOR.toEntryValue())
+      .setKey('creditcard-test')
+      .putValues('config-key', 'brand')
+      .build()
+
+    when:
+    CatalogueManager.INSTANCE.registerPluginEntries('CatalogueManagerSpec-generator', [generatorEntry])
+    def generator = CatalogueManager.INSTANCE.lookupEntry('generator/creditcard-test')
+    def asContentMatcher = CatalogueManager.INSTANCE.lookupEntry('content-matcher/creditcard-test')
+
+    then:
+    generator == new CatalogueEntry(CatalogueEntryType.GENERATOR, CatalogueEntryProviderType.PLUGIN,
+      'CatalogueManagerSpec-generator', 'creditcard-test', ['config-key': 'brand'])
+    asContentMatcher == null
+
+    cleanup:
+    CatalogueManager.INSTANCE.removePluginEntries('CatalogueManagerSpec-generator')
+  }
+
+  def 'ignores a catalogue entry whose type this driver does not understand'() {
+    given:
+    def entry = Plugin.CatalogueEntry.newBuilder()
+      .setTypeValue(99)
+      .setKey('unknown-entry-type-test')
+      .build()
+
+    when:
+    CatalogueManager.INSTANCE.registerPluginEntries('CatalogueManagerSpec-unknown', [entry])
+
+    then:
+    CatalogueManager.INSTANCE.entries().find { it.value.key == 'unknown-entry-type-test' } == null
+
+    cleanup:
+    CatalogueManager.INSTANCE.removePluginEntries('CatalogueManagerSpec-unknown')
+  }
+
   def 'resolveCapability resolves an unambiguous core entry'() {
     given:
     def key = 'resolveCapability resolves an unambiguous core entry'

--- a/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/CatalogueManagerSpec.groovy
+++ b/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/CatalogueManagerSpec.groovy
@@ -192,6 +192,59 @@ class CatalogueManagerSpec extends Specification {
     !CatalogueManagerKt.namesCatalogueKey('core/content-matcher/xml', 'ml')
   }
 
+  def 'the versioned fallback only applies to matcher and generator entries'() {
+    given:
+    // Content matchers, content generators and transports are registered under plain names, so a
+    // leading "v<n>-" there is part of the name, not a version to be stripped.
+    def key = 'versioned fallback entry types'
+    CatalogueManager.INSTANCE.registerCoreEntries([
+      new CatalogueEntry(CatalogueEntryType.CONTENT_MATCHER, CatalogueEntryProviderType.CORE, 'core', "v2-$key"),
+      new CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, 'core', "v2-matcher-$key")
+    ])
+
+    when:
+    CatalogueManager.INSTANCE.resolveCapability(key, CatalogueEntryType.CONTENT_MATCHER)
+
+    then:
+    // The content matcher is only reachable by its actual name
+    thrown(PactCatalogueEntryNotFoundException)
+    CatalogueManager.INSTANCE.lookupEntry(key) == null
+    CatalogueManager.INSTANCE.resolveCapability("v2-$key", CatalogueEntryType.CONTENT_MATCHER) != null
+    // ... while the matcher entry still gets the fallback
+    resolvedCoreKey("matcher-$key") == "v2-matcher-$key"
+  }
+
+  def 'lookupEntry matches by name, not by substring'() {
+    given:
+    def key = 'lookupEntry-matches-by-name'
+    def entry = Plugin.CatalogueEntry.newBuilder()
+      .setTypeValue(CatalogueEntryType.CONTENT_MATCHER.toEntryValue())
+      .setKey(key)
+      .build()
+    CatalogueManager.INSTANCE.registerPluginEntries('CatalogueManagerSpec-lookup', [entry])
+
+    expect:
+    CatalogueManager.INSTANCE.lookupEntry(key)?.type == CatalogueEntryType.CONTENT_MATCHER
+    CatalogueManager.INSTANCE.lookupEntry("content-matcher/$key")?.type == CatalogueEntryType.CONTENT_MATCHER
+    CatalogueManager.INSTANCE
+      .lookupEntry("plugin/CatalogueManagerSpec-lookup/content-matcher/$key")?.type == CatalogueEntryType.CONTENT_MATCHER
+    // A trailing substring of a component names nothing
+    CatalogueManager.INSTANCE.lookupEntry('matches-by-name') == null
+
+    cleanup:
+    CatalogueManager.INSTANCE.removePluginEntries('CatalogueManagerSpec-lookup')
+  }
+
+  def 'lookupEntry falls back to the versioned core key'() {
+    given:
+    registerCoreMatcherEntries()
+
+    expect:
+    CatalogueManager.INSTANCE.lookupEntry('type')?.key == 'v2-type'
+    CatalogueManager.INSTANCE.lookupEntry('v3-date')?.key == 'v3-date'
+    CatalogueManager.INSTANCE.lookupEntry('matcher/v3-date')?.key == 'v3-date'
+  }
+
   def 'resolveCapability prefers an entry named directly over the versioned fallback'() {
     given:
     def key = 'resolveCapability prefers an entry named directly'

--- a/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/CatalogueManagerSpec.groovy
+++ b/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/CatalogueManagerSpec.groovy
@@ -128,6 +128,99 @@ class CatalogueManagerSpec extends Specification {
     ((ResolvedCapability.Core) resolved).key == key
   }
 
+  /**
+   * The core matcher entries as the Pact frameworks actually register them - the Pact
+   * specification version the rule was introduced in, prefixed to the name. Kept in sync with
+   * MatcherExecutor.kt in Pact-JVM and MATCHER_CATALOGUE_ENTRIES in pact_matching.
+   */
+  private static void registerCoreMatcherEntries() {
+    CatalogueManager.INSTANCE.registerCoreEntries(
+      ['v2-regex', 'v2-type', 'v3-number-type', 'v3-integer-type', 'v3-decimal-type', 'v3-date',
+       'v3-time', 'v3-datetime', 'v2-min-type', 'v2-max-type', 'v2-minmax-type', 'v3-includes',
+       'v3-null', 'v4-equals-ignore-order', 'v4-min-equals-ignore-order',
+       'v4-max-equals-ignore-order', 'v4-minmax-equals-ignore-order', 'v3-content-type',
+       'v4-array-contains', 'v1-equality', 'v4-not-empty', 'v4-semver'].collect {
+        new CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, 'core', it)
+      }
+    )
+  }
+
+  private static String resolvedCoreKey(String entryKey) {
+    def resolved = CatalogueManager.INSTANCE.resolveCapability(entryKey, CatalogueEntryType.MATCHER)
+    assert resolved instanceof ResolvedCapability.Core
+    ((ResolvedCapability.Core) resolved).key
+  }
+
+  def 'resolveCapability falls back to the versioned core key'() {
+    given:
+    registerCoreMatcherEntries()
+
+    expect:
+    // The name a Pact file (and a plugin calling back) uses, without needing to know which
+    // specification version introduced the rule
+    resolvedCoreKey(name) == expected
+
+    where:
+    name                  || expected
+    'type'                || 'v2-type'
+    'regex'               || 'v2-regex'
+    'date'                || 'v3-date'
+    'equality'            || 'v1-equality'
+    'semver'              || 'v4-semver'
+    'not-empty'           || 'v4-not-empty'
+    // Only the whole name after the version prefix counts, so these are distinct rules and not
+    // ambiguous with `type`/`equals-ignore-order`
+    'content-type'        || 'v3-content-type'
+    'min-type'            || 'v2-min-type'
+    'equals-ignore-order' || 'v4-equals-ignore-order'
+    // The versioned key itself still resolves, by name
+    'v2-type'             || 'v2-type'
+    'matcher/v3-date'     || 'v3-date'
+    'core/matcher/v3-date' || 'v3-date'
+  }
+
+  def 'a key component is never matched as a substring'() {
+    // "type" must not name core/matcher/v2-type - if it did, it would match all eight core keys
+    // ending in "type" and be ambiguous. It resolves through the versioned fallback instead.
+    expect:
+    !CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'type')
+    CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'v2-type')
+    CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'matcher/v2-type')
+    CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'core/matcher/v2-type')
+    !CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'r/v2-type')
+    CatalogueManagerKt.namesCatalogueKey('core/content-matcher/xml', 'xml')
+    !CatalogueManagerKt.namesCatalogueKey('core/content-matcher/xml', 'ml')
+  }
+
+  def 'resolveCapability prefers an entry named directly over the versioned fallback'() {
+    given:
+    def key = 'resolveCapability prefers an entry named directly'
+    CatalogueManager.INSTANCE.registerCoreEntries([
+      new CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, 'core', "v3-$key")
+    ])
+    // Before the plugin registers anything, the bare name finds the core rule via the fallback
+    def coreFirst = resolvedCoreKey(key)
+
+    def pluginEntry = Plugin.CatalogueEntry.newBuilder()
+      .setTypeValue(CatalogueEntryType.MATCHER.toEntryValue())
+      .setKey(key)
+      .build()
+    CatalogueManager.INSTANCE.registerPluginEntries('CatalogueManagerSpec-versioned', [pluginEntry])
+
+    when:
+    def resolved = CatalogueManager.INSTANCE.resolveCapability(key, CatalogueEntryType.MATCHER)
+
+    then:
+    coreFirst == "v3-$key"
+    resolved instanceof ResolvedCapability.Plugin
+    ((ResolvedCapability.Plugin) resolved).pluginName == 'CatalogueManagerSpec-versioned'
+    // A caller that specifically wants the core rule can still name its versioned key
+    resolvedCoreKey("v3-$key") == "v3-$key"
+
+    cleanup:
+    CatalogueManager.INSTANCE.removePluginEntries('CatalogueManagerSpec-versioned')
+  }
+
   def 'resolveCapability throws a clear error for an unregistered key'() {
     when:
     CatalogueManager.INSTANCE.resolveCapability(

--- a/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/FieldSpec.groovy
+++ b/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/FieldSpec.groovy
@@ -1,0 +1,240 @@
+package io.pact.plugins.jvm.core
+
+import au.com.dius.pact.core.model.matchingrules.RegexMatcher
+import au.com.dius.pact.core.support.json.JsonValue
+import io.pact.plugin.v2.PluginV2
+import spock.lang.Specification
+
+class FieldSpec extends Specification {
+  private static final String PATH = '$.card.number'
+
+  private static void registerCoreEntry(String key, CatalogueEntryType type) {
+    CatalogueManager.INSTANCE.registerCoreEntries([
+      new CatalogueEntry(type, CatalogueEntryProviderType.CORE, 'core', key)
+    ])
+  }
+
+  private static FieldContext context() {
+    new FieldContext(PATH, 'body', null, [:])
+  }
+
+  /**
+   * The driver forwards whatever rule the host hands it - the rule's name and attributes - so any
+   * rule exercises the plumbing. Once the Pact-JVM model grows a carrier for plugin-provided rules
+   * (proposal 006 section 4), a plugin's own rule name arrives here by exactly this path.
+   */
+  private static aRule() {
+    new RegexMatcher('\\d{16}')
+  }
+
+  def 'each scalar type crosses the boundary under its own arm'() {
+    expect:
+    value.toProto().valueCase == arm
+
+    where:
+    value                                          || arm
+    FieldValue.Null.INSTANCE                       || PluginV2.FieldValue.ValueCase.NULLVALUE
+    new FieldValue.Bool(true)                      || PluginV2.FieldValue.ValueCase.BOOLEANVALUE
+    new FieldValue.Text('4111111111111111')        || PluginV2.FieldValue.ValueCase.STRINGVALUE
+    new FieldValue.Integer(100L)                   || PluginV2.FieldValue.ValueCase.INTEGERVALUE
+    new FieldValue.Decimal(100.5d)                 || PluginV2.FieldValue.ValueCase.DECIMALVALUE
+    new FieldValue.Binary([0, -97, -110, -106] as byte[]) || PluginV2.FieldValue.ValueCase.BINARYVALUE
+  }
+
+  def 'field values round trip through the proto form'() {
+    expect:
+    FieldValue.fromProto(value.toProto()) == value
+
+    where:
+    value << [
+      FieldValue.Null.INSTANCE,
+      new FieldValue.Bool(true),
+      new FieldValue.Text('4111111111111111'),
+      new FieldValue.Integer(100L),
+      new FieldValue.Decimal(-100.5d),
+      new FieldValue.Binary([0, -97, -110, -106] as byte[])
+    ]
+  }
+
+  def 'a whole number stays whole and a decimal stays decimal'() {
+    // The distinction the integer, decimal and type rules are built on, and the reason FieldValue
+    // does not put every value through a google.protobuf.Value
+    expect:
+    FieldValue.fromProto(new FieldValue.Integer(100L).toProto()) instanceof FieldValue.Integer
+    FieldValue.fromProto(new FieldValue.Decimal(100.0d).toProto()) instanceof FieldValue.Decimal
+  }
+
+  def 'an unset proto value reads as null'() {
+    expect:
+    FieldValue.fromProto(PluginV2.FieldValue.newBuilder().build()) == FieldValue.Null.INSTANCE
+  }
+
+  def 'converts a Pact JSON value keeping whole numbers whole'() {
+    expect:
+    FieldValue.fromJson(new JsonValue.Integer('100'.chars)) instanceof FieldValue.Integer
+    FieldValue.fromJson(new JsonValue.Decimal('100.5'.chars)) instanceof FieldValue.Decimal
+    FieldValue.fromJson(new JsonValue.StringValue('visa'.chars)) instanceof FieldValue.Text
+    FieldValue.fromJson(JsonValue.True.INSTANCE) == new FieldValue.Bool(true)
+    FieldValue.fromJson(JsonValue.Null.INSTANCE) == FieldValue.Null.INSTANCE
+  }
+
+  def 'matchField dispatches to a registered core handler'() {
+    given:
+    def key = 'matchField dispatches to a registered core handler'
+    registerCoreEntry(key, CatalogueEntryType.MATCHER)
+    def seen = null
+    CoreCapabilityRegistry.INSTANCE.registerFieldMatcher(key, { request ->
+      seen = request
+      PluginV2.MatchFieldResponse.newBuilder().build()
+    } as CoreFieldMatcher)
+
+    when:
+    def matcher = FieldKt.findFieldMatcher(key)
+    def result = matcher.matchField(aRule(), new FieldValue.Text('4111111111111111'),
+      new FieldValue.Text('4012888888881881'), context())
+
+    then:
+    matcher.isCore()
+    result.isEmpty()
+    // The request carried what the caller passed in
+    seen.path == PATH
+    seen.mismatchType == 'body'
+    seen.rule.type == 'regex'
+    seen.expected.stringValue == '4111111111111111'
+    seen.actual.stringValue == '4012888888881881'
+
+    cleanup:
+    CoreCapabilityRegistry.INSTANCE.deregisterFieldMatcher(key)
+  }
+
+  def 'matchField reports mismatches against the requested path'() {
+    given:
+    def key = 'matchField reports mismatches against the requested path'
+    registerCoreEntry(key, CatalogueEntryType.MATCHER)
+    CoreCapabilityRegistry.INSTANCE.registerFieldMatcher(key, { request ->
+      PluginV2.MatchFieldResponse.newBuilder()
+        // Deliberately no path/mismatchType: the driver fills them in from the request
+        .addMismatches(PluginV2.ContentMismatch.newBuilder().setMismatch('fails the Luhn check'))
+        .build()
+    } as CoreFieldMatcher)
+
+    when:
+    def result = FieldKt.findFieldMatcher(key).matchField(aRule(),
+      new FieldValue.Text('4111111111111111'), new FieldValue.Text('4111111111111112'), context())
+
+    then:
+    result.size() == 1
+    result[0].mismatch == 'fails the Luhn check'
+    result[0].path == PATH
+    result[0].type == 'body'
+
+    cleanup:
+    CoreCapabilityRegistry.INSTANCE.deregisterFieldMatcher(key)
+  }
+
+  def 'matchField turns a handler error into a mismatch'() {
+    given:
+    def key = 'matchField turns a handler error into a mismatch'
+    registerCoreEntry(key, CatalogueEntryType.MATCHER)
+    CoreCapabilityRegistry.INSTANCE.registerFieldMatcher(key, { request ->
+      PluginV2.MatchFieldResponse.newBuilder()
+        .setError("'amx' is not a brand this plugin knows about")
+        .build()
+    } as CoreFieldMatcher)
+
+    when:
+    def result = FieldKt.findFieldMatcher(key).matchField(aRule(),
+      new FieldValue.Text('4111111111111111'), new FieldValue.Text('4111111111111111'), context())
+
+    then:
+    result.size() == 1
+    result[0].mismatch == "'amx' is not a brand this plugin knows about"
+
+    cleanup:
+    CoreCapabilityRegistry.INSTANCE.deregisterFieldMatcher(key)
+  }
+
+  def 'matchField fails clearly when no core handler is registered'() {
+    given:
+    def key = 'matchField fails clearly when no core handler is registered'
+    registerCoreEntry(key, CatalogueEntryType.MATCHER)
+
+    when:
+    def result = FieldKt.findFieldMatcher(key).matchField(aRule(), FieldValue.Null.INSTANCE,
+      FieldValue.Null.INSTANCE, context())
+
+    then:
+    result.size() == 1
+    result[0].mismatch.contains('No core capability handler registered')
+  }
+
+  def 'generateField dispatches to a registered core handler'() {
+    given:
+    def key = 'generateField dispatches to a registered core handler'
+    registerCoreEntry(key, CatalogueEntryType.GENERATOR)
+    def seen = null
+    CoreCapabilityRegistry.INSTANCE.registerFieldGenerator(key, { request ->
+      seen = request
+      PluginV2.GenerateFieldResponse.newBuilder()
+        .setValue(new FieldValue.Text('4012888888881881').toProto())
+        .build()
+    } as CoreFieldGenerator)
+
+    when:
+    def generator = FieldKt.findFieldGenerator(key)
+    def result = generator.generateField(new au.com.dius.pact.core.model.generators.RandomStringGenerator(16),
+      new FieldValue.Text('4111111111111111'), FieldTestMode.CONSUMER, context())
+
+    then:
+    generator.isCore()
+    result == new FieldValue.Text('4012888888881881')
+    seen.path == PATH
+    seen.testMode == PluginV2.GenerateContentRequest.TestMode.Consumer
+
+    cleanup:
+    CoreCapabilityRegistry.INSTANCE.deregisterFieldGenerator(key)
+  }
+
+  def 'generateField reports a generator error'() {
+    given:
+    def key = 'generateField reports a generator error'
+    registerCoreEntry(key, CatalogueEntryType.GENERATOR)
+    CoreCapabilityRegistry.INSTANCE.registerFieldGenerator(key, { request ->
+      PluginV2.GenerateFieldResponse.newBuilder().setError('no such brand').build()
+    } as CoreFieldGenerator)
+
+    when:
+    FieldKt.findFieldGenerator(key).generateField(
+      new au.com.dius.pact.core.model.generators.RandomStringGenerator(16),
+      FieldValue.Null.INSTANCE, FieldTestMode.CONSUMER, context())
+
+    then:
+    def ex = thrown(PactFieldGenerationException)
+    ex.error == 'no such brand'
+
+    cleanup:
+    CoreCapabilityRegistry.INSTANCE.deregisterFieldGenerator(key)
+  }
+
+  def 'finding a rule that is not registered says so'() {
+    when:
+    FieldKt.findFieldMatcher('finding a rule that is not registered says so')
+
+    then:
+    thrown(PactCatalogueEntryNotFoundException)
+  }
+
+  def 'finding a rule that is a generator says so'() {
+    given:
+    def key = 'finding a rule that is a generator says so'
+    registerCoreEntry(key, CatalogueEntryType.GENERATOR)
+
+    when:
+    FieldKt.findFieldMatcher(key)
+
+    then:
+    def ex = thrown(PactCatalogueEntryTypeMismatchException)
+    ex.actualType == CatalogueEntryType.GENERATOR
+    ex.expectedType == CatalogueEntryType.MATCHER
+  }
+}

--- a/drivers/jvm/core/src/test/kotlin/io/pact/plugins/jvm/core/LuaPactPluginTest.kt
+++ b/drivers/jvm/core/src/test/kotlin/io/pact/plugins/jvm/core/LuaPactPluginTest.kt
@@ -679,4 +679,422 @@ class LuaPactPluginTest {
       pluginDir.deleteRecursively()
     }
   }
+
+  // ---- Field-level matchers and generators (proposal 006) ----
+
+  private fun creditcardManifest(): PactPluginManifest {
+    val pluginDir = File("../../../plugins/creditcard").canonicalFile
+    require(pluginDir.exists()) { "plugins/creditcard directory should exist at $pluginDir" }
+    return DefaultPactPluginManifest(
+      pluginDir = pluginDir,
+      pluginInterfaceVersion = 2,
+      name = "creditcard",
+      version = "0.0.0",
+      executableType = "lua",
+      minimumRequiredVersion = null,
+      entryPoint = "plugin.lua",
+      entryPoints = emptyMap(),
+      args = emptyList(),
+      dependencies = emptyList()
+    )
+  }
+
+  private fun textField(value: String): PluginV2.FieldValue =
+    PluginV2.FieldValue.newBuilder().setStringValue(value).build()
+
+  private fun brandValues(brand: String?): com.google.protobuf.Struct? =
+    brand?.let { Utils.mapToProtoStruct(mapOf("brand" to it)) }
+
+  /** A `MatchFieldRequest` for the `creditcard` rule, optionally configured with a brand. */
+  private fun creditcardMatchRequest(brand: String?, expected: String, actual: String): PluginV2.MatchFieldRequest {
+    val rule = PluginV2.MatchingRule.newBuilder().setType("creditcard")
+    brandValues(brand)?.let { rule.values = it }
+    return PluginV2.MatchFieldRequest.newBuilder()
+      .setKey("creditcard")
+      .setRule(rule.build())
+      .setPath("$.card.number")
+      .setMismatchType("body")
+      .setExpected(textField(expected))
+      .setActual(textField(actual))
+      .build()
+  }
+
+  private fun creditcardGenerateRequest(brand: String?, example: String): PluginV2.GenerateFieldRequest {
+    val generator = PluginV2.Generator.newBuilder().setType("creditcard")
+    brandValues(brand)?.let { generator.values = it }
+    return PluginV2.GenerateFieldRequest.newBuilder()
+      .setKey("creditcard")
+      .setGenerator(generator.build())
+      .setPath("$.card.number")
+      .setExampleValue(textField(example))
+      .setTestMode(PluginV2.GenerateContentRequest.TestMode.Consumer)
+      .build()
+  }
+
+  @Test
+  fun `creditcard plugin registers a matcher and a generator under the same key`() {
+    val plugin = LuaPactPlugin(creditcardManifest())
+    try {
+      val response = plugin.withRpcClient {
+        it.initPlugin(PluginInitRequest(implementation = "test", version = "0.0.0"))
+      }
+      assertEquals(2, response.catalogueEntries.size)
+      assertEquals("creditcard", response.catalogueEntries[0].key)
+      assertEquals(CatalogueEntryType.MATCHER.toEntryValue(), response.catalogueEntries[0].typeValue)
+      assertEquals("creditcard", response.catalogueEntries[1].key)
+      assertEquals(CatalogueEntryType.GENERATOR.toEntryValue(), response.catalogueEntries[1].typeValue)
+      // The values key that maps a single positional config argument in a rule definition
+      assertEquals("brand", response.catalogueEntries[0].valuesMap["config-key"])
+    } finally {
+      plugin.shutdown()
+    }
+  }
+
+  @Test
+  fun `creditcard plugin accepts a valid card number`() {
+    val plugin = LuaPactPlugin(creditcardManifest())
+    try {
+      val response = plugin.withRpcClient {
+        it.matchField(creditcardMatchRequest("visa", "4111111111111111", "4012888888881881"))
+      }
+      assertEquals("", response.error)
+      assertTrue(
+        response.mismatchesList.isEmpty(),
+        "expected no mismatches, got ${response.mismatchesList}"
+      )
+    } finally {
+      plugin.shutdown()
+    }
+  }
+
+  @Test
+  fun `creditcard plugin reports a number that fails the Luhn check`() {
+    val plugin = LuaPactPlugin(creditcardManifest())
+    try {
+      val response = plugin.withRpcClient {
+        it.matchField(creditcardMatchRequest(null, "4111111111111111", "4111111111111112"))
+      }
+      assertEquals("", response.error)
+      assertEquals(1, response.mismatchesCount)
+      val mismatch = response.getMismatches(0)
+      assertTrue(
+        mismatch.mismatch.contains("Luhn check"),
+        "unexpected mismatch description: ${mismatch.mismatch}"
+      )
+      // The plugin places its own mismatches, echoing back the path and part it was given
+      assertEquals("$.card.number", mismatch.path)
+      assertEquals("body", mismatch.mismatchType)
+      assertEquals("4111111111111111", mismatch.expected.value.toStringUtf8())
+      assertEquals("4111111111111112", mismatch.actual.value.toStringUtf8())
+    } finally {
+      plugin.shutdown()
+    }
+  }
+
+  @Test
+  fun `creditcard plugin reports a number from the wrong brand`() {
+    val plugin = LuaPactPlugin(creditcardManifest())
+    try {
+      // A valid Visa number, but the rule asks for a Mastercard
+      val response = plugin.withRpcClient {
+        it.matchField(creditcardMatchRequest("mastercard", "5555555555554444", "4012888888881881"))
+      }
+      assertEquals(1, response.mismatchesCount)
+      assertTrue(
+        response.getMismatches(0).mismatch.contains("Mastercard"),
+        "unexpected mismatch description: ${response.getMismatches(0).mismatch}"
+      )
+    } finally {
+      plugin.shutdown()
+    }
+  }
+
+  @Test
+  fun `creditcard plugin reports a misconfigured brand as an error not a mismatch`() {
+    // The test author's mistake, not the provider's - so it fails the test outright rather than
+    // being reported as the provider sending the wrong value.
+    val plugin = LuaPactPlugin(creditcardManifest())
+    try {
+      val response = plugin.withRpcClient {
+        it.matchField(creditcardMatchRequest("amx", "4111111111111111", "4111111111111111"))
+      }
+      assertTrue(
+        response.error.contains("'amx' is not a credit card brand"),
+        "unexpected error: ${response.error}"
+      )
+      assertTrue(response.mismatchesList.isEmpty())
+    } finally {
+      plugin.shutdown()
+    }
+  }
+
+  @Test
+  fun `creditcard plugin generates a number for the configured brand`() {
+    val plugin = LuaPactPlugin(creditcardManifest())
+    try {
+      val response = plugin.withRpcClient {
+        it.generateField(creditcardGenerateRequest("amex", "4111111111111111"))
+      }
+      assertEquals("", response.error)
+      assertEquals(PluginV2.FieldValue.ValueCase.STRINGVALUE, response.value.valueCase)
+      val generated = response.value.stringValue
+      assertEquals(15, generated.length, "an Amex number has 15 digits, got '$generated'")
+      assertTrue(generated.startsWith("34") || generated.startsWith("37"), "got '$generated'")
+
+      // And the number it generated is one it will accept back
+      val matchResponse = plugin.withRpcClient {
+        it.matchField(creditcardMatchRequest("amex", "371449635398431", generated))
+      }
+      assertTrue(
+        matchResponse.mismatchesList.isEmpty(),
+        "the plugin should accept its own generated number, got ${matchResponse.mismatchesList}"
+      )
+    } finally {
+      plugin.shutdown()
+    }
+  }
+
+  @Test
+  fun `creditcard plugin reports a generator error`() {
+    val plugin = LuaPactPlugin(creditcardManifest())
+    try {
+      val response = plugin.withRpcClient {
+        it.generateField(creditcardGenerateRequest("amx", "4111111111111111"))
+      }
+      assertTrue(response.error.contains("amx"), "unexpected error: ${response.error}")
+      assertFalse(response.hasValue())
+    } finally {
+      plugin.shutdown()
+    }
+  }
+
+  @Test
+  fun `each field value type survives the round trip through Lua`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-field-value-round-trip-test").toFile()
+    val manifest = hostCallbackManifest(
+      pluginDir,
+      "field-value-round-trip-test",
+      """
+        function generate_field(request)
+          return { value = request.example_value }
+        end
+      """.trimIndent()
+    )
+    val plugin = LuaPactPlugin(manifest)
+    try {
+      val values = listOf(
+        PluginV2.FieldValue.newBuilder().setNullValueValue(0).build(),
+        PluginV2.FieldValue.newBuilder().setBooleanValue(true).build(),
+        PluginV2.FieldValue.newBuilder().setStringValue("4111111111111111").build(),
+        PluginV2.FieldValue.newBuilder().setIntegerValue(100).build(),
+        PluginV2.FieldValue.newBuilder().setDecimalValue(100.5).build(),
+        // Deliberately starts with a NUL and is not valid UTF-8: a Lua string is an arbitrary
+        // byte array, and reading one back as a Java String would truncate this to nothing
+        PluginV2.FieldValue.newBuilder()
+          .setBinaryValue(com.google.protobuf.ByteString.copyFrom(byteArrayOf(0, -97, -110, -106)))
+          .build()
+      )
+      for (value in values) {
+        val request = PluginV2.GenerateFieldRequest.newBuilder().setExampleValue(value).build()
+        val response = plugin.withRpcClient { it.generateField(request) }
+        assertEquals(value, response.value, "$value did not survive the round trip through Lua")
+      }
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `a whole number reaches Lua as an integer and a decimal as a float`() {
+    // The distinction the integer, decimal and type rules are built on. Lua 5.4 has separate
+    // integer and float subtypes, so it can be checked from inside the script itself.
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-field-value-type-test").toFile()
+    val manifest = hostCallbackManifest(
+      pluginDir,
+      "field-value-lua-type-test",
+      """
+        function generate_field(request)
+          return { value = math.type(request.example_value) }
+        end
+      """.trimIndent()
+    )
+    val plugin = LuaPactPlugin(manifest)
+    try {
+      val luaTypeOf = { value: PluginV2.FieldValue ->
+        val request = PluginV2.GenerateFieldRequest.newBuilder().setExampleValue(value).build()
+        plugin.withRpcClient { it.generateField(request) }.value.stringValue
+      }
+      assertEquals("integer", luaTypeOf(PluginV2.FieldValue.newBuilder().setIntegerValue(100).build()))
+      assertEquals("float", luaTypeOf(PluginV2.FieldValue.newBuilder().setDecimalValue(100.0).build()))
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `a mismatch that does not place itself is reported against the request path`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-field-mismatch-path-test").toFile()
+    val manifest = hostCallbackManifest(
+      pluginDir,
+      "field-mismatch-path-test",
+      """
+        function match_field(request)
+          return { mismatches = { "not a card number" } }
+        end
+      """.trimIndent()
+    )
+    val plugin = LuaPactPlugin(manifest)
+    try {
+      val response = plugin.withRpcClient {
+        it.matchField(creditcardMatchRequest(null, "4111111111111111", "nope"))
+      }
+      assertEquals(1, response.mismatchesCount)
+      assertEquals("not a card number", response.getMismatches(0).mismatch)
+      assertEquals("$.card.number", response.getMismatches(0).path)
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `a plugin that does not define the field functions says so`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-field-functions-missing-test").toFile()
+    val manifest = hostCallbackManifest(pluginDir, "field-functions-missing-test", "-- nothing here")
+    val plugin = LuaPactPlugin(manifest)
+    try {
+      val matchError = assertThrows(RuntimeException::class.java) {
+        plugin.withRpcClient { it.matchField(PluginV2.MatchFieldRequest.newBuilder().build()) }
+      }
+      assertTrue(
+        matchError.message?.contains("does not define a global 'match_field' function") == true,
+        "unexpected error: ${matchError.message}"
+      )
+
+      val generateError = assertThrows(RuntimeException::class.java) {
+        plugin.withRpcClient { it.generateField(PluginV2.GenerateFieldRequest.newBuilder().build()) }
+      }
+      assertTrue(
+        generateError.message?.contains("does not define a global 'generate_field' function") == true,
+        "unexpected error: ${generateError.message}"
+      )
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `match_field calls host_match_field for a registered core capability`() {
+    // A plugin that owns a content type delegating one value inside it to a standard Pact rule,
+    // rather than reimplementing it - the point of the host callbacks (proposal 006 section 7).
+    val key = "match_field-calls-host_match_field-for-a-registered-core-capability"
+    CatalogueManager.registerCoreEntries(listOf(
+      CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "", key)
+    ))
+    CoreCapabilityRegistry.registerFieldMatcher(key) { request ->
+      PluginV2.MatchFieldResponse.newBuilder()
+        .addMismatches(
+          PluginV2.ContentMismatch.newBuilder()
+            .setMismatch("core matcher saw rule '${request.rule.type}' at ${request.path}")
+            .setPath(request.path)
+            .setMismatchType(request.mismatchType)
+            .build()
+        )
+        .build()
+    }
+
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-host-match-field-test").toFile()
+    val manifest = hostCallbackManifest(
+      pluginDir,
+      "host-match-field-test",
+      """
+        function match_field(request)
+          return host_match_field("$key", request)
+        end
+      """.trimIndent()
+    )
+    val plugin = LuaPactPlugin(manifest)
+    try {
+      val response = plugin.withRpcClient {
+        it.matchField(creditcardMatchRequest("visa", "4111111111111111", "4012888888881881"))
+      }
+      assertEquals(1, response.mismatchesCount)
+      assertEquals(
+        "core matcher saw rule 'creditcard' at $.card.number",
+        response.getMismatches(0).mismatch
+      )
+      assertEquals("body", response.getMismatches(0).mismatchType)
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+      CoreCapabilityRegistry.deregisterFieldMatcher(key)
+    }
+  }
+
+  @Test
+  fun `host_match_field surfaces a clear error when the entry is not registered`() {
+    val key = "host_match_field-surfaces-a-clear-error-when-the-entry-is-not-registered"
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-host-match-field-missing-test").toFile()
+    val manifest = hostCallbackManifest(
+      pluginDir,
+      "host-match-field-missing-test",
+      """
+        function match_field(request)
+          return host_match_field("$key", request)
+        end
+      """.trimIndent()
+    )
+    val plugin = LuaPactPlugin(manifest)
+    try {
+      val ex = assertThrows(RuntimeException::class.java) {
+        plugin.withRpcClient {
+          it.matchField(creditcardMatchRequest(null, "4111111111111111", "4111111111111111"))
+        }
+      }
+      assertTrue(
+        ex.message?.contains("No catalogue entry found") == true,
+        "expected a 'No catalogue entry found' error, got: ${ex.message}"
+      )
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `generate_field calls host_generate_field for a registered core capability`() {
+    val key = "generate_field-calls-host_generate_field-for-a-registered-core-capability"
+    CatalogueManager.registerCoreEntries(listOf(
+      CatalogueEntry(CatalogueEntryType.GENERATOR, CatalogueEntryProviderType.CORE, "", key)
+    ))
+    CoreCapabilityRegistry.registerFieldGenerator(key) {
+      PluginV2.GenerateFieldResponse.newBuilder().setValue(textField("generated by the host")).build()
+    }
+
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-host-generate-field-test").toFile()
+    val manifest = hostCallbackManifest(
+      pluginDir,
+      "host-generate-field-test",
+      """
+        function generate_field(request)
+          return host_generate_field("$key", request)
+        end
+      """.trimIndent()
+    )
+    val plugin = LuaPactPlugin(manifest)
+    try {
+      val response = plugin.withRpcClient {
+        it.generateField(creditcardGenerateRequest("visa", "4111111111111111"))
+      }
+      assertEquals("", response.error)
+      assertEquals("generated by the host", response.value.stringValue)
+    } finally {
+      plugin.shutdown()
+      pluginDir.deleteRecursively()
+      CoreCapabilityRegistry.deregisterFieldGenerator(key)
+    }
+  }
 }

--- a/drivers/rust/driver/src/catalogue_manager.rs
+++ b/drivers/rust/driver/src/catalogue_manager.rs
@@ -337,6 +337,20 @@ fn names_versioned_core_key(entry: &CatalogueEntry, entry_key: &str) -> bool {
 /// content-generator registered under the same name as an unrelated content-matcher), mirroring
 /// the explicit `entry_type` check [`find_content_matcher`]/[`find_content_generator`] already do.
 pub fn resolve_capability(entry_key: &str, expected_type: CatalogueEntryType) -> anyhow::Result<ResolvedCapability> {
+  let entry = resolve_capability_entry(entry_key, expected_type)?;
+  match entry.provider_type {
+    CatalogueEntryProviderType::CORE => Ok(ResolvedCapability::Core(entry.key.clone())),
+    CatalogueEntryProviderType::PLUGIN => entry.plugin.clone()
+      .map(|manifest| ResolvedCapability::Plugin(Box::new(manifest)))
+      .ok_or_else(|| anyhow::anyhow!("Catalogue entry '{}' has no plugin manifest", entry_key))
+  }
+}
+
+/// Resolve a catalogue entry key to the entry itself, using the same two-pass matching
+/// [`resolve_capability`] documents. Callers that need the entry rather than a dispatch target -
+/// [`crate::field::find_field_matcher`] and [`crate::field::find_field_generator`], which wrap it
+/// in a matcher/generator - use this directly.
+pub fn resolve_capability_entry(entry_key: &str, expected_type: CatalogueEntryType) -> anyhow::Result<CatalogueEntry> {
   let all_entries: Vec<(String, CatalogueEntry)> = {
     let inner = CATALOGUE_REGISTER.lock().unwrap();
     inner.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
@@ -379,12 +393,7 @@ pub fn resolve_capability(entry_key: &str, expected_type: CatalogueEntryType) ->
     }
   };
 
-  match entry.provider_type {
-    CatalogueEntryProviderType::CORE => Ok(ResolvedCapability::Core(entry.key.clone())),
-    CatalogueEntryProviderType::PLUGIN => entry.plugin.clone()
-      .map(|manifest| ResolvedCapability::Plugin(Box::new(manifest)))
-      .ok_or_else(|| anyhow::anyhow!("Catalogue entry '{}' has no plugin manifest", entry_key))
-  }
+  Ok(entry.clone())
 }
 
 /// Remove all entries for a plugin given the plugin name

--- a/drivers/rust/driver/src/catalogue_manager.rs
+++ b/drivers/rust/driver/src/catalogue_manager.rs
@@ -245,12 +245,18 @@ pub fn register_core_entries(entries: &Vec<CatalogueEntry>) {
   }
 }
 
-/// Lookup an entry in the catalogue by the key. Will find the first entry that ends with the
-/// given key.
+/// Lookup an entry in the catalogue by the key, matched the same way [`resolve_capability`] does:
+/// by name first - the whole catalogue key, or a trailing run of its `/`-separated components -
+/// then against the core catalogue's versioned naming convention.
+///
+/// Unlike [`resolve_capability`], this takes the first match when more than one entry matches, and
+/// `HashMap` iteration order is randomised per process. Prefer [`resolve_capability`] wherever the
+/// expected entry type is known and a deterministic answer matters.
 pub fn lookup_entry(key: &str) -> Option<CatalogueEntry> {
   let inner = CATALOGUE_REGISTER.lock().unwrap();
   inner.iter()
-    .find(|(k, _)| k.ends_with(key))
+    .find(|(k, _)| names_catalogue_key(k, key))
+    .or_else(|| inner.iter().find(|(_, entry)| names_versioned_core_key(entry, key)))
     .map(|(_, v)| v.clone())
 }
 
@@ -289,7 +295,15 @@ fn names_catalogue_key(catalogue_key: &str, entry_key: &str) -> bool {
 ///
 /// Only the whole name after the version prefix counts, so `type` names `v2-type` but not
 /// `v3-content-type` or `v2-min-type` - those are the `content-type` and `min-type` rules.
+///
+/// The convention only applies to matching rules and generators. Content matchers, content
+/// generators and transports are registered under plain names (`xml`, `json`, `grpc`), so a
+/// leading `v<n>-` there is part of the name rather than a version, and stripping it would be
+/// wrong.
 fn names_versioned_core_key(entry: &CatalogueEntry, entry_key: &str) -> bool {
+  if entry.entry_type != CatalogueEntryType::MATCHER && entry.entry_type != CatalogueEntryType::GENERATOR {
+    return false;
+  }
   match entry.key.split_once('-') {
     Some((version, name)) => name == entry_key
       && version.len() > 1
@@ -742,6 +756,83 @@ mod tests {
     expect!(names_catalogue_key("core/matcher/v2-type", "r/v2-type")).to(be_false());
     expect!(names_catalogue_key("core/content-matcher/xml", "xml")).to(be_true());
     expect!(names_catalogue_key("core/content-matcher/xml", "ml")).to(be_false());
+  }
+
+  #[test]
+  fn the_versioned_fallback_only_applies_to_matcher_and_generator_entries() {
+    // Content matchers, content generators and transports are registered under plain names, so a
+    // leading "v<n>-" there is part of the name, not a version to be stripped.
+    let name = "the_versioned_fallback_only_applies_to_matcher_and_generator_entries";
+    register_core_entries(&vec![
+      CatalogueEntry {
+        entry_type: CatalogueEntryType::CONTENT_MATCHER,
+        provider_type: CatalogueEntryProviderType::CORE,
+        plugin: None,
+        key: format!("v2-{}", name),
+        values: hashmap!{}
+      },
+      CatalogueEntry {
+        entry_type: CatalogueEntryType::MATCHER,
+        provider_type: CatalogueEntryProviderType::CORE,
+        plugin: None,
+        key: format!("v2-matcher-{}", name),
+        values: hashmap!{}
+      }
+    ]);
+
+    // The content matcher is only reachable by its actual name
+    expect!(resolve_capability(name, CatalogueEntryType::CONTENT_MATCHER).is_err()).to(be_true());
+    expect!(lookup_entry(name).map(|entry| entry.key)).to(be_none());
+    expect!(resolve_capability(&format!("v2-{}", name), CatalogueEntryType::CONTENT_MATCHER).is_ok())
+      .to(be_true());
+
+    // ... while the matcher entry still gets the fallback
+    expect!(resolved_core_key(&format!("matcher-{}", name)))
+      .to(be_equal_to(format!("v2-matcher-{}", name)));
+  }
+
+  #[test]
+  fn lookup_entry_matches_by_name_not_by_substring() {
+    let name = "lookup_entry_matches_by_name_not_by_substring";
+    let manifest = PactPluginManifest { name: name.to_string(), .. PactPluginManifest::default() };
+    register_plugin_entries(&manifest, &vec![
+      ProtoCatalogueEntry {
+        r#type: CatalogueEntryType::CONTENT_MATCHER.to_proto_value(),
+        key: name.to_string(),
+        values: hashmap!{}
+      },
+      ProtoCatalogueEntry {
+        r#type: CatalogueEntryType::MATCHER.to_proto_value(),
+        key: format!("v3-{}", name),
+        values: hashmap!{}
+      }
+    ]);
+
+    let by_name = lookup_entry(name).map(|entry| entry.entry_type);
+    let by_components = lookup_entry(&format!("content-matcher/{}", name)).map(|entry| entry.entry_type);
+    let fully_qualified = lookup_entry(&format!("plugin/{}/content-matcher/{}", name, name))
+      .map(|entry| entry.entry_type);
+    // A trailing substring of a component names nothing
+    let by_substring = lookup_entry(&name[3..]);
+    // But the versioned convention still resolves for a matcher entry
+    let versioned = lookup_entry(&format!("{}-{}", "matcher-fallback", name));
+
+    remove_plugin_entries(name);
+
+    expect!(by_name).to(be_some().value(CatalogueEntryType::CONTENT_MATCHER));
+    expect!(by_components).to(be_some().value(CatalogueEntryType::CONTENT_MATCHER));
+    expect!(fully_qualified).to(be_some().value(CatalogueEntryType::CONTENT_MATCHER));
+    expect!(by_substring).to(be_none());
+    expect!(versioned).to(be_none());
+  }
+
+  #[test]
+  fn lookup_entry_falls_back_to_the_versioned_core_key() {
+    register_core_matcher_entries();
+
+    expect!(lookup_entry("type").map(|entry| entry.key)).to(be_some().value("v2-type".to_string()));
+    expect!(lookup_entry("v3-date").map(|entry| entry.key)).to(be_some().value("v3-date".to_string()));
+    expect!(lookup_entry("matcher/v3-date").map(|entry| entry.key)).to(be_some().value("v3-date".to_string()));
   }
 
   #[test]

--- a/drivers/rust/driver/src/catalogue_manager.rs
+++ b/drivers/rust/driver/src/catalogue_manager.rs
@@ -266,28 +266,81 @@ pub enum ResolvedCapability {
   Plugin(Box<PactPluginManifest>)
 }
 
+/// Does `entry_key` name this catalogue key? Either the whole key (`core/content-matcher/xml`),
+/// or a trailing run of its `/`-separated components (`content-matcher/xml`, or just `xml`).
+///
+/// Components are compared whole, never as substrings: `"type"` does not name
+/// `core/matcher/v2-type`. That distinction is the point - the core catalogue prefixes the Pact
+/// specification version a matcher was introduced in to its name, so a substring match would let
+/// an unqualified name collide with a versioned core key it has nothing to do with (a plugin's
+/// own `matcher/date` against `core/matcher/v3-date`, say). The versioned form is handled
+/// deliberately by [`names_versioned_core_key`] instead, as a fallback rather than a coincidence.
+fn names_catalogue_key(catalogue_key: &str, entry_key: &str) -> bool {
+  let key_parts = catalogue_key.split('/').collect::<Vec<_>>();
+  let query_parts = entry_key.split('/').collect::<Vec<_>>();
+  query_parts.len() <= key_parts.len()
+    && key_parts[key_parts.len() - query_parts.len()..] == query_parts[..]
+}
+
+/// Does `entry_key` name this entry under the core catalogue's versioned naming convention - the
+/// Pact specification version the rule was introduced in, prefixed to its name (`v2-type`,
+/// `v3-date`, `v4-not-empty`)? This is what lets a caller ask for `type` and get `v2-type`
+/// without having to know which specification version introduced it.
+///
+/// Only the whole name after the version prefix counts, so `type` names `v2-type` but not
+/// `v3-content-type` or `v2-min-type` - those are the `content-type` and `min-type` rules.
+fn names_versioned_core_key(entry: &CatalogueEntry, entry_key: &str) -> bool {
+  match entry.key.split_once('-') {
+    Some((version, name)) => name == entry_key
+      && version.len() > 1
+      && version.starts_with('v')
+      && version[1..].chars().all(|c| c.is_ascii_digit()),
+    None => false
+  }
+}
+
 /// Resolve a callback's catalogue entry key to a dispatch target, the same way
 /// [`crate::content::ContentMatcher::is_core`]/[`crate::content::ContentGenerator::is_core`] do
 /// for the driver's own outbound calls.
 ///
-/// `entry_key` is matched by suffix against the full catalogue key (e.g. a plugin passing
-/// `"xml"` matches `"core/content-matcher/xml"`), the same lookup [`lookup_entry`] does - except
-/// unlike [`lookup_entry`], this does not just take the first `HashMap` hit if more than one
-/// entry matches the suffix. A short, unqualified `entry_key` could otherwise coincidentally
-/// match more than one entry of the *same* `expected_type` (e.g. a plugin registering its own
-/// `content-matcher/xml` alongside a host-registered core `content-matcher/xml`), and `HashMap`
-/// iteration order is randomised per process - silently picking one would make the dispatch
-/// target non-deterministic across restarts. `expected_type` still guards against the *wrong*
-/// capability shape (a content-generator registered under the same name as an unrelated
-/// content-matcher), mirroring the explicit `entry_type` check [`find_content_matcher`]/
-/// [`find_content_generator`] already do.
+/// `entry_key` is matched against the catalogue in two passes:
+///
+/// 1. by name - the whole catalogue key (`core/content-matcher/xml`) or a trailing run of its
+///    components (`content-matcher/xml`, `xml`), compared component by component;
+/// 2. failing that, against the core catalogue's versioned naming convention, so `type` resolves
+///    to `v2-type` and `date` to `v3-date`.
+///
+/// Naming an entry directly always wins over the versioned fallback: if a plugin registers its
+/// own `matcher/date`, `date` resolves to that plugin, and a caller that specifically wants the
+/// core rule asks for `v3-date`.
+///
+/// Unlike [`lookup_entry`], this does not just take the first `HashMap` hit when more than one
+/// entry matches. A short, unqualified `entry_key` can still match more than one entry of the
+/// *same* `expected_type` (a plugin registering its own `content-matcher/xml` alongside a
+/// host-registered core `content-matcher/xml`), and `HashMap` iteration order is randomised per
+/// process - silently picking one would make the dispatch target non-deterministic across
+/// restarts. `expected_type` still guards against the *wrong* capability shape (a
+/// content-generator registered under the same name as an unrelated content-matcher), mirroring
+/// the explicit `entry_type` check [`find_content_matcher`]/[`find_content_generator`] already do.
 pub fn resolve_capability(entry_key: &str, expected_type: CatalogueEntryType) -> anyhow::Result<ResolvedCapability> {
-  let candidates: Vec<(String, CatalogueEntry)> = {
+  let all_entries: Vec<(String, CatalogueEntry)> = {
     let inner = CATALOGUE_REGISTER.lock().unwrap();
-    inner.iter()
-      .filter(|(k, _)| k.ends_with(entry_key))
-      .map(|(k, v)| (k.clone(), v.clone()))
-      .collect()
+    inner.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+  };
+
+  let named: Vec<(String, CatalogueEntry)> = all_entries.iter()
+    .filter(|(k, _)| names_catalogue_key(k, entry_key))
+    .cloned()
+    .collect();
+  let candidates = if named.iter().any(|(_, entry)| entry.entry_type == expected_type) {
+    named
+  } else {
+    let versioned: Vec<(String, CatalogueEntry)> = all_entries.iter()
+      .filter(|(_, entry)| names_versioned_core_key(entry, entry_key))
+      .cloned()
+      .collect();
+    // Keep any wrong-typed direct matches for the diagnostic below if the fallback finds nothing
+    if versioned.is_empty() { named } else { versioned }
   };
 
   let mut of_expected_type = candidates.iter().filter(|(_, entry)| entry.entry_type == expected_type);
@@ -621,6 +674,107 @@ mod tests {
       ResolvedCapability::Plugin(_) => panic!("expected a Core resolution, got Plugin")
     };
     expect!(core_key).to(be_equal_to(key.to_string()));
+  }
+
+  /// The core matcher entries as the Pact frameworks actually register them - the Pact
+  /// specification version the rule was introduced in, prefixed to the name. Kept in sync with
+  /// `MATCHER_CATALOGUE_ENTRIES` in pact_matching and `MatcherExecutor.kt` in Pact-JVM.
+  fn register_core_matcher_entries() {
+    let entries = ["v2-regex", "v2-type", "v3-number-type", "v3-integer-type", "v3-decimal-type",
+      "v3-date", "v3-time", "v3-datetime", "v2-min-type", "v2-max-type", "v2-minmax-type",
+      "v3-includes", "v3-null", "v4-equals-ignore-order", "v4-min-equals-ignore-order",
+      "v4-max-equals-ignore-order", "v4-minmax-equals-ignore-order", "v3-content-type",
+      "v4-array-contains", "v1-equality", "v4-not-empty", "v4-semver"]
+      .iter()
+      .map(|key| CatalogueEntry {
+        entry_type: CatalogueEntryType::MATCHER,
+        provider_type: CatalogueEntryProviderType::CORE,
+        plugin: None,
+        key: key.to_string(),
+        values: hashmap!{}
+      })
+      .collect();
+    register_core_entries(&entries);
+  }
+
+  fn resolved_core_key(entry_key: &str) -> String {
+    match resolve_capability(entry_key, CatalogueEntryType::MATCHER) {
+      Ok(ResolvedCapability::Core(key)) => key,
+      other => panic!("expected '{}' to resolve to a core entry, got {:?}", entry_key, other)
+    }
+  }
+
+  #[test]
+  fn resolve_capability_falls_back_to_the_versioned_core_key() {
+    register_core_matcher_entries();
+
+    // The name a Pact file (and a plugin calling back) uses, without needing to know which
+    // specification version introduced the rule
+    expect!(resolved_core_key("type")).to(be_equal_to("v2-type".to_string()));
+    expect!(resolved_core_key("regex")).to(be_equal_to("v2-regex".to_string()));
+    expect!(resolved_core_key("date")).to(be_equal_to("v3-date".to_string()));
+    expect!(resolved_core_key("equality")).to(be_equal_to("v1-equality".to_string()));
+    expect!(resolved_core_key("semver")).to(be_equal_to("v4-semver".to_string()));
+    expect!(resolved_core_key("not-empty")).to(be_equal_to("v4-not-empty".to_string()));
+
+    // Only the whole name after the version prefix counts, so these are distinct rules and not
+    // ambiguous with `type`/`equals-ignore-order`
+    expect!(resolved_core_key("content-type")).to(be_equal_to("v3-content-type".to_string()));
+    expect!(resolved_core_key("min-type")).to(be_equal_to("v2-min-type".to_string()));
+    expect!(resolved_core_key("equals-ignore-order"))
+      .to(be_equal_to("v4-equals-ignore-order".to_string()));
+
+    // The versioned key itself still resolves, by name
+    expect!(resolved_core_key("v2-type")).to(be_equal_to("v2-type".to_string()));
+    expect!(resolved_core_key("core/matcher/v3-date")).to(be_equal_to("v3-date".to_string()));
+    expect!(resolved_core_key("matcher/v3-date")).to(be_equal_to("v3-date".to_string()));
+  }
+
+  #[test]
+  fn resolve_capability_does_not_match_a_key_component_as_a_substring() {
+    // "type" must not name `core/matcher/v2-type` by suffix - if it did, it would match all eight
+    // core keys ending in "type" and be ambiguous. It resolves through the versioned fallback to
+    // exactly one entry instead.
+    expect!(names_catalogue_key("core/matcher/v2-type", "type")).to(be_false());
+    expect!(names_catalogue_key("core/matcher/v2-type", "v2-type")).to(be_true());
+    expect!(names_catalogue_key("core/matcher/v2-type", "matcher/v2-type")).to(be_true());
+    expect!(names_catalogue_key("core/matcher/v2-type", "core/matcher/v2-type")).to(be_true());
+    expect!(names_catalogue_key("core/matcher/v2-type", "r/v2-type")).to(be_false());
+    expect!(names_catalogue_key("core/content-matcher/xml", "xml")).to(be_true());
+    expect!(names_catalogue_key("core/content-matcher/xml", "ml")).to(be_false());
+  }
+
+  #[test]
+  fn resolve_capability_prefers_an_entry_named_directly_over_the_versioned_fallback() {
+    let name = "resolve_capability_prefers_an_entry_named_directly_over_the_versioned_fallback";
+    register_core_entries(&vec![CatalogueEntry {
+      entry_type: CatalogueEntryType::MATCHER,
+      provider_type: CatalogueEntryProviderType::CORE,
+      plugin: None,
+      key: format!("v3-{}", name),
+      values: hashmap!{}
+    }]);
+    // Before the plugin registers anything, the bare name finds the core rule via the fallback
+    let core_first = resolved_core_key(name);
+
+    let manifest = PactPluginManifest { name: name.to_string(), .. PactPluginManifest::default() };
+    register_plugin_entries(&manifest, &vec![ProtoCatalogueEntry {
+      r#type: CatalogueEntryType::MATCHER.to_proto_value(),
+      key: name.to_string(),
+      values: hashmap!{}
+    }]);
+
+    let resolved = resolve_capability(name, CatalogueEntryType::MATCHER);
+    // A caller that specifically wants the core rule can still name its versioned key
+    let still_core = resolved_core_key(&format!("v3-{}", name));
+    remove_plugin_entries(name);
+
+    expect!(core_first).to(be_equal_to(format!("v3-{}", name)));
+    match resolved.expect("expected the plugin's own entry to resolve") {
+      ResolvedCapability::Plugin(resolved_manifest) => expect!(resolved_manifest.name).to(be_equal_to(name.to_string())),
+      ResolvedCapability::Core(key) => panic!("expected the plugin entry to win, got core '{}'", key)
+    };
+    expect!(still_core).to(be_equal_to(format!("v3-{}", name)));
   }
 
   #[test]

--- a/drivers/rust/driver/src/catalogue_manager.rs
+++ b/drivers/rust/driver/src/catalogue_manager.rs
@@ -10,12 +10,13 @@ use maplit::hashset;
 use pact_models::content_types::ContentType;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, instrument, trace};
+use tracing::{debug, error, instrument, trace, warn};
 
 use crate::content::{ContentGenerator, ContentMatcher};
 use crate::plugin_models::PactPluginManifest;
 use crate::proto::catalogue_entry::EntryType;
 use crate::proto::CatalogueEntry as ProtoCatalogueEntry;
+use crate::proto_v2::catalogue_entry::EntryType as EntryTypeV2;
 
 lazy_static! {
   static ref CATALOGUE_REGISTER: Mutex<HashMap<String, CatalogueEntry>> = Mutex::new(HashMap::new());
@@ -31,22 +32,87 @@ pub enum CatalogueEntryType {
   CONTENT_GENERATOR,
   /// Network transport
   TRANSPORT,
-  /// Matching rule
+  /// Matching rule for a content field/value
   MATCHER,
-  /// Generator
-  INTERACTION
+  /// Type of interaction
+  INTERACTION,
+  /// Generator for a content field/value. Only representable on the V2 plugin interface - the V1
+  /// `EntryType` enum has no equivalent. See proposal 006 (Field-level matchers and generators).
+  GENERATOR
 }
 
 impl CatalogueEntryType {
-  /// Return the protobuf type for this entry type
+  /// Return the protobuf type for this entry type.
+  ///
+  /// This maps to the *V1* enum, which cannot represent every entry type: `GENERATOR` has no V1
+  /// equivalent and is reported as `Matcher`. Use [`CatalogueEntryType::to_proto_value`] instead,
+  /// which returns the wire value and is lossless for both interface versions.
+  #[deprecated(
+    since = "1.2.0",
+    note = "Use to_proto_value, which can represent entry types that only exist on the V2 interface"
+  )]
   pub fn to_proto_type(&self) -> EntryType {
     match self {
       CatalogueEntryType::CONTENT_MATCHER => EntryType::ContentMatcher,
       CatalogueEntryType::CONTENT_GENERATOR => EntryType::ContentGenerator,
       CatalogueEntryType::TRANSPORT => EntryType::Transport,
       CatalogueEntryType::MATCHER => EntryType::Matcher,
-      CatalogueEntryType::INTERACTION => EntryType::Interaction
+      CatalogueEntryType::INTERACTION => EntryType::Interaction,
+      CatalogueEntryType::GENERATOR => EntryType::Matcher
     }
+  }
+
+  /// The V2 protobuf enum for this entry type. V2 is the canonical source of the wire values: it
+  /// mirrors V1 for the entry types both versions share, and adds the ones V1 never had.
+  fn to_proto_enum(self) -> EntryTypeV2 {
+    match self {
+      CatalogueEntryType::CONTENT_MATCHER => EntryTypeV2::ContentMatcher,
+      CatalogueEntryType::CONTENT_GENERATOR => EntryTypeV2::ContentGenerator,
+      CatalogueEntryType::TRANSPORT => EntryTypeV2::Transport,
+      CatalogueEntryType::MATCHER => EntryTypeV2::Matcher,
+      CatalogueEntryType::INTERACTION => EntryTypeV2::Interaction,
+      CatalogueEntryType::GENERATOR => EntryTypeV2::Generator
+    }
+  }
+
+  fn from_proto_enum(entry_type: EntryTypeV2) -> CatalogueEntryType {
+    match entry_type {
+      EntryTypeV2::ContentMatcher => CatalogueEntryType::CONTENT_MATCHER,
+      EntryTypeV2::ContentGenerator => CatalogueEntryType::CONTENT_GENERATOR,
+      EntryTypeV2::Transport => CatalogueEntryType::TRANSPORT,
+      EntryTypeV2::Matcher => CatalogueEntryType::MATCHER,
+      EntryTypeV2::Interaction => CatalogueEntryType::INTERACTION,
+      EntryTypeV2::Generator => CatalogueEntryType::GENERATOR
+    }
+  }
+
+  /// The protobuf enum value for this entry type, for setting the `type` field of a
+  /// `CatalogueEntry` message. Lossless for every entry type, including those a V1 plugin will
+  /// not recognise - a V1 plugin decodes an unknown value as an unrecognised enum and ignores the
+  /// entry, which is the correct outcome, whereas mapping it onto some other V1 type would have
+  /// the plugin act on an entry that is not what it thinks it is.
+  pub fn to_proto_value(self) -> i32 {
+    self.to_proto_enum() as i32
+  }
+
+  /// The entry type for a protobuf enum value, or `None` if the value is not one this driver
+  /// understands (an entry type added by a later interface version). Deliberately not defaulting
+  /// to `CONTENT_MATCHER` the way prost's generated accessor does: silently mis-typing an entry
+  /// is worse than ignoring one.
+  pub fn from_proto_value(value: i32) -> Option<CatalogueEntryType> {
+    EntryTypeV2::try_from(value).ok().map(CatalogueEntryType::from_proto_enum)
+  }
+
+  /// The protobuf enum value name for this entry type, e.g. `"CONTENT_MATCHER"`. This is the form
+  /// a Lua plugin uses in the catalogue entries returned from its `init` function.
+  pub fn as_proto_name(&self) -> &'static str {
+    self.to_proto_enum().as_str_name()
+  }
+
+  /// The entry type for a protobuf enum value name, e.g. `"CONTENT_MATCHER"`, or `None` if the
+  /// name is not one this driver understands.
+  pub fn from_proto_name(name: &str) -> Option<CatalogueEntryType> {
+    EntryTypeV2::from_str_name(name).map(CatalogueEntryType::from_proto_enum)
   }
 }
 
@@ -58,6 +124,7 @@ impl Display for CatalogueEntryType {
       CatalogueEntryType::TRANSPORT => write!(f, "transport"),
       CatalogueEntryType::MATCHER => write!(f, "matcher"),
       CatalogueEntryType::INTERACTION => write!(f, "interaction"),
+      CatalogueEntryType::GENERATOR => write!(f, "generator"),
     }
   }
 }
@@ -70,6 +137,7 @@ impl From<&str> for CatalogueEntryType {
       "interaction" => CatalogueEntryType::INTERACTION,
       "matcher" => CatalogueEntryType::MATCHER,
       "transport" => CatalogueEntryType::TRANSPORT,
+      "generator" => CatalogueEntryType::GENERATOR,
       _ => {
         let message = format!("'{}' is not a valid CatalogueEntryType value", s);
         error!("{}", message);
@@ -130,7 +198,20 @@ pub fn register_plugin_entries(plugin: &PactPluginManifest, catalogue_list: &Vec
   let mut guard = CATALOGUE_REGISTER.lock().unwrap();
 
   for entry in catalogue_list {
-    let entry_type = CatalogueEntryType::from(entry.r#type());
+    // Deliberately reading the raw field rather than prost's `entry.r#type()` accessor: the
+    // accessor is generated against the V1 enum and maps anything it doesn't recognise to the
+    // default (`CONTENT_MATCHER`), which would silently register a V2-only entry type - a
+    // `GENERATOR`, say - as a content matcher.
+    let entry_type = match CatalogueEntryType::from_proto_value(entry.r#type) {
+      Some(entry_type) => entry_type,
+      None => {
+        warn!(
+          "Ignoring catalogue entry '{}' from plugin '{}': {} is not a catalogue entry type this driver understands",
+          entry.key, plugin.name, entry.r#type
+        );
+        continue;
+      }
+    };
     let key = format!("plugin/{}/{}/{}", plugin.name, entry_type, entry.key);
     guard.insert(key.clone(), CatalogueEntry {
       entry_type,
@@ -413,6 +494,84 @@ mod tests {
       key: "grpc".to_string(),
       values: hashmap!{}
     }));
+  }
+
+  #[test]
+  fn entry_type_proto_values_and_names_round_trip() {
+    for entry_type in [
+      CatalogueEntryType::CONTENT_MATCHER,
+      CatalogueEntryType::CONTENT_GENERATOR,
+      CatalogueEntryType::TRANSPORT,
+      CatalogueEntryType::MATCHER,
+      CatalogueEntryType::INTERACTION,
+      CatalogueEntryType::GENERATOR
+    ] {
+      expect!(CatalogueEntryType::from_proto_value(entry_type.to_proto_value()))
+        .to(be_some().value(entry_type));
+      expect!(CatalogueEntryType::from_proto_name(entry_type.as_proto_name()))
+        .to(be_some().value(entry_type));
+      // The Display form round-trips too - it is what catalogue keys are built from
+      expect!(CatalogueEntryType::from(entry_type.to_string().as_str())).to(be_equal_to(entry_type));
+    }
+
+    expect!(CatalogueEntryType::from_proto_value(99)).to(be_none());
+    expect!(CatalogueEntryType::from_proto_name("NOT_AN_ENTRY_TYPE")).to(be_none());
+  }
+
+  #[test]
+  fn entry_types_shared_with_v1_keep_their_v1_wire_values() {
+    // The wire values come from the V2 enum, but the driver publishes one catalogue to every
+    // running plugin, V1 ones included - so the values V1 knows about must not shift.
+    expect!(CatalogueEntryType::CONTENT_MATCHER.to_proto_value())
+      .to(be_equal_to(EntryType::ContentMatcher as i32));
+    expect!(CatalogueEntryType::CONTENT_GENERATOR.to_proto_value())
+      .to(be_equal_to(EntryType::ContentGenerator as i32));
+    expect!(CatalogueEntryType::TRANSPORT.to_proto_value())
+      .to(be_equal_to(EntryType::Transport as i32));
+    expect!(CatalogueEntryType::MATCHER.to_proto_value())
+      .to(be_equal_to(EntryType::Matcher as i32));
+    expect!(CatalogueEntryType::INTERACTION.to_proto_value())
+      .to(be_equal_to(EntryType::Interaction as i32));
+  }
+
+  #[test]
+  fn registers_a_generator_entry_under_its_own_entry_type() {
+    let name = "registers_a_generator_entry_under_its_own_entry_type";
+    let manifest = PactPluginManifest { name: name.to_string(), .. PactPluginManifest::default() };
+    // GENERATOR only exists on the V2 enum. This is exactly the case where prost's generated
+    // `entry.r#type()` accessor - built against V1 - would report CONTENT_MATCHER instead.
+    let entries = vec![
+      ProtoCatalogueEntry {
+        r#type: CatalogueEntryType::GENERATOR.to_proto_value(),
+        key: name.to_string(),
+        values: hashmap!{}
+      }
+    ];
+
+    register_plugin_entries(&manifest, &entries);
+
+    let entry = lookup_entry(&format!("generator/{}", name));
+    let as_a_content_matcher = lookup_entry(&format!("content-matcher/{}", name));
+    remove_plugin_entries(name);
+
+    expect!(entry.map(|entry| entry.entry_type)).to(be_some().value(CatalogueEntryType::GENERATOR));
+    expect!(as_a_content_matcher).to(be_none());
+  }
+
+  #[test]
+  fn ignores_a_catalogue_entry_whose_type_this_driver_does_not_understand() {
+    let name = "ignores_a_catalogue_entry_whose_type_this_driver_does_not_understand";
+    let manifest = PactPluginManifest { name: name.to_string(), .. PactPluginManifest::default() };
+    let entries = vec![
+      ProtoCatalogueEntry { r#type: 99, key: name.to_string(), values: hashmap!{} }
+    ];
+
+    register_plugin_entries(&manifest, &entries);
+
+    let registered = all_entries().into_iter().find(|entry| entry.key == name);
+    remove_plugin_entries(name);
+
+    expect!(registered).to(be_none());
   }
 
   #[test]

--- a/drivers/rust/driver/src/core_capabilities.rs
+++ b/drivers/rust/driver/src/core_capabilities.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use lazy_static::lazy_static;
 
 use crate::proto::{CompareContentsRequest, CompareContentsResponse, GenerateContentRequest, GenerateContentResponse};
+use crate::proto_v2::{GenerateFieldRequest, GenerateFieldResponse, MatchFieldRequest, MatchFieldResponse};
 
 /// A host-provided handler for the `CompareContents` capability shape. Implemented by the
 /// embedding Pact framework and registered via [`register_core_content_matcher`].
@@ -25,6 +26,28 @@ use crate::proto::{CompareContentsRequest, CompareContentsResponse, GenerateCont
 pub trait CoreContentMatcher: Send + Sync {
   /// Compare the actual contents against the expected contents, returning any mismatches.
   async fn compare_contents(&self, request: CompareContentsRequest) -> anyhow::Result<CompareContentsResponse>;
+}
+
+/// A host-provided handler for the `MatchField` capability shape - one of the standard Pact
+/// matching rules applied to a single value. Implemented by the embedding Pact framework and
+/// registered via [`register_core_field_matcher`]. See proposals 006 (Field-level matchers and
+/// generators) and 009 (Host-provided core matching and generation).
+///
+/// The request and response are the V2 interface types: field-level operations were introduced in
+/// V2 and have no V1 equivalent.
+#[async_trait]
+pub trait CoreFieldMatcher: Send + Sync {
+  /// Apply the matching rule to a single value, returning any mismatches.
+  async fn match_field(&self, request: MatchFieldRequest) -> anyhow::Result<MatchFieldResponse>;
+}
+
+/// A host-provided handler for the `GenerateField` capability shape - one of the standard Pact
+/// generators applied to a single value. Implemented by the embedding Pact framework and registered
+/// via [`register_core_field_generator`]. See [`CoreFieldMatcher`].
+#[async_trait]
+pub trait CoreFieldGenerator: Send + Sync {
+  /// Generate a single value, replacing the example value from the Pact interaction.
+  async fn generate_field(&self, request: GenerateFieldRequest) -> anyhow::Result<GenerateFieldResponse>;
 }
 
 /// A host-provided handler for the `GenerateContent` capability shape. Implemented by the
@@ -38,6 +61,8 @@ pub trait CoreContentGenerator: Send + Sync {
 lazy_static! {
   static ref CORE_CONTENT_MATCHERS: Mutex<HashMap<String, Arc<dyn CoreContentMatcher>>> = Mutex::new(HashMap::new());
   static ref CORE_CONTENT_GENERATORS: Mutex<HashMap<String, Arc<dyn CoreContentGenerator>>> = Mutex::new(HashMap::new());
+  static ref CORE_FIELD_MATCHERS: Mutex<HashMap<String, Arc<dyn CoreFieldMatcher>>> = Mutex::new(HashMap::new());
+  static ref CORE_FIELD_GENERATORS: Mutex<HashMap<String, Arc<dyn CoreFieldGenerator>>> = Mutex::new(HashMap::new());
 }
 
 /// Register a handler for a host-provided content matcher capability, keyed by the catalogue
@@ -72,6 +97,52 @@ pub fn lookup_core_content_generator(key: &str) -> Option<Arc<dyn CoreContentGen
     .get(key).cloned()
 }
 
+/// Register a handler for a host-provided field matching rule, keyed by the catalogue entry key
+/// (e.g. `"v2-type"` for the `core/matcher/v2-type` entry). Replaces any handler previously
+/// registered under the same key.
+pub fn register_core_field_matcher(key: &str, handler: Arc<dyn CoreFieldMatcher>) {
+  CORE_FIELD_MATCHERS.lock()
+    .expect("CORE_FIELD_MATCHERS mutex poisoned")
+    .insert(key.to_string(), handler);
+}
+
+/// Register a handler for a host-provided field generator, keyed by the catalogue entry key
+/// (e.g. `"v3-date"` for the `core/generator/v3-date` entry). Replaces any handler previously
+/// registered under the same key.
+pub fn register_core_field_generator(key: &str, handler: Arc<dyn CoreFieldGenerator>) {
+  CORE_FIELD_GENERATORS.lock()
+    .expect("CORE_FIELD_GENERATORS mutex poisoned")
+    .insert(key.to_string(), handler);
+}
+
+/// Look up a registered core field matcher handler by catalogue entry key.
+pub fn lookup_core_field_matcher(key: &str) -> Option<Arc<dyn CoreFieldMatcher>> {
+  CORE_FIELD_MATCHERS.lock()
+    .expect("CORE_FIELD_MATCHERS mutex poisoned")
+    .get(key).cloned()
+}
+
+/// Look up a registered core field generator handler by catalogue entry key.
+pub fn lookup_core_field_generator(key: &str) -> Option<Arc<dyn CoreFieldGenerator>> {
+  CORE_FIELD_GENERATORS.lock()
+    .expect("CORE_FIELD_GENERATORS mutex poisoned")
+    .get(key).cloned()
+}
+
+/// Remove a registered core field matcher handler. Mainly useful for tests.
+pub fn deregister_core_field_matcher(key: &str) {
+  CORE_FIELD_MATCHERS.lock()
+    .expect("CORE_FIELD_MATCHERS mutex poisoned")
+    .remove(key);
+}
+
+/// Remove a registered core field generator handler. Mainly useful for tests.
+pub fn deregister_core_field_generator(key: &str) {
+  CORE_FIELD_GENERATORS.lock()
+    .expect("CORE_FIELD_GENERATORS mutex poisoned")
+    .remove(key);
+}
+
 /// Remove a registered core content matcher handler. Mainly useful for tests.
 pub fn deregister_core_content_matcher(key: &str) {
   CORE_CONTENT_MATCHERS.lock()
@@ -91,6 +162,7 @@ mod tests {
   use expectest::prelude::*;
 
   use crate::proto::{CompareContentsRequest, CompareContentsResponse, GenerateContentRequest, GenerateContentResponse};
+  use crate::proto_v2::{GenerateFieldRequest, GenerateFieldResponse, MatchFieldRequest, MatchFieldResponse};
 
   use super::*;
 
@@ -148,5 +220,62 @@ mod tests {
   fn deregister_is_a_no_op_for_an_unknown_key() {
     deregister_core_content_matcher("never-registered");
     deregister_core_content_generator("never-registered");
+    deregister_core_field_matcher("never-registered");
+    deregister_core_field_generator("never-registered");
+  }
+
+  #[derive(Debug)]
+  struct TestFieldMatcher;
+
+  #[async_trait]
+  impl CoreFieldMatcher for TestFieldMatcher {
+    async fn match_field(&self, request: MatchFieldRequest) -> anyhow::Result<MatchFieldResponse> {
+      Ok(MatchFieldResponse { error: request.key, .. MatchFieldResponse::default() })
+    }
+  }
+
+  #[derive(Debug)]
+  struct TestFieldGenerator;
+
+  #[async_trait]
+  impl CoreFieldGenerator for TestFieldGenerator {
+    async fn generate_field(&self, request: GenerateFieldRequest) -> anyhow::Result<GenerateFieldResponse> {
+      Ok(GenerateFieldResponse { error: request.key, .. GenerateFieldResponse::default() })
+    }
+  }
+
+  #[test_log::test]
+  fn returns_none_for_an_unregistered_field_key() {
+    expect!(lookup_core_field_matcher("unregistered-field-matcher-key").is_none()).to(be_true());
+    expect!(lookup_core_field_generator("unregistered-field-generator-key").is_none()).to(be_true());
+  }
+
+  #[test_log::test(tokio::test)]
+  async fn registers_and_looks_up_a_field_matcher() {
+    register_core_field_matcher("test-field-matcher-key", Arc::new(TestFieldMatcher));
+
+    let handler = lookup_core_field_matcher("test-field-matcher-key");
+    deregister_core_field_matcher("test-field-matcher-key");
+
+    expect!(handler.is_some()).to(be_true());
+    let response = handler.unwrap()
+      .match_field(MatchFieldRequest { key: "v2-type".to_string(), .. MatchFieldRequest::default() })
+      .await;
+    // The stub echoes the request key back, so this also proves the request reached the handler
+    expect!(response.unwrap().error).to(be_equal_to("v2-type".to_string()));
+  }
+
+  #[test_log::test(tokio::test)]
+  async fn registers_and_looks_up_a_field_generator() {
+    register_core_field_generator("test-field-generator-key", Arc::new(TestFieldGenerator));
+
+    let handler = lookup_core_field_generator("test-field-generator-key");
+    deregister_core_field_generator("test-field-generator-key");
+
+    expect!(handler.is_some()).to(be_true());
+    let response = handler.unwrap()
+      .generate_field(GenerateFieldRequest { key: "v3-date".to_string(), .. GenerateFieldRequest::default() })
+      .await;
+    expect!(response.unwrap().error).to(be_equal_to("v3-date".to_string()));
   }
 }

--- a/drivers/rust/driver/src/field.rs
+++ b/drivers/rust/driver/src/field.rs
@@ -1,0 +1,863 @@
+//! Support for matching and generating individual field/element values.
+//!
+//! This is the field-level counterpart of [`crate::content`]: where a content matcher owns a whole
+//! content type, a field matcher applies one matching rule to one value inside somebody else's
+//! content - a field in a JSON body, a header, a message metadata value. See proposal 006
+//! (Field-level matchers and generators) for the design.
+//!
+//! The proto types used here are the V2 interface ones. Field-level operations were introduced in
+//! V2 and have no V1 equivalent, so a V1 plugin cannot provide them.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::anyhow;
+use bytes::Bytes;
+use lazy_static::lazy_static;
+use pact_models::matchingrules::MatchingRule;
+use pact_models::path_exp::DocPath;
+use pact_models::prelude::Generator;
+use serde_json::Value;
+use tokio::runtime::Runtime;
+use tracing::{debug, error};
+
+use crate::catalogue_manager::{CatalogueEntry, CatalogueEntryProviderType, CatalogueEntryType, resolve_capability_entry};
+use crate::content::ContentMismatch;
+use crate::core_capabilities;
+use crate::plugin_manager::lookup_plugin;
+use crate::plugin_models::{PactPluginManifest, PluginInteractionConfig};
+use crate::proto_v2::{
+  FieldValue as ProtoFieldValue,
+  GenerateFieldRequest,
+  GenerateFieldResponse,
+  MatchFieldRequest,
+  MatchFieldResponse,
+  MatchingRule as ProtoMatchingRule,
+  Generator as ProtoGenerator,
+  PluginConfiguration as ProtoPluginConfiguration,
+  field_value
+};
+use crate::utils::{proto_value_to_json, to_proto_struct, to_proto_value};
+
+/// A single value being matched or generated at the field/element level - the driver-side
+/// counterpart of the proto `FieldValue`.
+///
+/// Binary-safe by construction: a value that is not representable as text is carried as bytes
+/// rather than being stringified into one. Scalar types survive the trip to a plugin intact,
+/// including the difference between a whole number and a decimal, which the `integer`, `decimal`
+/// and `type` matching rules all depend on - see [`FieldValue::to_proto`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum FieldValue {
+  /// A JSON-like value
+  Json(Value),
+  /// Raw bytes, for a value that is not representable as JSON
+  Binary(Bytes)
+}
+
+impl FieldValue {
+  /// Convert to the protobuf form sent to a plugin or core handler.
+  ///
+  /// Each scalar type gets its own arm, so a matching rule on the other side sees the type the
+  /// value actually has - in particular a whole number stays whole, which `integer`, `decimal` and
+  /// `type` all depend on. Only maps and lists go across as a `google.protobuf.Value`.
+  pub fn to_proto(&self) -> ProtoFieldValue {
+    ProtoFieldValue {
+      value: Some(match self {
+        FieldValue::Binary(bytes) => field_value::Value::BinaryValue(bytes.to_vec()),
+        FieldValue::Json(Value::Null) => field_value::Value::NullValue(0),
+        FieldValue::Json(Value::Bool(value)) => field_value::Value::BooleanValue(*value),
+        FieldValue::Json(Value::String(value)) => field_value::Value::StringValue(value.clone()),
+        FieldValue::Json(Value::Number(number)) => match number.as_i64() {
+          Some(value) => field_value::Value::IntegerValue(value),
+          // A u64 above i64::MAX has nowhere exact to go; a double at least keeps the magnitude
+          None => field_value::Value::DecimalValue(number.as_f64().unwrap_or_default())
+        },
+        FieldValue::Json(value) => field_value::Value::StructuredValue(to_proto_value(value))
+      })
+    }
+  }
+
+  /// Convert from the protobuf form returned by a plugin or core handler. An unset value is
+  /// treated as null, matching how an absent `oneof` reads everywhere else in the interface.
+  pub fn from_proto(value: &ProtoFieldValue) -> FieldValue {
+    match &value.value {
+      Some(field_value::Value::NullValue(_)) | None => FieldValue::Json(Value::Null),
+      Some(field_value::Value::BooleanValue(value)) => FieldValue::Json(Value::Bool(*value)),
+      Some(field_value::Value::StringValue(value)) => FieldValue::Json(Value::String(value.clone())),
+      Some(field_value::Value::IntegerValue(value)) => FieldValue::Json(Value::Number((*value).into())),
+      Some(field_value::Value::DecimalValue(value)) => FieldValue::Json(
+        serde_json::Number::from_f64(*value)
+          .map(Value::Number)
+          // NaN and the infinities have no JSON representation
+          .unwrap_or(Value::Null)
+      ),
+      Some(field_value::Value::BinaryValue(bytes)) => FieldValue::Binary(Bytes::from(bytes.clone())),
+      Some(field_value::Value::StructuredValue(value)) => FieldValue::Json(proto_value_to_json(value))
+    }
+  }
+}
+
+impl From<Value> for FieldValue {
+  fn from(value: Value) -> Self {
+    FieldValue::Json(value)
+  }
+}
+
+impl From<Bytes> for FieldValue {
+  fn from(bytes: Bytes) -> Self {
+    FieldValue::Binary(bytes)
+  }
+}
+
+/// Where a value sits and what is known about it, shared by matching and generation.
+#[derive(Clone, Debug)]
+pub struct FieldContext {
+  /// Path to the value, as a Pact matching rule expression (`$.card.number`)
+  pub path: DocPath,
+  /// Part of the interaction the value came from: `body`, `header`, `metadata`, `query`, `path`,
+  /// `status`. Only affects how a mismatch is reported; generation ignores it.
+  pub category: String,
+  /// Plugin configuration persisted into the Pact file for this interaction
+  pub plugin_config: Option<PluginInteractionConfig>,
+  /// Context data provided by the test framework
+  pub test_context: HashMap<String, Value>
+}
+
+impl Default for FieldContext {
+  fn default() -> Self {
+    FieldContext {
+      path: DocPath::root(),
+      category: "body".to_string(),
+      plugin_config: None,
+      test_context: HashMap::default()
+    }
+  }
+}
+
+impl FieldContext {
+  /// A context for a value at the given path in the given part of the interaction
+  pub fn new(path: &DocPath, category: &str) -> FieldContext {
+    FieldContext {
+      path: path.clone(),
+      category: category.to_string(),
+      .. FieldContext::default()
+    }
+  }
+
+  /// Set the plugin configuration
+  pub fn with_plugin_config(self, plugin_config: Option<PluginInteractionConfig>) -> FieldContext {
+    FieldContext { plugin_config, .. self }
+  }
+
+  /// Set the test framework context data
+  pub fn with_test_context(self, test_context: HashMap<String, Value>) -> FieldContext {
+    FieldContext { test_context, .. self }
+  }
+}
+
+/// Matching rule for a single field/element value, provided by a plugin or by a handler the host
+/// framework registered (see [`crate::core_capabilities::CoreFieldMatcher`]).
+#[derive(Clone, Debug)]
+pub struct FieldMatcher {
+  /// Catalogue entry for this matching rule
+  pub catalogue_entry: CatalogueEntry
+}
+
+/// Generator for a single field/element value. See [`FieldMatcher`].
+#[derive(Clone, Debug)]
+pub struct FieldGenerator {
+  /// Catalogue entry for this generator
+  pub catalogue_entry: CatalogueEntry
+}
+
+/// Find the field-level matching rule with the given name. The name is resolved against the
+/// catalogue the same way any other capability key is - see
+/// [`crate::catalogue_manager::resolve_capability`] - so `creditcard` finds a plugin's own rule and
+/// `type` finds the core `v2-type` rule. Returns a descriptive error if the name matches nothing,
+/// matches more than one rule, or names something that is not a matching rule.
+pub fn find_field_matcher(name: &str) -> anyhow::Result<FieldMatcher> {
+  resolve_capability_entry(name, CatalogueEntryType::MATCHER)
+    .map(|catalogue_entry| FieldMatcher { catalogue_entry })
+}
+
+/// Find the field-level generator with the given name. See [`find_field_matcher`].
+pub fn find_field_generator(name: &str) -> anyhow::Result<FieldGenerator> {
+  resolve_capability_entry(name, CatalogueEntryType::GENERATOR)
+    .map(|catalogue_entry| FieldGenerator { catalogue_entry })
+}
+
+impl FieldMatcher {
+  /// If this is a matching rule provided by the core framework rather than a plugin
+  pub fn is_core(&self) -> bool {
+    self.catalogue_entry.provider_type == CatalogueEntryProviderType::CORE
+  }
+
+  /// Catalogue entry key for this matching rule
+  pub fn catalogue_entry_key(&self) -> String {
+    if self.is_core() {
+      format!("core/matcher/{}", self.catalogue_entry.key)
+    } else {
+      format!("plugin/{}/matcher/{}", self.plugin_name(), self.catalogue_entry.key)
+    }
+  }
+
+  /// Plugin that provides this matching rule, if any
+  pub fn plugin(&self) -> Option<PactPluginManifest> {
+    self.catalogue_entry.plugin.clone()
+  }
+
+  /// Name of the plugin that provides this matching rule
+  pub fn plugin_name(&self) -> String {
+    self.catalogue_entry.plugin.as_ref()
+      .map(|plugin| plugin.name.clone())
+      .unwrap_or("core".to_string())
+  }
+
+  /// Apply this matching rule to a single value.
+  ///
+  /// The context carries where the value lives and which part of the interaction it came from;
+  /// both are echoed back on any mismatch that does not place itself. An empty result means the
+  /// value matched.
+  pub async fn match_field(
+    &self,
+    rule: &MatchingRule,
+    expected: &FieldValue,
+    actual: &FieldValue,
+    context: &FieldContext
+  ) -> Result<(), Vec<ContentMismatch>> {
+    let request = MatchFieldRequest {
+      key: self.catalogue_entry.key.clone(),
+      rule: Some(to_proto_matching_rule(rule)),
+      path: context.path.to_string(),
+      mismatch_type: context.category.clone(),
+      expected: Some(expected.to_proto()),
+      actual: Some(actual.to_proto()),
+      plugin_configuration: context.plugin_config.clone().map(to_proto_plugin_config),
+      test_context: Some(to_proto_struct(&context.test_context))
+    };
+
+    let response = if self.is_core() {
+      match core_capabilities::lookup_core_field_matcher(&self.catalogue_entry.key) {
+        Some(handler) => handler.match_field(request).await,
+        None => Err(anyhow!("No core field matcher registered for '{}'", self.catalogue_entry.key))
+      }
+    } else {
+      self.call_plugin(request).await
+    };
+
+    process_match_field_response(response, context)
+  }
+
+  async fn call_plugin(&self, request: MatchFieldRequest) -> anyhow::Result<MatchFieldResponse> {
+    let manifest = self.catalogue_entry.plugin.as_ref()
+      .ok_or_else(|| anyhow!("Catalogue entry '{}' has no plugin manifest", self.catalogue_entry_key()))?;
+    let plugin = lookup_plugin(&manifest.as_dependency())
+      .ok_or_else(|| anyhow!("Plugin '{}' for matching rule '{}' is not currently running",
+        manifest.name, self.catalogue_entry.key))?;
+    debug!("Sending MatchField request to plugin {:?}", manifest.name);
+    let chain_id = crate::call_chain::new_call_chain_id();
+    let deadline_ms = crate::call_chain::default_deadline_ms();
+    plugin.match_field_with_chain(request, &chain_id, deadline_ms).await
+  }
+
+  /// Apply this matching rule to a single value from a synchronous call path.
+  ///
+  /// Every Rust host applies matching rules synchronously (`match_values` and the matching engine's
+  /// `execute_*_plan` functions), while a plugin call is async, so this bridge exists so each host
+  /// does not have to build its own - see [`block_on_field_call`] for why the obvious ways of doing
+  /// it do not work.
+  pub fn match_field_blocking(
+    &self,
+    rule: &MatchingRule,
+    expected: &FieldValue,
+    actual: &FieldValue,
+    context: &FieldContext
+  ) -> Result<(), Vec<ContentMismatch>> {
+    let matcher = self.clone();
+    let rule = rule.clone();
+    let expected = expected.clone();
+    let actual = actual.clone();
+    let call_context = context.clone();
+
+    block_on_field_call(async move {
+      matcher.match_field(&rule, &expected, &actual, &call_context).await
+    })
+    .unwrap_or_else(|err| Err(vec![mismatch_for(err.to_string(), context)]))
+  }
+}
+
+impl FieldGenerator {
+  /// If this is a generator provided by the core framework rather than a plugin
+  pub fn is_core(&self) -> bool {
+    self.catalogue_entry.provider_type == CatalogueEntryProviderType::CORE
+  }
+
+  /// Catalogue entry key for this generator
+  pub fn catalogue_entry_key(&self) -> String {
+    if self.is_core() {
+      format!("core/generator/{}", self.catalogue_entry.key)
+    } else {
+      format!("plugin/{}/generator/{}", self.plugin_name(), self.catalogue_entry.key)
+    }
+  }
+
+  /// Plugin that provides this generator, if any
+  pub fn plugin(&self) -> Option<PactPluginManifest> {
+    self.catalogue_entry.plugin.clone()
+  }
+
+  /// Name of the plugin that provides this generator
+  pub fn plugin_name(&self) -> String {
+    self.catalogue_entry.plugin.as_ref()
+      .map(|plugin| plugin.name.clone())
+      .unwrap_or("core".to_string())
+  }
+
+  /// Generate a single value, replacing the example value from the Pact interaction.
+  pub async fn generate_field(
+    &self,
+    generator: &Generator,
+    example: &FieldValue,
+    mode: TestMode,
+    context: &FieldContext
+  ) -> anyhow::Result<FieldValue> {
+    let request = GenerateFieldRequest {
+      key: self.catalogue_entry.key.clone(),
+      generator: Some(to_proto_generator(generator)),
+      path: context.path.to_string(),
+      example_value: Some(example.to_proto()),
+      plugin_configuration: context.plugin_config.clone().map(to_proto_plugin_config),
+      test_context: Some(to_proto_struct(&context.test_context)),
+      test_mode: mode.to_proto() as i32
+    };
+
+    let response = if self.is_core() {
+      let handler = core_capabilities::lookup_core_field_generator(&self.catalogue_entry.key)
+        .ok_or_else(|| anyhow!("No core field generator registered for '{}'", self.catalogue_entry.key))?;
+      handler.generate_field(request).await?
+    } else {
+      self.call_plugin(request).await?
+    };
+
+    if !response.error.is_empty() {
+      return Err(anyhow!("Generator '{}' failed: {}", self.catalogue_entry.key, response.error));
+    }
+    match &response.value {
+      Some(value) => Ok(FieldValue::from_proto(value)),
+      None => Err(anyhow!("Generator '{}' returned no value", self.catalogue_entry.key))
+    }
+  }
+
+  async fn call_plugin(&self, request: GenerateFieldRequest) -> anyhow::Result<GenerateFieldResponse> {
+    let manifest = self.catalogue_entry.plugin.as_ref()
+      .ok_or_else(|| anyhow!("Catalogue entry '{}' has no plugin manifest", self.catalogue_entry_key()))?;
+    let plugin = lookup_plugin(&manifest.as_dependency())
+      .ok_or_else(|| anyhow!("Plugin '{}' for generator '{}' is not currently running",
+        manifest.name, self.catalogue_entry.key))?;
+    debug!("Sending GenerateField request to plugin {:?}", manifest.name);
+    let chain_id = crate::call_chain::new_call_chain_id();
+    let deadline_ms = crate::call_chain::default_deadline_ms();
+    plugin.generate_field_with_chain(request, &chain_id, deadline_ms).await
+  }
+
+  /// Generate a single value from a synchronous call path. See
+  /// [`FieldMatcher::match_field_blocking`].
+  pub fn generate_field_blocking(
+    &self,
+    generator: &Generator,
+    example: &FieldValue,
+    mode: TestMode,
+    context: &FieldContext
+  ) -> anyhow::Result<FieldValue> {
+    let field_generator = self.clone();
+    let generator = generator.clone();
+    let example = example.clone();
+    let context = context.clone();
+
+    block_on_field_call(async move {
+      field_generator.generate_field(&generator, &example, mode, &context).await
+    })?
+  }
+}
+
+/// Which side of the test a generator is running on, mirroring `GenerateContentRequest.TestMode`
+/// in the plugin interface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TestMode {
+  /// Running on the consumer side
+  Consumer,
+  /// Running on the provider side
+  Provider,
+  /// Not known
+  Unknown
+}
+
+impl TestMode {
+  fn to_proto(self) -> crate::proto_v2::generate_content_request::TestMode {
+    use crate::proto_v2::generate_content_request::TestMode as ProtoTestMode;
+    match self {
+      TestMode::Consumer => ProtoTestMode::Consumer,
+      TestMode::Provider => ProtoTestMode::Provider,
+      TestMode::Unknown => ProtoTestMode::Unknown
+    }
+  }
+}
+
+lazy_static! {
+  /// Runtime the driver owns for field-level plugin calls made from a synchronous call path.
+  /// Built on first use and never dropped - dropping a Tokio runtime from inside an async context
+  /// panics, and by definition this one is reached from call paths that may be exactly that.
+  static ref FIELD_RUNTIME: Mutex<Option<Arc<Runtime>>> = Mutex::new(None);
+}
+
+fn field_runtime() -> anyhow::Result<Arc<Runtime>> {
+  let mut guard = FIELD_RUNTIME.lock()
+    .map_err(|err| anyhow!("FIELD_RUNTIME mutex poisoned - {}", err))?;
+  match guard.as_ref() {
+    Some(runtime) => Ok(runtime.clone()),
+    None => {
+      let runtime = Arc::new(tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .thread_name("pact-plugin-field")
+        .build()?);
+      *guard = Some(runtime.clone());
+      Ok(runtime)
+    }
+  }
+}
+
+/// Run a field-level plugin call to completion from a synchronous call path.
+///
+/// The obvious approaches do not work. `Handle::current().block_on(..)` panics ("Cannot start a
+/// runtime from within a runtime") because matching is reached from an async call path, so the
+/// calling thread is already driving tasks. `task::block_in_place` re-enters legitimately but
+/// panics on a `current_thread` runtime, and some Pact entry points use one.
+///
+/// So the future runs on a runtime the driver owns, and the calling thread waits on a channel. It
+/// does block a host thread for the duration, which is inherent to bridging sync and async, but the
+/// plugin call itself never depends on the host's runtime making progress: the driver opens a fresh
+/// gRPC channel per call (see `GrpcPactPlugin::connect_channel`), so the connection driving that
+/// call belongs to this runtime too.
+fn block_on_field_call<F, T>(future: F) -> anyhow::Result<T>
+where
+  F: std::future::Future<Output = T> + Send + 'static,
+  T: Send + 'static
+{
+  let runtime = field_runtime()?;
+  let deadline_ms = crate::call_chain::default_deadline_ms();
+  let (sender, receiver) = std::sync::mpsc::channel();
+  runtime.spawn(async move {
+    // A send error just means the caller already gave up waiting
+    let _ = sender.send(future.await);
+  });
+  receiver.recv_timeout(crate::call_chain::remaining(deadline_ms))
+    .map_err(|err| {
+      error!("Timed out waiting for a field-level plugin call to complete - {}", err);
+      anyhow!("Timed out waiting for the plugin call to complete - {}", err)
+    })
+}
+
+fn process_match_field_response(
+  response: anyhow::Result<MatchFieldResponse>,
+  context: &FieldContext
+) -> Result<(), Vec<ContentMismatch>> {
+  let path = context.path.to_string();
+  match response {
+    Ok(response) => if !response.error.is_empty() {
+      Err(vec![mismatch_for(response.error, context)])
+    } else if response.mismatches.is_empty() {
+      Ok(())
+    } else {
+      Err(response.mismatches.iter().map(|mismatch| ContentMismatch {
+        expected: mismatch.expected.as_ref()
+          .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+          .unwrap_or_default(),
+        actual: mismatch.actual.as_ref()
+          .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+          .unwrap_or_default(),
+        mismatch: mismatch.mismatch.clone(),
+        // A mismatch that does not place itself is reported against the value being matched
+        path: if mismatch.path.is_empty() { path.clone() } else { mismatch.path.clone() },
+        diff: if mismatch.diff.is_empty() { None } else { Some(mismatch.diff.clone()) },
+        mismatch_type: if mismatch.mismatch_type.is_empty() {
+          Some(context.category.clone())
+        } else {
+          Some(mismatch.mismatch_type.clone())
+        }
+      }).collect())
+    },
+    Err(err) => {
+      error!("Field-level match call failed - {}", err);
+      Err(vec![mismatch_for(err.to_string(), context)])
+    }
+  }
+}
+
+fn mismatch_for(message: String, context: &FieldContext) -> ContentMismatch {
+  ContentMismatch {
+    expected: Default::default(),
+    actual: Default::default(),
+    mismatch: message,
+    path: context.path.to_string(),
+    diff: None,
+    mismatch_type: Some(context.category.clone())
+  }
+}
+
+fn to_proto_matching_rule(rule: &MatchingRule) -> ProtoMatchingRule {
+  ProtoMatchingRule {
+    r#type: rule.name(),
+    values: Some(to_proto_struct(&rule.values().iter()
+      .map(|(k, v)| (k.to_string(), v.clone()))
+      .collect()))
+  }
+}
+
+fn to_proto_generator(generator: &Generator) -> ProtoGenerator {
+  ProtoGenerator {
+    r#type: generator.name(),
+    values: Some(to_proto_struct(&generator.values().iter()
+      .map(|(k, v)| (k.to_string(), v.clone()))
+      .collect()))
+  }
+}
+
+fn to_proto_plugin_config(config: PluginInteractionConfig) -> ProtoPluginConfiguration {
+  ProtoPluginConfiguration {
+    interaction_configuration: Some(to_proto_struct(&config.interaction_configuration)),
+    pact_configuration: Some(to_proto_struct(&config.pact_configuration))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use async_trait::async_trait;
+  use expectest::prelude::*;
+  use maplit::hashmap;
+  use pact_models::matchingrules::MatchingRule;
+
+  use crate::catalogue_manager::{CatalogueEntryProviderType, register_core_entries};
+  use crate::core_capabilities::{
+    CoreFieldGenerator,
+    CoreFieldMatcher,
+    deregister_core_field_generator,
+    deregister_core_field_matcher,
+    register_core_field_generator,
+    register_core_field_matcher
+  };
+  use crate::proto_v2::ContentMismatch as ProtoContentMismatch;
+
+  use super::*;
+
+  #[test]
+  fn field_values_round_trip_through_the_proto_form() {
+    for value in [
+      FieldValue::Json(Value::String("4111111111111111".to_string())),
+      FieldValue::Json(serde_json::json!(100)),
+      FieldValue::Json(serde_json::json!(-100.5)),
+      FieldValue::Json(Value::Bool(true)),
+      FieldValue::Json(Value::Null),
+      FieldValue::Json(serde_json::json!({ "brand": "visa" })),
+      // A value that is not representable as JSON survives as bytes rather than being stringified
+      FieldValue::Binary(Bytes::from(vec![0u8, 159, 146, 150]))
+    ] {
+      expect!(FieldValue::from_proto(&value.to_proto())).to(be_equal_to(value));
+    }
+  }
+
+  #[test]
+  fn a_whole_number_stays_whole_and_a_decimal_stays_decimal() {
+    // The distinction the `integer`, `decimal` and `type` rules are built on, and the reason
+    // FieldValue does not put every value through a google.protobuf.Value
+    let integer = FieldValue::from_proto(&FieldValue::Json(serde_json::json!(100)).to_proto());
+    let decimal = FieldValue::from_proto(&FieldValue::Json(serde_json::json!(100.5)).to_proto());
+    let whole_decimal = FieldValue::from_proto(&FieldValue::Json(serde_json::json!(100.0)).to_proto());
+
+    expect!(integer.clone()).to(be_equal_to(FieldValue::Json(serde_json::json!(100))));
+    expect!(decimal).to(be_equal_to(FieldValue::Json(serde_json::json!(100.5))));
+    match integer {
+      FieldValue::Json(Value::Number(number)) => expect!(number.is_i64()).to(be_true()),
+      other => panic!("expected a JSON number, got {:?}", other)
+    };
+    // A decimal that happens to be whole stays a decimal - it is not quietly promoted to an
+    // integer, which would make `decimal` reject a value it should accept
+    expect!(whole_decimal.clone()).to(be_equal_to(FieldValue::Json(serde_json::json!(100.0))));
+    match whole_decimal {
+      FieldValue::Json(Value::Number(number)) => expect!(number.is_f64()).to(be_true()),
+      other => panic!("expected a JSON number, got {:?}", other)
+    };
+  }
+
+  #[test]
+  fn each_scalar_type_crosses_the_boundary_under_its_own_arm() {
+    let cases = [
+      (FieldValue::Json(Value::Null), "null"),
+      (FieldValue::Json(Value::Bool(true)), "boolean"),
+      (FieldValue::Json(serde_json::json!("4111111111111111")), "string"),
+      (FieldValue::Json(serde_json::json!(100)), "integer"),
+      (FieldValue::Json(serde_json::json!(100.5)), "decimal"),
+      (FieldValue::Binary(Bytes::from(vec![0u8, 159, 146, 150])), "binary"),
+      (FieldValue::Json(serde_json::json!({ "brand": "visa" })), "structured")
+    ];
+    for (value, expected_arm) in cases {
+      let arm = match value.to_proto().value {
+        Some(field_value::Value::NullValue(_)) => "null",
+        Some(field_value::Value::BooleanValue(_)) => "boolean",
+        Some(field_value::Value::StringValue(_)) => "string",
+        Some(field_value::Value::IntegerValue(_)) => "integer",
+        Some(field_value::Value::DecimalValue(_)) => "decimal",
+        Some(field_value::Value::BinaryValue(_)) => "binary",
+        Some(field_value::Value::StructuredValue(_)) => "structured",
+        None => "unset"
+      };
+      expect!(arm).to(be_equal_to(expected_arm));
+    }
+  }
+
+  #[test]
+  fn an_unset_proto_value_reads_as_json_null() {
+    expect!(FieldValue::from_proto(&ProtoFieldValue { value: None }))
+      .to(be_equal_to(FieldValue::Json(Value::Null)));
+  }
+
+  /// Records the request it was given, and answers with the mismatches it was built with
+  #[derive(Debug)]
+  struct TestCoreMatcher {
+    mismatches: Vec<ProtoContentMismatch>,
+    error: String
+  }
+
+  #[async_trait]
+  impl CoreFieldMatcher for TestCoreMatcher {
+    async fn match_field(&self, request: MatchFieldRequest) -> anyhow::Result<MatchFieldResponse> {
+      // Prove the request carried what the caller passed in
+      assert_eq!(request.path, "$.card.number");
+      assert_eq!(request.mismatch_type, "body");
+      assert_eq!(request.rule.as_ref().unwrap().r#type, "regex");
+      Ok(MatchFieldResponse {
+        error: self.error.clone(),
+        mismatches: self.mismatches.clone()
+      })
+    }
+  }
+
+  #[derive(Debug)]
+  struct TestCoreGenerator;
+
+  #[async_trait]
+  impl CoreFieldGenerator for TestCoreGenerator {
+    async fn generate_field(&self, request: GenerateFieldRequest) -> anyhow::Result<GenerateFieldResponse> {
+      assert_eq!(request.path, "$.card.number");
+      assert_eq!(request.test_mode, TestMode::Consumer.to_proto() as i32);
+      Ok(GenerateFieldResponse {
+        error: String::default(),
+        value: Some(FieldValue::Json(Value::String("4012888888881881".to_string())).to_proto())
+      })
+    }
+  }
+
+  fn register_core_matcher_entry(key: &str, entry_type: CatalogueEntryType) {
+    register_core_entries(&vec![CatalogueEntry {
+      entry_type,
+      provider_type: CatalogueEntryProviderType::CORE,
+      plugin: None,
+      key: key.to_string(),
+      values: hashmap!{}
+    }]);
+  }
+
+  /// The driver forwards whatever rule the host hands it - `rule.name()` and `rule.values()` -
+  /// so any rule exercises the plumbing. Once pact_models grows the `Plugin` carrier variant
+  /// (proposal 006 section 4), a plugin's own rule name arrives here by exactly this path.
+  fn a_rule() -> MatchingRule {
+    MatchingRule::Regex("\\d{16}".to_string())
+  }
+
+  fn field_context() -> FieldContext {
+    FieldContext::new(&DocPath::new("$.card.number").unwrap(), "body")
+  }
+
+  #[test_log::test(tokio::test)]
+  async fn match_field_dispatches_to_a_registered_core_handler() {
+    let key = "match_field_dispatches_to_a_registered_core_handler";
+    register_core_matcher_entry(key, CatalogueEntryType::MATCHER);
+    register_core_field_matcher(key, Arc::new(TestCoreMatcher {
+      mismatches: vec![],
+      error: String::default()
+    }));
+
+    let matcher = find_field_matcher(key).unwrap();
+    let result = matcher.match_field(
+      &a_rule(),
+      &FieldValue::Json(Value::String("4111111111111111".to_string())),
+      &FieldValue::Json(Value::String("4012888888881881".to_string())),
+      &field_context()
+    ).await;
+
+    deregister_core_field_matcher(key);
+
+    expect!(matcher.is_core()).to(be_true());
+    expect!(result).to(be_ok());
+  }
+
+  #[test_log::test(tokio::test)]
+  async fn match_field_reports_mismatches_against_the_requested_path() {
+    let key = "match_field_reports_mismatches_against_the_requested_path";
+    register_core_matcher_entry(key, CatalogueEntryType::MATCHER);
+    register_core_field_matcher(key, Arc::new(TestCoreMatcher {
+      mismatches: vec![ProtoContentMismatch {
+        // Deliberately no path/mismatchType: the driver fills them in from the request
+        mismatch: "fails the Luhn check".to_string(),
+        expected: Some("4111111111111111".as_bytes().to_vec()),
+        actual: Some("4111111111111112".as_bytes().to_vec()),
+        .. ProtoContentMismatch::default()
+      }],
+      error: String::default()
+    }));
+
+    let matcher = find_field_matcher(key).unwrap();
+    let result = matcher.match_field(
+      &a_rule(),
+      &FieldValue::Json(Value::String("4111111111111111".to_string())),
+      &FieldValue::Json(Value::String("4111111111111112".to_string())),
+      &field_context()
+    ).await;
+
+    deregister_core_field_matcher(key);
+
+    let mismatches = result.expect_err("expected a mismatch");
+    expect!(mismatches.len()).to(be_equal_to(1));
+    expect!(mismatches[0].mismatch.clone()).to(be_equal_to("fails the Luhn check".to_string()));
+    expect!(mismatches[0].path.clone()).to(be_equal_to("$.card.number".to_string()));
+    expect!(mismatches[0].mismatch_type.clone()).to(be_some().value("body".to_string()));
+    expect!(mismatches[0].expected.clone()).to(be_equal_to("4111111111111111".to_string()));
+  }
+
+  #[test_log::test(tokio::test)]
+  async fn match_field_turns_a_handler_error_into_a_mismatch() {
+    let key = "match_field_turns_a_handler_error_into_a_mismatch";
+    register_core_matcher_entry(key, CatalogueEntryType::MATCHER);
+    register_core_field_matcher(key, Arc::new(TestCoreMatcher {
+      mismatches: vec![],
+      error: "'amx' is not a brand this plugin knows about".to_string()
+    }));
+
+    let matcher = find_field_matcher(key).unwrap();
+    let result = matcher.match_field(
+      &a_rule(),
+      &FieldValue::Json(Value::String("4111111111111111".to_string())),
+      &FieldValue::Json(Value::String("4111111111111111".to_string())),
+      &field_context()
+    ).await;
+
+    deregister_core_field_matcher(key);
+
+    let mismatches = result.expect_err("expected the error to surface");
+    expect!(mismatches[0].mismatch.clone())
+      .to(be_equal_to("'amx' is not a brand this plugin knows about".to_string()));
+  }
+
+  #[test_log::test(tokio::test)]
+  async fn match_field_fails_clearly_when_no_core_handler_is_registered() {
+    let key = "match_field_fails_clearly_when_no_core_handler_is_registered";
+    register_core_matcher_entry(key, CatalogueEntryType::MATCHER);
+
+    let matcher = find_field_matcher(key).unwrap();
+    let result = matcher.match_field(
+      &a_rule(),
+      &FieldValue::Json(Value::Null),
+      &FieldValue::Json(Value::Null),
+      &field_context()
+    ).await;
+
+    let mismatches = result.expect_err("expected an error for a registered entry with no handler");
+    expect!(mismatches[0].mismatch.contains("No core field matcher registered")).to(be_true());
+  }
+
+  #[test_log::test(tokio::test)]
+  async fn generate_field_dispatches_to_a_registered_core_handler() {
+    let key = "generate_field_dispatches_to_a_registered_core_handler";
+    register_core_matcher_entry(key, CatalogueEntryType::GENERATOR);
+    register_core_field_generator(key, Arc::new(TestCoreGenerator));
+
+    let generator = find_field_generator(key).unwrap();
+    let result = generator.generate_field(
+      &Generator::RandomString(16),
+      &FieldValue::Json(Value::String("4111111111111111".to_string())),
+      TestMode::Consumer,
+      &field_context()
+    ).await;
+
+    deregister_core_field_generator(key);
+
+    expect!(generator.is_core()).to(be_true());
+    expect!(result.unwrap()).to(be_equal_to(
+      FieldValue::Json(Value::String("4012888888881881".to_string()))
+    ));
+  }
+
+  #[test]
+  fn finding_a_rule_that_is_not_registered_says_so() {
+    let err = find_field_matcher("finding_a_rule_that_is_not_registered_says_so")
+      .expect_err("expected an error for an unregistered rule");
+    expect!(err.to_string().contains("No catalogue entry found")).to(be_true());
+  }
+
+  #[test]
+  fn finding_a_rule_that_is_a_generator_says_so() {
+    let key = "finding_a_rule_that_is_a_generator_says_so";
+    register_core_matcher_entry(key, CatalogueEntryType::GENERATOR);
+
+    let err = find_field_matcher(key).expect_err("expected an error for the wrong entry type");
+    expect!(err.to_string().contains("is a GENERATOR, not a MATCHER")).to(be_true());
+  }
+
+  #[test_log::test]
+  fn the_blocking_bridge_runs_a_call_from_a_synchronous_context() {
+    let key = "the_blocking_bridge_runs_a_call_from_a_synchronous_context";
+    register_core_matcher_entry(key, CatalogueEntryType::MATCHER);
+    register_core_field_matcher(key, Arc::new(TestCoreMatcher {
+      mismatches: vec![],
+      error: String::default()
+    }));
+
+    let matcher = find_field_matcher(key).unwrap();
+    let result = matcher.match_field_blocking(
+      &a_rule(),
+      &FieldValue::Json(Value::String("4111111111111111".to_string())),
+      &FieldValue::Json(Value::String("4012888888881881".to_string())),
+      &field_context()
+    );
+
+    deregister_core_field_matcher(key);
+
+    expect!(result).to(be_ok());
+  }
+
+  #[test_log::test(tokio::test(flavor = "multi_thread"))]
+  async fn the_blocking_bridge_works_from_inside_a_runtime() {
+    // The case Handle::block_on panics on: the calling thread is already driving async tasks.
+    // Run it on a blocking thread, which is how a host's synchronous matching path reaches us.
+    let key = "the_blocking_bridge_works_from_inside_a_runtime";
+    register_core_matcher_entry(key, CatalogueEntryType::MATCHER);
+    register_core_field_matcher(key, Arc::new(TestCoreMatcher {
+      mismatches: vec![],
+      error: String::default()
+    }));
+
+    let result = tokio::task::spawn_blocking(move || {
+      let matcher = find_field_matcher(key).unwrap();
+      matcher.match_field_blocking(
+        &a_rule(),
+        &FieldValue::Json(Value::String("4111111111111111".to_string())),
+        &FieldValue::Json(Value::String("4012888888881881".to_string())),
+        &field_context()
+      )
+    }).await.unwrap();
+
+    deregister_core_field_matcher(key);
+
+    expect!(result).to(be_ok());
+  }
+}

--- a/drivers/rust/driver/src/grpc_plugin.rs
+++ b/drivers/rust/driver/src/grpc_plugin.rs
@@ -259,6 +259,72 @@ impl PluginClient {
     }
   }
 
+  async fn match_field(
+    &mut self,
+    request: proto_v2::MatchFieldRequest,
+  ) -> Result<proto_v2::MatchFieldResponse, Status> {
+    match self {
+      PluginClient::V1(_) => Err(Status::unimplemented(
+        "Field-level matching rules require the V2 plugin interface, and this plugin uses V1"
+      )),
+      PluginClient::V2(client) => client
+        .match_field(Request::new(request))
+        .await
+        .map(|response| response.into_inner()),
+    }
+  }
+
+  async fn match_field_with_metadata(
+    &mut self,
+    request: proto_v2::MatchFieldRequest,
+    chain_id: &str,
+    deadline_ms: u64,
+  ) -> Result<proto_v2::MatchFieldResponse, Status> {
+    match self {
+      PluginClient::V1(_) => Err(Status::unimplemented(
+        "Field-level matching rules require the V2 plugin interface, and this plugin uses V1"
+      )),
+      PluginClient::V2(client) => {
+        let mut req = Request::new(request);
+        insert_chain_metadata(&mut req, chain_id, deadline_ms)?;
+        client.match_field(req).await.map(|response| response.into_inner())
+      }
+    }
+  }
+
+  async fn generate_field(
+    &mut self,
+    request: proto_v2::GenerateFieldRequest,
+  ) -> Result<proto_v2::GenerateFieldResponse, Status> {
+    match self {
+      PluginClient::V1(_) => Err(Status::unimplemented(
+        "Field-level generators require the V2 plugin interface, and this plugin uses V1"
+      )),
+      PluginClient::V2(client) => client
+        .generate_field(Request::new(request))
+        .await
+        .map(|response| response.into_inner()),
+    }
+  }
+
+  async fn generate_field_with_metadata(
+    &mut self,
+    request: proto_v2::GenerateFieldRequest,
+    chain_id: &str,
+    deadline_ms: u64,
+  ) -> Result<proto_v2::GenerateFieldResponse, Status> {
+    match self {
+      PluginClient::V1(_) => Err(Status::unimplemented(
+        "Field-level generators require the V2 plugin interface, and this plugin uses V1"
+      )),
+      PluginClient::V2(client) => {
+        let mut req = Request::new(request);
+        insert_chain_metadata(&mut req, chain_id, deadline_ms)?;
+        client.generate_field(req).await.map(|response| response.into_inner())
+      }
+    }
+  }
+
   async fn start_mock_server_v2(
     &mut self,
     request: proto_v2::StartMockServerRequest,
@@ -531,6 +597,48 @@ impl PluginInstance for GrpcPactPlugin {
     let mut client = self.get_plugin_client().await?;
     client
       .generate_content_with_metadata(request, chain_id, deadline_ms)
+      .await
+      .map_err(anyhow::Error::from)
+  }
+
+  async fn match_field(
+    &self,
+    request: proto_v2::MatchFieldRequest,
+  ) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+    let mut client = self.get_plugin_client().await?;
+    client.match_field(request).await.map_err(anyhow::Error::from)
+  }
+
+  async fn match_field_with_chain(
+    &self,
+    request: proto_v2::MatchFieldRequest,
+    chain_id: &str,
+    deadline_ms: u64,
+  ) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+    let mut client = self.get_plugin_client().await?;
+    client
+      .match_field_with_metadata(request, chain_id, deadline_ms)
+      .await
+      .map_err(anyhow::Error::from)
+  }
+
+  async fn generate_field(
+    &self,
+    request: proto_v2::GenerateFieldRequest,
+  ) -> anyhow::Result<proto_v2::GenerateFieldResponse> {
+    let mut client = self.get_plugin_client().await?;
+    client.generate_field(request).await.map_err(anyhow::Error::from)
+  }
+
+  async fn generate_field_with_chain(
+    &self,
+    request: proto_v2::GenerateFieldRequest,
+    chain_id: &str,
+    deadline_ms: u64,
+  ) -> anyhow::Result<proto_v2::GenerateFieldResponse> {
+    let mut client = self.get_plugin_client().await?;
+    client
+      .generate_field_with_metadata(request, chain_id, deadline_ms)
       .await
       .map_err(anyhow::Error::from)
   }

--- a/drivers/rust/driver/src/lib.rs
+++ b/drivers/rust/driver/src/lib.rs
@@ -22,6 +22,7 @@ pub mod grpc_plugin;
 pub(crate) mod plugin_host;
 pub mod content;
 pub mod download;
+pub mod field;
 #[cfg(feature = "lua")]
 pub mod lua_plugin;
 mod metrics;
@@ -30,7 +31,10 @@ pub mod plugin_log_sink;
 pub mod plugin_manager;
 pub mod plugin_models;
 pub mod proto;
-pub(crate) mod proto_v2;
+// Public because the V2-only message types are part of the driver's public API: the field-level
+// operations (proposal 006) have no V1 equivalent, so the embedding Pact framework needs these
+// types to implement `core_capabilities::CoreFieldMatcher`/`CoreFieldGenerator`.
+pub mod proto_v2;
 pub mod repository;
 pub mod test_context;
 pub mod utils;

--- a/drivers/rust/driver/src/lua_plugin.rs
+++ b/drivers/rust/driver/src/lua_plugin.rs
@@ -365,6 +365,27 @@ fn register_host_functions(lua: &Lua, plugin_name: &str, log: &Arc<LuaPluginLog>
     })?,
   )?;
 
+  // The field-level equivalents (proposal 006, "Lua transport"): let a plugin that owns a content
+  // type delegate one value inside it to a standard Pact rule - or to another plugin's rule -
+  // instead of reimplementing it. Async and cycle-free for the same reasons as the two above.
+  globals.set(
+    "host_match_field",
+    lua.create_async_function(move |lua, (entry_key, request): (String, Table)| async move {
+      let request = lua_to_match_field_request(&lua, request).map_err(mlua::Error::external)?;
+      let response = call_host_match_field(&entry_key, request).await.map_err(mlua::Error::external)?;
+      match_field_response_to_lua(&lua, &response)
+    })?,
+  )?;
+
+  globals.set(
+    "host_generate_field",
+    lua.create_async_function(move |lua, (entry_key, request): (String, Table)| async move {
+      let request = lua_to_generate_field_request(&lua, request).map_err(mlua::Error::external)?;
+      let response = call_host_generate_field(&entry_key, request).await.map_err(mlua::Error::external)?;
+      generate_field_response_to_lua(&lua, &response)
+    })?,
+  )?;
+
   Ok(())
 }
 
@@ -411,6 +432,50 @@ async fn call_host_generate_content(
       let chain_id = call_chain::new_call_chain_id();
       let deadline_ms = call_chain::default_deadline_ms();
       plugin.generate_content_with_chain(request, &chain_id, deadline_ms).await
+    }
+  }
+}
+
+/// Resolve `entry_key` to a field-level matching rule and dispatch to it. See
+/// [`call_host_compare_contents`]; backs the `host_match_field` Lua host function.
+async fn call_host_match_field(
+  entry_key: &str,
+  request: proto_v2::MatchFieldRequest
+) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+  match resolve_capability(entry_key, CatalogueEntryType::MATCHER)? {
+    ResolvedCapability::Core(core_key) => {
+      let handler = crate::core_capabilities::lookup_core_field_matcher(&core_key)
+        .ok_or_else(|| anyhow!("No core field matcher registered for '{}'", core_key))?;
+      handler.match_field(request).await
+    }
+    ResolvedCapability::Plugin(manifest) => {
+      let plugin = lookup_plugin(&manifest.as_dependency())
+        .ok_or_else(|| anyhow!("Plugin '{}' for entry '{}' is not currently running", manifest.name, entry_key))?;
+      let chain_id = call_chain::new_call_chain_id();
+      let deadline_ms = call_chain::default_deadline_ms();
+      plugin.match_field_with_chain(request, &chain_id, deadline_ms).await
+    }
+  }
+}
+
+/// Resolve `entry_key` to a field-level generator and dispatch to it. See
+/// [`call_host_compare_contents`]; backs the `host_generate_field` Lua host function.
+async fn call_host_generate_field(
+  entry_key: &str,
+  request: proto_v2::GenerateFieldRequest
+) -> anyhow::Result<proto_v2::GenerateFieldResponse> {
+  match resolve_capability(entry_key, CatalogueEntryType::GENERATOR)? {
+    ResolvedCapability::Core(core_key) => {
+      let handler = crate::core_capabilities::lookup_core_field_generator(&core_key)
+        .ok_or_else(|| anyhow!("No core field generator registered for '{}'", core_key))?;
+      handler.generate_field(request).await
+    }
+    ResolvedCapability::Plugin(manifest) => {
+      let plugin = lookup_plugin(&manifest.as_dependency())
+        .ok_or_else(|| anyhow!("Plugin '{}' for entry '{}' is not currently running", manifest.name, entry_key))?;
+      let chain_id = call_chain::new_call_chain_id();
+      let deadline_ms = call_chain::default_deadline_ms();
+      plugin.generate_field_with_chain(request, &chain_id, deadline_ms).await
     }
   }
 }
@@ -809,17 +874,312 @@ fn lua_to_generate_request(
       generator_map.insert(path, Generator { r#type, values });
     }
   }
-  let test_mode = match test_mode.as_deref() {
-    Some("Consumer") => generate_content_request::TestMode::Consumer,
-    Some("Provider") => generate_content_request::TestMode::Provider,
-    _ => generate_content_request::TestMode::Unknown,
-  };
   Ok(GenerateContentRequest {
     contents: lua_to_body(contents)?,
     generators: generator_map,
-    test_mode: test_mode as i32,
+    test_mode: str_to_test_mode(test_mode.as_deref()),
     .. GenerateContentRequest::default()
   })
+}
+
+/// The test mode name a Lua script sees. The V1 and V2 `GenerateContentRequest.TestMode` enums
+/// have the same values, so one pair of helpers covers content generation on either interface as
+/// well as field-level generation (which is V2-only).
+fn test_mode_to_str(test_mode: i32) -> &'static str {
+  match generate_content_request::TestMode::try_from(test_mode)
+    .unwrap_or(generate_content_request::TestMode::Unknown)
+  {
+    generate_content_request::TestMode::Consumer => "Consumer",
+    generate_content_request::TestMode::Provider => "Provider",
+    generate_content_request::TestMode::Unknown => "Unknown",
+  }
+}
+
+/// Reverse of [`test_mode_to_str`]. Anything unrecognised (including a missing value) is
+/// `Unknown`, rather than an error - the mode is context for the plugin, not a contract.
+fn str_to_test_mode(test_mode: Option<&str>) -> i32 {
+  match test_mode {
+    Some("Consumer") => generate_content_request::TestMode::Consumer as i32,
+    Some("Provider") => generate_content_request::TestMode::Provider as i32,
+    _ => generate_content_request::TestMode::Unknown as i32,
+  }
+}
+
+// ---- MatchField / GenerateField <-> Lua ----
+
+/// Converts a single field value to a plain Lua value, following the convention message metadata
+/// values already use (see [`metadata_to_lua`]): everything crosses as a plain Lua value except
+/// binary data, which arrives as a `{ binary = <lua string> }` wrapper table so a script can tell
+/// a string of text from a blob of bytes.
+///
+/// Lua 5.4 has separate integer and float subtypes, so a whole number stays whole across the
+/// boundary. That distinction is what the `integer`, `decimal` and `type` rules are built on, and
+/// is the reason `FieldValue` has an arm per scalar type in the first place - see proposal 006,
+/// section 5.
+fn field_value_to_lua(lua: &Lua, value: &Option<proto_v2::FieldValue>) -> mlua::Result<Value> {
+  use proto_v2::field_value::Value as FieldValue;
+  match value.as_ref().and_then(|value| value.value.as_ref()) {
+    None | Some(FieldValue::NullValue(_)) => Ok(Value::Nil),
+    Some(FieldValue::BooleanValue(value)) => Ok(Value::Boolean(*value)),
+    Some(FieldValue::StringValue(value)) => Ok(Value::String(lua.create_string(value)?)),
+    Some(FieldValue::IntegerValue(value)) => Ok(Value::Integer(*value)),
+    Some(FieldValue::DecimalValue(value)) => Ok(Value::Number(*value)),
+    Some(FieldValue::BinaryValue(bytes)) => {
+      let wrapper = lua.create_table()?;
+      wrapper.set("binary", lua.create_string(bytes)?)?;
+      Ok(Value::Table(wrapper))
+    }
+    Some(FieldValue::StructuredValue(value)) => lua.to_value(&proto_value_to_json(value)),
+  }
+}
+
+/// Reverse of [`field_value_to_lua`]. A table is a binary wrapper if it has a `binary` key, and a
+/// map or list otherwise - the same test [`lua_to_metadata`] applies.
+fn lua_to_field_value(lua: &Lua, value: Value) -> anyhow::Result<proto_v2::FieldValue> {
+  use proto_v2::field_value::Value as FieldValue;
+  let value = match value {
+    Value::Nil => FieldValue::NullValue(0),
+    Value::Boolean(value) => FieldValue::BooleanValue(value),
+    Value::Integer(value) => FieldValue::IntegerValue(value),
+    Value::Number(value) => FieldValue::DecimalValue(value),
+    Value::String(value) => FieldValue::StringValue(value.to_str()?.to_string()),
+    Value::Table(table) => match table.get::<Option<mlua::String>>("binary")? {
+      Some(binary) => FieldValue::BinaryValue(binary.as_bytes().to_vec()),
+      None => FieldValue::StructuredValue(to_proto_value(&lua.from_value(Value::Table(table))?)),
+    },
+    other => return Err(anyhow!("Expected a field value from Lua, got {}", other.type_name())),
+  };
+  Ok(proto_v2::FieldValue { value: Some(value) })
+}
+
+/// Converts a matching rule or a generator - each is a name plus an optional struct of configured
+/// values - into the `{ type = "...", values = { ... } }` table a script already sees for the
+/// rules and generators passed to `match_contents`/`generate_content`. Always a table, even with
+/// no values, so a script can read `rule.values` without checking `rule` first.
+fn typed_values_to_lua(
+  lua: &Lua,
+  r#type: &str,
+  values: &Option<prost_types::Struct>
+) -> mlua::Result<Table> {
+  let table = lua.create_table()?;
+  table.set("type", r#type.to_string())?;
+  if let Some(values) = values {
+    table.set("values", lua.to_value(&proto_struct_to_json(values))?)?;
+  }
+  Ok(table)
+}
+
+/// Reverse of [`typed_values_to_lua`], returning the name and values separately so the caller can
+/// build either a `MatchingRule` or a `Generator` from them.
+fn lua_to_typed_values(
+  lua: &Lua,
+  table: Option<Table>,
+  what: &str
+) -> anyhow::Result<(String, Option<prost_types::Struct>)> {
+  let table = table.ok_or_else(|| anyhow!("Expected a '{}' table from Lua", what))?;
+  let r#type: String = table.get("type")
+    .map_err(|_| anyhow!("Expected the '{}' table from Lua to have a 'type'", what))?;
+  let values: Option<Value> = table.get("values")?;
+  let values = match values {
+    Some(Value::Nil) | None => None,
+    Some(value) => Some(to_proto_struct(&as_json_map(lua.from_value(value)?))),
+  };
+  Ok((r#type, values))
+}
+
+/// V2's `PluginConfiguration` carries the same two `Struct` fields as the V1 message the rest of
+/// this module converts, so the field-level requests reuse those conversions rather than
+/// duplicating them. The conversion is needed at all only because field-level operations exist
+/// solely on the V2 interface (proposal 006).
+fn v2_plugin_configuration_to_v1(
+  config: &Option<proto_v2::PluginConfiguration>
+) -> Option<PluginConfiguration> {
+  config.as_ref().map(|config| PluginConfiguration {
+    interaction_configuration: config.interaction_configuration.clone(),
+    pact_configuration: config.pact_configuration.clone(),
+  })
+}
+
+/// Reverse of [`v2_plugin_configuration_to_v1`].
+fn v1_plugin_configuration_to_v2(
+  config: Option<PluginConfiguration>
+) -> Option<proto_v2::PluginConfiguration> {
+  config.map(|config| proto_v2::PluginConfiguration {
+    interaction_configuration: config.interaction_configuration,
+    pact_configuration: config.pact_configuration,
+  })
+}
+
+/// See [`v2_plugin_configuration_to_v1`] - `ContentMismatch` is likewise identical between the two
+/// interfaces, so the existing mismatch conversions are reused for the V2-only field messages.
+fn v1_content_mismatch_to_v2(mismatch: ContentMismatch) -> proto_v2::ContentMismatch {
+  proto_v2::ContentMismatch {
+    expected: mismatch.expected,
+    actual: mismatch.actual,
+    mismatch: mismatch.mismatch,
+    path: mismatch.path,
+    diff: mismatch.diff,
+    mismatch_type: mismatch.mismatch_type,
+  }
+}
+
+/// Reverse of [`v1_content_mismatch_to_v2`].
+fn v2_content_mismatch_to_v1(mismatch: &proto_v2::ContentMismatch) -> ContentMismatch {
+  ContentMismatch {
+    expected: mismatch.expected.clone(),
+    actual: mismatch.actual.clone(),
+    mismatch: mismatch.mismatch.clone(),
+    path: mismatch.path.clone(),
+    diff: mismatch.diff.clone(),
+    mismatch_type: mismatch.mismatch_type.clone(),
+  }
+}
+
+/// Builds the request table a plugin's own `match_field(request)` function receives.
+fn match_field_request_to_lua(lua: &Lua, request: &proto_v2::MatchFieldRequest) -> mlua::Result<Table> {
+  let table = lua.create_table()?;
+  table.set("key", request.key.clone())?;
+  let rule = request.rule.clone().unwrap_or_default();
+  table.set("rule", typed_values_to_lua(lua, &rule.r#type, &rule.values)?)?;
+  table.set("path", request.path.clone())?;
+  table.set("mismatch_type", request.mismatch_type.clone())?;
+  table.set("expected", field_value_to_lua(lua, &request.expected)?)?;
+  table.set("actual", field_value_to_lua(lua, &request.actual)?)?;
+  table.set(
+    "plugin_configuration",
+    plugin_configuration_to_lua(lua, &v2_plugin_configuration_to_v1(&request.plugin_configuration))?,
+  )?;
+  table.set("test_context", struct_to_lua(lua, &request.test_context)?)?;
+  Ok(table)
+}
+
+/// Reverse of [`match_field_request_to_lua`] - the table a script builds when calling
+/// `host_match_field(entry_key, request)` is the same shape its own `match_field` receives, so it
+/// can forward the request it was given after adjusting whatever it needs to.
+fn lua_to_match_field_request(lua: &Lua, table: Table) -> anyhow::Result<proto_v2::MatchFieldRequest> {
+  let (r#type, values) = lua_to_typed_values(lua, table.get("rule")?, "rule")?;
+  let plugin_configuration: Option<Value> = table.get("plugin_configuration")?;
+  let test_context: Option<Value> = table.get("test_context")?;
+  Ok(proto_v2::MatchFieldRequest {
+    key: table.get::<Option<String>>("key")?.unwrap_or_default(),
+    rule: Some(proto_v2::MatchingRule { r#type, values }),
+    path: table.get::<Option<String>>("path")?.unwrap_or_default(),
+    mismatch_type: table.get::<Option<String>>("mismatch_type")?.unwrap_or_default(),
+    expected: Some(lua_to_field_value(lua, table.get("expected")?)?),
+    actual: Some(lua_to_field_value(lua, table.get("actual")?)?),
+    plugin_configuration: v1_plugin_configuration_to_v2(
+      lua_to_plugin_configuration(lua, plugin_configuration)?
+    ),
+    test_context: lua_to_struct(lua, test_context)?,
+  })
+}
+
+/// Parses the table a plugin's `match_field` function returns: `{ error = "..." }`, or
+/// `{ mismatches = { ... } }` where each entry is a mismatch table or a bare description string
+/// (the same leniency `match_contents` responses get - see [`lua_value_to_content_mismatches`]).
+/// An absent or empty list means the value matched.
+fn lua_to_match_field_response(table: Table, path: &str) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+  let error: Option<String> = table.get("error")?;
+  if let Some(error) = error {
+    return Ok(proto_v2::MatchFieldResponse { error, mismatches: vec![] });
+  }
+
+  let mismatches: Option<Value> = table.get("mismatches")?;
+  let mismatches = match mismatches {
+    Some(value) => lua_value_to_content_mismatches(path, value)?
+      .into_iter()
+      .map(v1_content_mismatch_to_v2)
+      .collect(),
+    None => vec![],
+  };
+  Ok(proto_v2::MatchFieldResponse { error: String::new(), mismatches })
+}
+
+/// Reverse of [`lua_to_match_field_response`], so a script can return the result of a
+/// `host_match_field` call straight through as its own response.
+fn match_field_response_to_lua(lua: &Lua, response: &proto_v2::MatchFieldResponse) -> mlua::Result<Table> {
+  let table = lua.create_table()?;
+  if !response.error.is_empty() {
+    table.set("error", response.error.clone())?;
+    return Ok(table);
+  }
+  let mismatches: Vec<ContentMismatch> = response.mismatches.iter()
+    .map(v2_content_mismatch_to_v1)
+    .collect();
+  table.set("mismatches", content_mismatches_to_lua(lua, &mismatches)?)?;
+  Ok(table)
+}
+
+/// Builds the request table a plugin's own `generate_field(request)` function receives.
+fn generate_field_request_to_lua(lua: &Lua, request: &proto_v2::GenerateFieldRequest) -> mlua::Result<Table> {
+  let table = lua.create_table()?;
+  table.set("key", request.key.clone())?;
+  let generator = request.generator.clone().unwrap_or_default();
+  table.set("generator", typed_values_to_lua(lua, &generator.r#type, &generator.values)?)?;
+  table.set("path", request.path.clone())?;
+  table.set("example_value", field_value_to_lua(lua, &request.example_value)?)?;
+  table.set(
+    "plugin_configuration",
+    plugin_configuration_to_lua(lua, &v2_plugin_configuration_to_v1(&request.plugin_configuration))?,
+  )?;
+  table.set("test_context", struct_to_lua(lua, &request.test_context)?)?;
+  table.set("test_mode", test_mode_to_str(request.test_mode))?;
+  Ok(table)
+}
+
+/// Reverse of [`generate_field_request_to_lua`] - the table a script passes to
+/// `host_generate_field(entry_key, request)`.
+fn lua_to_generate_field_request(lua: &Lua, table: Table) -> anyhow::Result<proto_v2::GenerateFieldRequest> {
+  let (r#type, values) = lua_to_typed_values(lua, table.get("generator")?, "generator")?;
+  let plugin_configuration: Option<Value> = table.get("plugin_configuration")?;
+  let test_context: Option<Value> = table.get("test_context")?;
+  let test_mode: Option<String> = table.get("test_mode")?;
+  Ok(proto_v2::GenerateFieldRequest {
+    key: table.get::<Option<String>>("key")?.unwrap_or_default(),
+    generator: Some(proto_v2::Generator { r#type, values }),
+    path: table.get::<Option<String>>("path")?.unwrap_or_default(),
+    example_value: Some(lua_to_field_value(lua, table.get("example_value")?)?),
+    plugin_configuration: v1_plugin_configuration_to_v2(
+      lua_to_plugin_configuration(lua, plugin_configuration)?
+    ),
+    test_context: lua_to_struct(lua, test_context)?,
+    test_mode: str_to_test_mode(test_mode.as_deref()),
+  })
+}
+
+/// Parses the table a plugin's `generate_field` function returns: `{ value = ... }` or
+/// `{ error = "..." }`.
+fn lua_to_generate_field_response(lua: &Lua, table: Table) -> anyhow::Result<proto_v2::GenerateFieldResponse> {
+  let error: Option<String> = table.get("error")?;
+  if let Some(error) = error {
+    return Ok(proto_v2::GenerateFieldResponse { error, value: None });
+  }
+  Ok(proto_v2::GenerateFieldResponse {
+    error: String::new(),
+    value: Some(lua_to_field_value(lua, table.get("value")?)?),
+  })
+}
+
+/// Reverse of [`lua_to_generate_field_response`], so a script can return the result of a
+/// `host_generate_field` call straight through as its own response.
+fn generate_field_response_to_lua(lua: &Lua, response: &proto_v2::GenerateFieldResponse) -> mlua::Result<Table> {
+  let table = lua.create_table()?;
+  if !response.error.is_empty() {
+    table.set("error", response.error.clone())?;
+  } else {
+    table.set("value", field_value_to_lua(lua, &response.value)?)?;
+  }
+  Ok(table)
+}
+
+/// Converts a plain Lua value back into a `google.protobuf.Struct`, the reverse of
+/// [`struct_to_lua`]. A `nil` (or a non-map value, which a `Struct` cannot represent) becomes no
+/// struct at all rather than an error.
+fn lua_to_struct(lua: &Lua, value: Option<Value>) -> anyhow::Result<Option<prost_types::Struct>> {
+  match value {
+    None | Some(Value::Nil) => Ok(None),
+    Some(value) => Ok(Some(to_proto_struct(&as_json_map(lua.from_value(value)?)))),
+  }
 }
 
 // ---- ConfigureInteraction <-> Lua ----
@@ -1215,13 +1575,7 @@ impl PluginInstance for LuaPactPlugin {
           }
           generators.set(path.clone(), generator_table)?;
         }
-        let test_mode = match generate_content_request::TestMode::try_from(request.test_mode)
-          .unwrap_or(generate_content_request::TestMode::Unknown)
-        {
-          generate_content_request::TestMode::Consumer => "Consumer",
-          generate_content_request::TestMode::Provider => "Provider",
-          generate_content_request::TestMode::Unknown => "Unknown",
-        };
+        let test_mode = test_mode_to_str(request.test_mode);
         let result: Value = generate_fn
           .call_async((contents, generators, test_mode))
           .await
@@ -1231,6 +1585,50 @@ impl PluginInstance for LuaPactPlugin {
         })
       }
     }
+  }
+
+  /// `match_field` and `generate_field` are optional globals - a plugin only defines them if it
+  /// registered a `MATCHER` or `GENERATOR` catalogue entry. Reaching here without one is a real
+  /// error (the driver resolved an entry the plugin registered), so it is reported rather than
+  /// silently treated as a match.
+  ///
+  /// Called via `call_async` for the same reason as `match_contents`: the script may reach a host
+  /// function, and mlua only allows an async host function to be called from a chain started with
+  /// `call_async`.
+  async fn match_field(
+    &self,
+    request: proto_v2::MatchFieldRequest,
+  ) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+    let lua = self.runtime.lock().await;
+    let match_fn: Function = lua
+      .globals()
+      .get("match_field")
+      .map_err(|_| anyhow!("Lua plugin does not define a global 'match_field' function"))?;
+    let path = request.path.clone();
+    let request_table = match_field_request_to_lua(&lua, &request)?;
+    let result: Table = match_fn
+      .call_async(request_table)
+      .await
+      .map_err(|err| anyhow!("Lua match_field() function failed - {}", err))?;
+    lua_to_match_field_response(result, &path)
+  }
+
+  /// See [`LuaPactPlugin::match_field`].
+  async fn generate_field(
+    &self,
+    request: proto_v2::GenerateFieldRequest,
+  ) -> anyhow::Result<proto_v2::GenerateFieldResponse> {
+    let lua = self.runtime.lock().await;
+    let generate_fn: Function = lua
+      .globals()
+      .get("generate_field")
+      .map_err(|_| anyhow!("Lua plugin does not define a global 'generate_field' function"))?;
+    let request_table = generate_field_request_to_lua(&lua, &request)?;
+    let result: Table = generate_fn
+      .call_async(request_table)
+      .await
+      .map_err(|err| anyhow!("Lua generate_field() function failed - {}", err))?;
+    lua_to_generate_field_response(&lua, result)
   }
 
   async fn start_mock_server(
@@ -2347,6 +2745,447 @@ mod tests {
       result.is_err(),
       "expected a wrong-typed 'path' field (a table, not a string) to be a hard error, not silently default, got {:?}",
       result
+    );
+  }
+
+  // ---- Field-level matchers and generators (proposal 006) ----
+
+  fn creditcard_manifest() -> PactPluginManifest {
+    // See jwt_manifest() for why this path is deliberately not canonicalized.
+    let plugin_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../plugins/creditcard");
+    assert!(plugin_dir.exists(), "plugins/creditcard directory should exist at {:?}", plugin_dir);
+    PactPluginManifest {
+      plugin_dir: plugin_dir.to_string_lossy().to_string(),
+      plugin_interface_version: 2,
+      name: "creditcard".to_string(),
+      version: "0.0.0".to_string(),
+      executable_type: "lua".to_string(),
+      minimum_required_version: None,
+      entry_point: "plugin.lua".to_string(),
+      entry_points: HashMap::new(),
+      args: None,
+      dependencies: None,
+      plugin_config: HashMap::new(),
+    }
+  }
+
+  fn text_field(value: &str) -> proto_v2::FieldValue {
+    proto_v2::FieldValue {
+      value: Some(proto_v2::field_value::Value::StringValue(value.to_string()))
+    }
+  }
+
+  /// A `MatchFieldRequest` for the `creditcard` rule, optionally configured with a brand.
+  fn creditcard_match_request(brand: Option<&str>, expected: &str, actual: &str) -> proto_v2::MatchFieldRequest {
+    let values = brand.map(|brand| {
+      let mut fields = HashMap::new();
+      fields.insert("brand".to_string(), serde_json::Value::String(brand.to_string()));
+      to_proto_struct(&fields)
+    });
+    proto_v2::MatchFieldRequest {
+      key: "creditcard".to_string(),
+      rule: Some(proto_v2::MatchingRule { r#type: "creditcard".to_string(), values }),
+      path: "$.card.number".to_string(),
+      mismatch_type: "body".to_string(),
+      expected: Some(text_field(expected)),
+      actual: Some(text_field(actual)),
+      plugin_configuration: None,
+      test_context: None,
+    }
+  }
+
+  fn creditcard_generate_request(brand: Option<&str>, example: &str) -> proto_v2::GenerateFieldRequest {
+    let values = brand.map(|brand| {
+      let mut fields = HashMap::new();
+      fields.insert("brand".to_string(), serde_json::Value::String(brand.to_string()));
+      to_proto_struct(&fields)
+    });
+    proto_v2::GenerateFieldRequest {
+      key: "creditcard".to_string(),
+      generator: Some(proto_v2::Generator { r#type: "creditcard".to_string(), values }),
+      path: "$.card.number".to_string(),
+      example_value: Some(text_field(example)),
+      plugin_configuration: None,
+      test_context: None,
+      test_mode: proto_v2::generate_content_request::TestMode::Consumer as i32,
+    }
+  }
+
+  #[tokio::test]
+  async fn creditcard_plugin_registers_a_matcher_and_a_generator_under_the_same_key() {
+    let manifest = creditcard_manifest();
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+    let lua = plugin.runtime.lock().await;
+    let entries = call_init(&lua, "test", "0.0.0").unwrap();
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].key, "creditcard");
+    assert_eq!(entries[0].r#type, proto_v2::catalogue_entry::EntryType::Matcher as i32);
+    assert_eq!(entries[1].key, "creditcard");
+    assert_eq!(entries[1].r#type, proto_v2::catalogue_entry::EntryType::Generator as i32);
+    // The values key that maps a single positional config argument in a rule definition
+    assert_eq!(entries[0].values.get("config-key"), Some(&"brand".to_string()));
+  }
+
+  #[tokio::test]
+  async fn creditcard_plugin_accepts_a_valid_card_number() {
+    let plugin = start_lua_plugin(&creditcard_manifest(), "test-instance".to_string()).unwrap();
+
+    let response = plugin
+      .match_field(creditcard_match_request(Some("visa"), "4111111111111111", "4012888888881881"))
+      .await
+      .unwrap();
+
+    assert_eq!(response.error, "");
+    assert!(response.mismatches.is_empty(), "expected no mismatches, got {:?}", response.mismatches);
+  }
+
+  #[tokio::test]
+  async fn creditcard_plugin_reports_a_number_that_fails_the_luhn_check() {
+    let plugin = start_lua_plugin(&creditcard_manifest(), "test-instance".to_string()).unwrap();
+
+    let response = plugin
+      .match_field(creditcard_match_request(None, "4111111111111111", "4111111111111112"))
+      .await
+      .unwrap();
+
+    assert_eq!(response.error, "");
+    assert_eq!(response.mismatches.len(), 1);
+    let mismatch = &response.mismatches[0];
+    assert!(
+      mismatch.mismatch.contains("Luhn check"),
+      "unexpected mismatch description: {}", mismatch.mismatch
+    );
+    // The plugin places its own mismatches, echoing back the path and part it was given
+    assert_eq!(mismatch.path, "$.card.number");
+    assert_eq!(mismatch.mismatch_type, "body");
+    assert_eq!(mismatch.expected.as_deref(), Some("4111111111111111".as_bytes()));
+    assert_eq!(mismatch.actual.as_deref(), Some("4111111111111112".as_bytes()));
+  }
+
+  #[tokio::test]
+  async fn creditcard_plugin_reports_a_number_from_the_wrong_brand() {
+    let plugin = start_lua_plugin(&creditcard_manifest(), "test-instance".to_string()).unwrap();
+
+    // A valid Visa number, but the rule asks for a Mastercard
+    let response = plugin
+      .match_field(creditcard_match_request(Some("mastercard"), "5555555555554444", "4012888888881881"))
+      .await
+      .unwrap();
+
+    assert_eq!(response.mismatches.len(), 1);
+    assert!(
+      response.mismatches[0].mismatch.contains("Mastercard"),
+      "unexpected mismatch description: {}", response.mismatches[0].mismatch
+    );
+  }
+
+  #[tokio::test]
+  async fn creditcard_plugin_reports_a_misconfigured_brand_as_an_error_not_a_mismatch() {
+    // The test author's mistake, not the provider's - so it fails the test outright rather than
+    // being reported as the provider sending the wrong value.
+    let plugin = start_lua_plugin(&creditcard_manifest(), "test-instance".to_string()).unwrap();
+
+    let response = plugin
+      .match_field(creditcard_match_request(Some("amx"), "4111111111111111", "4111111111111111"))
+      .await
+      .unwrap();
+
+    assert!(
+      response.error.contains("'amx' is not a credit card brand"),
+      "unexpected error: {}", response.error
+    );
+    assert!(response.mismatches.is_empty());
+  }
+
+  #[tokio::test]
+  async fn creditcard_plugin_generates_a_number_for_the_configured_brand() {
+    let plugin = start_lua_plugin(&creditcard_manifest(), "test-instance".to_string()).unwrap();
+
+    let response = plugin
+      .generate_field(creditcard_generate_request(Some("amex"), "4111111111111111"))
+      .await
+      .unwrap();
+
+    assert_eq!(response.error, "");
+    let generated = match response.value.and_then(|value| value.value) {
+      Some(proto_v2::field_value::Value::StringValue(value)) => value,
+      other => panic!("expected a generated string value, got {:?}", other)
+    };
+    assert_eq!(generated.len(), 15, "an Amex number has 15 digits, got '{}'", generated);
+    assert!(generated.starts_with("34") || generated.starts_with("37"), "got '{}'", generated);
+
+    // And the number it generated is one it will accept back
+    let match_response = plugin
+      .match_field(creditcard_match_request(Some("amex"), "371449635398431", &generated))
+      .await
+      .unwrap();
+    assert!(
+      match_response.mismatches.is_empty(),
+      "the plugin should accept its own generated number, got {:?}", match_response.mismatches
+    );
+  }
+
+  #[tokio::test]
+  async fn creditcard_plugin_reports_a_generator_error() {
+    let plugin = start_lua_plugin(&creditcard_manifest(), "test-instance".to_string()).unwrap();
+
+    let response = plugin
+      .generate_field(creditcard_generate_request(Some("amx"), "4111111111111111"))
+      .await
+      .unwrap();
+
+    assert!(response.error.contains("amx"), "unexpected error: {}", response.error);
+    assert!(response.value.is_none());
+  }
+
+  /// Starts a Lua plugin whose entry point is the given script source.
+  fn start_field_plugin(name: &str, script: &str) -> (tempdir::TempDir, LuaPactPlugin) {
+    let plugin_dir = tempdir::TempDir::new("lua-plugin-test").unwrap();
+    std::fs::write(plugin_dir.path().join("entry.lua"), script).unwrap();
+    let manifest = lua_manifest(plugin_dir.path(), name);
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+    // The temp dir is returned so it outlives the plugin - dropping it deletes the script
+    (plugin_dir, plugin)
+  }
+
+  #[tokio::test]
+  async fn each_field_value_type_survives_the_round_trip_through_lua() {
+    use proto_v2::field_value::Value as FieldValue;
+
+    let (_dir, plugin) = start_field_plugin(
+      "field-value-round-trip-test",
+      r#"
+        function generate_field(request)
+          return { value = request.example_value }
+        end
+      "#,
+    );
+
+    let values = vec![
+      FieldValue::NullValue(0),
+      FieldValue::BooleanValue(true),
+      FieldValue::StringValue("4111111111111111".to_string()),
+      FieldValue::IntegerValue(100),
+      FieldValue::DecimalValue(100.5),
+      FieldValue::BinaryValue(vec![0, 159, 146, 150]),
+    ];
+
+    for value in values {
+      let request = proto_v2::GenerateFieldRequest {
+        generator: Some(proto_v2::Generator::default()),
+        example_value: Some(proto_v2::FieldValue { value: Some(value.clone()) }),
+        .. proto_v2::GenerateFieldRequest::default()
+      };
+      let response = plugin.generate_field(request).await.unwrap();
+      assert_eq!(
+        response.value.and_then(|response| response.value), Some(value.clone()),
+        "{:?} did not survive the round trip through Lua", value
+      );
+    }
+  }
+
+  #[tokio::test]
+  async fn a_whole_number_reaches_lua_as_an_integer_and_a_decimal_as_a_float() {
+    // The distinction the integer, decimal and type rules are built on. Lua 5.4 has separate
+    // integer and float subtypes, so it can be checked from inside the script itself.
+    let (_dir, plugin) = start_field_plugin(
+      "field-value-lua-type-test",
+      r#"
+        function generate_field(request)
+          return { value = math.type(request.example_value) }
+        end
+      "#,
+    );
+
+    let lua_type_of = async |value: proto_v2::field_value::Value| {
+      let request = proto_v2::GenerateFieldRequest {
+        example_value: Some(proto_v2::FieldValue { value: Some(value) }),
+        .. proto_v2::GenerateFieldRequest::default()
+      };
+      match plugin.generate_field(request).await.unwrap().value.and_then(|value| value.value) {
+        Some(proto_v2::field_value::Value::StringValue(value)) => value,
+        other => panic!("expected math.type() to return a string, got {:?}", other)
+      }
+    };
+
+    assert_eq!(lua_type_of(proto_v2::field_value::Value::IntegerValue(100)).await, "integer");
+    assert_eq!(lua_type_of(proto_v2::field_value::Value::DecimalValue(100.0)).await, "float");
+  }
+
+  #[tokio::test]
+  async fn a_mismatch_that_does_not_place_itself_is_reported_against_the_request_path() {
+    let (_dir, plugin) = start_field_plugin(
+      "field-mismatch-path-test",
+      r#"
+        function match_field(request)
+          return { mismatches = { "not a card number" } }
+        end
+      "#,
+    );
+
+    let response = plugin
+      .match_field(creditcard_match_request(None, "4111111111111111", "nope"))
+      .await
+      .unwrap();
+
+    assert_eq!(response.mismatches.len(), 1);
+    assert_eq!(response.mismatches[0].mismatch, "not a card number");
+    assert_eq!(response.mismatches[0].path, "$.card.number");
+  }
+
+  #[tokio::test]
+  async fn a_plugin_that_does_not_define_the_field_functions_says_so() {
+    let (_dir, plugin) = start_field_plugin("field-functions-missing-test", "-- nothing here");
+
+    let match_error = plugin.match_field(proto_v2::MatchFieldRequest::default()).await
+      .expect_err("expected an error when the plugin does not define match_field");
+    assert!(
+      match_error.to_string().contains("does not define a global 'match_field' function"),
+      "unexpected error: {}", match_error
+    );
+
+    let generate_error = plugin.generate_field(proto_v2::GenerateFieldRequest::default()).await
+      .expect_err("expected an error when the plugin does not define generate_field");
+    assert!(
+      generate_error.to_string().contains("does not define a global 'generate_field' function"),
+      "unexpected error: {}", generate_error
+    );
+  }
+
+  fn core_field_matcher_entry(key: &str) -> crate::catalogue_manager::CatalogueEntry {
+    crate::catalogue_manager::CatalogueEntry {
+      entry_type: crate::catalogue_manager::CatalogueEntryType::MATCHER,
+      provider_type: crate::catalogue_manager::CatalogueEntryProviderType::CORE,
+      plugin: None,
+      key: key.to_string(),
+      values: HashMap::new()
+    }
+  }
+
+  fn core_field_generator_entry(key: &str) -> crate::catalogue_manager::CatalogueEntry {
+    crate::catalogue_manager::CatalogueEntry {
+      entry_type: crate::catalogue_manager::CatalogueEntryType::GENERATOR,
+      provider_type: crate::catalogue_manager::CatalogueEntryProviderType::CORE,
+      plugin: None,
+      key: key.to_string(),
+      values: HashMap::new()
+    }
+  }
+
+  /// A core field matcher that reports what it was handed, so the test can check the request the
+  /// script built actually arrived intact.
+  struct EchoCoreFieldMatcher;
+
+  #[async_trait]
+  impl crate::core_capabilities::CoreFieldMatcher for EchoCoreFieldMatcher {
+    async fn match_field(&self, request: proto_v2::MatchFieldRequest) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+      let rule = request.rule.unwrap_or_default();
+      Ok(proto_v2::MatchFieldResponse {
+        error: String::new(),
+        mismatches: vec![proto_v2::ContentMismatch {
+          expected: None,
+          actual: None,
+          mismatch: format!("core matcher saw rule '{}' at {}", rule.r#type, request.path),
+          path: request.path,
+          diff: String::new(),
+          mismatch_type: request.mismatch_type,
+        }]
+      })
+    }
+  }
+
+  #[tokio::test]
+  async fn match_field_calls_host_match_field_for_a_registered_core_capability() {
+    // A plugin that owns a content type delegating one value inside it to a standard Pact rule,
+    // rather than reimplementing it - the point of the host callbacks (proposal 006 section 7).
+    let key = "match_field_calls_host_match_field_for_a_registered_core_capability";
+    crate::catalogue_manager::register_core_entries(&vec![core_field_matcher_entry(key)]);
+    crate::core_capabilities::register_core_field_matcher(key, Arc::new(EchoCoreFieldMatcher));
+
+    let (_dir, plugin) = start_field_plugin(
+      "host-match-field-test",
+      &format!(r#"
+        function match_field(request)
+          return host_match_field("{key}", request)
+        end
+      "#, key = key),
+    );
+
+    let response = plugin
+      .match_field(creditcard_match_request(Some("visa"), "4111111111111111", "4012888888881881"))
+      .await
+      .unwrap();
+
+    crate::core_capabilities::deregister_core_field_matcher(key);
+
+    assert_eq!(response.mismatches.len(), 1);
+    assert_eq!(
+      response.mismatches[0].mismatch,
+      "core matcher saw rule 'creditcard' at $.card.number"
+    );
+    assert_eq!(response.mismatches[0].mismatch_type, "body");
+  }
+
+  #[tokio::test]
+  async fn host_match_field_surfaces_a_clear_error_when_the_entry_is_not_registered() {
+    let key = "host_match_field_surfaces_a_clear_error_when_the_entry_is_not_registered";
+    let (_dir, plugin) = start_field_plugin(
+      "host-match-field-missing-test",
+      &format!(r#"
+        function match_field(request)
+          return host_match_field("{key}", request)
+        end
+      "#, key = key),
+    );
+
+    let err = plugin.match_field(creditcard_match_request(None, "4111111111111111", "4111111111111111"))
+      .await
+      .expect_err("expected an error when the target entry is not registered");
+    assert!(
+      err.to_string().contains("No catalogue entry found"),
+      "unexpected error message: {}", err
+    );
+  }
+
+  struct FixedCoreFieldGenerator;
+
+  #[async_trait]
+  impl crate::core_capabilities::CoreFieldGenerator for FixedCoreFieldGenerator {
+    async fn generate_field(&self, _request: proto_v2::GenerateFieldRequest) -> anyhow::Result<proto_v2::GenerateFieldResponse> {
+      Ok(proto_v2::GenerateFieldResponse {
+        error: String::new(),
+        value: Some(text_field("generated by the host"))
+      })
+    }
+  }
+
+  #[tokio::test]
+  async fn generate_field_calls_host_generate_field_for_a_registered_core_capability() {
+    let key = "generate_field_calls_host_generate_field_for_a_registered_core_capability";
+    crate::catalogue_manager::register_core_entries(&vec![core_field_generator_entry(key)]);
+    crate::core_capabilities::register_core_field_generator(key, Arc::new(FixedCoreFieldGenerator));
+
+    let (_dir, plugin) = start_field_plugin(
+      "host-generate-field-test",
+      &format!(r#"
+        function generate_field(request)
+          return host_generate_field("{key}", request)
+        end
+      "#, key = key),
+    );
+
+    let response = plugin
+      .generate_field(creditcard_generate_request(Some("visa"), "4111111111111111"))
+      .await
+      .unwrap();
+
+    crate::core_capabilities::deregister_core_field_generator(key);
+
+    assert_eq!(response.error, "");
+    assert_eq!(
+      response.value.and_then(|value| value.value),
+      Some(proto_v2::field_value::Value::StringValue("generated by the host".to_string()))
     );
   }
 }

--- a/drivers/rust/driver/src/lua_plugin.rs
+++ b/drivers/rust/driver/src/lua_plugin.rs
@@ -57,7 +57,7 @@ use mlua::{Function, Lua, LuaSerdeExt, Table, Value, Variadic};
 use rsa::pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPublicKey, LineEnding};
 use rsa::{Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey};
 use sha2::{Digest, Sha512};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::call_chain;
 use crate::catalogue_manager::{CatalogueEntryType, ResolvedCapability, resolve_capability};
@@ -446,10 +446,10 @@ fn lua_table_to_catalogue_entries(table: Table) -> anyhow::Result<Vec<CatalogueE
     let entry_type_str: String = entry.get("entryType")?;
     let key: String = entry.get("key")?;
     let values: Option<HashMap<String, String>> = entry.get("values")?;
-    let entry_type = catalogue_entry::EntryType::from_str_name(&entry_type_str)
+    let entry_type = CatalogueEntryType::from_proto_name(&entry_type_str)
       .ok_or_else(|| anyhow!("Unknown catalogue entry type '{}'", entry_type_str))?;
     entries.push(CatalogueEntry {
-      r#type: entry_type as i32,
+      r#type: entry_type.to_proto_value(),
       key,
       values: values.unwrap_or_default(),
     });
@@ -1403,9 +1403,14 @@ impl PluginInstance for LuaPactPlugin {
       let table = lua.create_table()?;
       for entry in &request.catalogue {
         let entry_table = lua.create_table()?;
-        let entry_type = catalogue_entry::EntryType::try_from(entry.r#type)
-          .unwrap_or(catalogue_entry::EntryType::ContentMatcher);
-        entry_table.set("entryType", entry_type.as_str_name())?;
+        // An entry type this driver doesn't understand is skipped rather than passed to the
+        // script as some other type it isn't - see `register_plugin_entries`.
+        let Some(entry_type) = CatalogueEntryType::from_proto_value(entry.r#type) else {
+          warn!("Not passing catalogue entry '{}' to the plugin: {} is not a catalogue entry type this driver understands",
+            entry.key, entry.r#type);
+          continue;
+        };
+        entry_table.set("entryType", entry_type.as_proto_name())?;
         entry_table.set("key", entry.key.clone())?;
         entry_table.set("values", entry.values.clone())?;
         table.push(entry_table)?;
@@ -1648,6 +1653,56 @@ mod tests {
     assert_eq!(entries[0].key, "jwt");
     assert_eq!(entries[0].r#type, catalogue_entry::EntryType::ContentMatcher as i32);
     assert_eq!(entries[1].r#type, catalogue_entry::EntryType::ContentGenerator as i32);
+  }
+
+  #[tokio::test]
+  async fn init_accepts_matcher_and_generator_catalogue_entries() {
+    // A field-level plugin registers MATCHER/GENERATOR entries rather than content ones. GENERATOR
+    // only exists on the V2 enum, so this also covers the entry type surviving the trip through
+    // the V1-shaped CatalogueEntry message the driver uses internally.
+    let plugin_dir = tempdir::TempDir::new("lua-plugin-test").unwrap();
+    std::fs::write(
+      plugin_dir.path().join("entry.lua"),
+      r#"
+        function init(implementation, version)
+          return {
+            { entryType = "MATCHER", key = "creditcard", values = { ["config-key"] = "brand" } },
+            { entryType = "GENERATOR", key = "creditcard" }
+          }
+        end
+      "#,
+    ).unwrap();
+
+    let manifest = lua_manifest(plugin_dir.path(), "field-entries-test");
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+    let lua = plugin.runtime.lock().await;
+    let entries = call_init(&lua, "test", "0.0.0").unwrap();
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].key, "creditcard");
+    assert_eq!(entries[0].r#type, CatalogueEntryType::MATCHER.to_proto_value());
+    assert_eq!(entries[0].values.get("config-key"), Some(&"brand".to_string()));
+    assert_eq!(entries[1].r#type, CatalogueEntryType::GENERATOR.to_proto_value());
+  }
+
+  #[tokio::test]
+  async fn init_rejects_an_unknown_catalogue_entry_type() {
+    let plugin_dir = tempdir::TempDir::new("lua-plugin-test").unwrap();
+    std::fs::write(
+      plugin_dir.path().join("entry.lua"),
+      r#"
+        function init(implementation, version)
+          return { { entryType = "NOT_AN_ENTRY_TYPE", key = "nope" } }
+        end
+      "#,
+    ).unwrap();
+
+    let manifest = lua_manifest(plugin_dir.path(), "bad-entry-type-test");
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+    let lua = plugin.runtime.lock().await;
+
+    let error = call_init(&lua, "test", "0.0.0").unwrap_err().to_string();
+    assert!(error.contains("NOT_AN_ENTRY_TYPE"), "unexpected error: {}", error);
   }
 
   #[tokio::test]

--- a/drivers/rust/driver/src/plugin_host.rs
+++ b/drivers/rust/driver/src/plugin_host.rs
@@ -13,8 +13,9 @@ use crate::catalogue_manager::{CatalogueEntryType, ResolvedCapability, resolve_c
 use crate::grpc_plugin::PluginClient;
 use crate::plugin_log_sink::{PluginLogEntry, PluginLogSource, emit_plugin_log};
 use crate::proto_v2::{
-  CompareContentsResponse, GenerateContentResponse, HostCompareContentsRequest,
-  HostGenerateContentRequest, LogMessage, plugin_host_server,
+  CompareContentsResponse, GenerateContentResponse, GenerateFieldResponse,
+  HostCompareContentsRequest, HostGenerateContentRequest, HostGenerateFieldRequest,
+  HostMatchFieldRequest, LogMessage, MatchFieldResponse, plugin_host_server,
 };
 
 static PLUGIN_HOST_PORT: OnceLock<u16> = OnceLock::new();
@@ -112,6 +113,34 @@ impl plugin_host_server::PluginHost for PluginHostService {
         Ok(Response::new(PluginClient::convert_message(response)?))
       }
     }
+  }
+
+  // The field-level callbacks are defined in the V2 proto (proposal 006) but not dispatched yet:
+  // that needs the field matcher/generator surface and the core field capability registries, which
+  // are step 2 of the proposal's sequencing. Answering `unimplemented` is the honest response - a
+  // plugin gets a clear, catchable error naming the entry it asked for, rather than a hang or a
+  // silent pass.
+
+  async fn match_field(
+    &self,
+    request: Request<HostMatchFieldRequest>,
+  ) -> Result<Response<MatchFieldResponse>, Status> {
+    Err(Status::unimplemented(format!(
+      "Field-level matching rules are not implemented by this driver yet (requested entry '{}'). \
+       See proposal 006 (Field-level matchers and generators).",
+      request.into_inner().entry_key
+    )))
+  }
+
+  async fn generate_field(
+    &self,
+    request: Request<HostGenerateFieldRequest>,
+  ) -> Result<Response<GenerateFieldResponse>, Status> {
+    Err(Status::unimplemented(format!(
+      "Field-level generators are not implemented by this driver yet (requested entry '{}'). \
+       See proposal 006 (Field-level matchers and generators).",
+      request.into_inner().entry_key
+    )))
   }
 }
 

--- a/drivers/rust/driver/src/plugin_host.rs
+++ b/drivers/rust/driver/src/plugin_host.rs
@@ -115,32 +115,76 @@ impl plugin_host_server::PluginHost for PluginHostService {
     }
   }
 
-  // The field-level callbacks are defined in the V2 proto (proposal 006) but not dispatched yet:
-  // that needs the field matcher/generator surface and the core field capability registries, which
-  // are step 2 of the proposal's sequencing. Answering `unimplemented` is the honest response - a
-  // plugin gets a clear, catchable error naming the entry it asked for, rather than a hang or a
-  // silent pass.
-
   async fn match_field(
     &self,
     request: Request<HostMatchFieldRequest>,
   ) -> Result<Response<MatchFieldResponse>, Status> {
-    Err(Status::unimplemented(format!(
-      "Field-level matching rules are not implemented by this driver yet (requested entry '{}'). \
-       See proposal 006 (Field-level matchers and generators).",
-      request.into_inner().entry_key
-    )))
+    let (metadata, _, msg) = request.into_parts();
+    let (chain_id, deadline_ms) = call_chain_context(&metadata);
+    let entry_key = msg.entry_key;
+    let inner_request = msg.request
+      .ok_or_else(|| Status::invalid_argument("HostMatchFieldRequest.request is required"))?;
+
+    if call_chain::is_expired(deadline_ms) {
+      return Err(Status::deadline_exceeded(format!(
+        "Call chain {} deadline has already passed", chain_id
+      )));
+    }
+    let _guard = call_chain::push_call(&chain_id, &entry_key).map_err(Status::already_exists)?;
+
+    match resolve_capability(&entry_key, CatalogueEntryType::MATCHER)
+      .map_err(|err| Status::not_found(err.to_string()))? {
+      ResolvedCapability::Core(core_key) => {
+        let handler = crate::core_capabilities::lookup_core_field_matcher(&core_key)
+          .ok_or_else(|| Status::not_found(format!("No core field matcher registered for '{}'", core_key)))?;
+        let response = handler.match_field(inner_request).await
+          .map_err(|err| Status::internal(format!("Core field matcher for '{}' failed: {}", core_key, err)))?;
+        Ok(Response::new(response))
+      }
+      ResolvedCapability::Plugin(manifest) => {
+        let plugin = crate::plugin_manager::lookup_plugin(&manifest.as_dependency())
+          .ok_or_else(|| Status::not_found(format!("Plugin '{}' for entry '{}' is not currently running", manifest.name, entry_key)))?;
+        let response = plugin.match_field_with_chain(inner_request, &chain_id, deadline_ms).await
+          .map_err(|err| Status::internal(format!("Call to plugin '{}' failed: {}", manifest.name, err)))?;
+        Ok(Response::new(response))
+      }
+    }
   }
 
   async fn generate_field(
     &self,
     request: Request<HostGenerateFieldRequest>,
   ) -> Result<Response<GenerateFieldResponse>, Status> {
-    Err(Status::unimplemented(format!(
-      "Field-level generators are not implemented by this driver yet (requested entry '{}'). \
-       See proposal 006 (Field-level matchers and generators).",
-      request.into_inner().entry_key
-    )))
+    let (metadata, _, msg) = request.into_parts();
+    let (chain_id, deadline_ms) = call_chain_context(&metadata);
+    let entry_key = msg.entry_key;
+    let inner_request = msg.request
+      .ok_or_else(|| Status::invalid_argument("HostGenerateFieldRequest.request is required"))?;
+
+    if call_chain::is_expired(deadline_ms) {
+      return Err(Status::deadline_exceeded(format!(
+        "Call chain {} deadline has already passed", chain_id
+      )));
+    }
+    let _guard = call_chain::push_call(&chain_id, &entry_key).map_err(Status::already_exists)?;
+
+    match resolve_capability(&entry_key, CatalogueEntryType::GENERATOR)
+      .map_err(|err| Status::not_found(err.to_string()))? {
+      ResolvedCapability::Core(core_key) => {
+        let handler = crate::core_capabilities::lookup_core_field_generator(&core_key)
+          .ok_or_else(|| Status::not_found(format!("No core field generator registered for '{}'", core_key)))?;
+        let response = handler.generate_field(inner_request).await
+          .map_err(|err| Status::internal(format!("Core field generator for '{}' failed: {}", core_key, err)))?;
+        Ok(Response::new(response))
+      }
+      ResolvedCapability::Plugin(manifest) => {
+        let plugin = crate::plugin_manager::lookup_plugin(&manifest.as_dependency())
+          .ok_or_else(|| Status::not_found(format!("Plugin '{}' for entry '{}' is not currently running", manifest.name, entry_key)))?;
+        let response = plugin.generate_field_with_chain(inner_request, &chain_id, deadline_ms).await
+          .map_err(|err| Status::internal(format!("Call to plugin '{}' failed: {}", manifest.name, err)))?;
+        Ok(Response::new(response))
+      }
+    }
   }
 }
 

--- a/drivers/rust/driver/src/plugin_manager.rs
+++ b/drivers/rust/driver/src/plugin_manager.rs
@@ -458,7 +458,7 @@ pub async fn publish_updated_catalogue() {
     catalogue: all_entries()
       .iter()
       .map(|entry| crate::proto::CatalogueEntry {
-        r#type: entry.entry_type.to_proto_type() as i32,
+        r#type: entry.entry_type.to_proto_value(),
         key: entry.key.clone(),
         values: entry.values.clone(),
       })

--- a/drivers/rust/driver/src/plugin_models.rs
+++ b/drivers/rust/driver/src/plugin_models.rs
@@ -232,6 +232,52 @@ pub trait PluginInstance: std::fmt::Debug + Send + Sync {
     self.generate_content(request).await
   }
 
+  /// Apply a plugin-provided matching rule to a single value (see proposal 006). Field-level
+  /// operations exist only on the V2 interface, so the default reports that this plugin cannot
+  /// provide them - the same shape as the other V2-only operations below.
+  async fn match_field(
+    &self,
+    request: proto_v2::MatchFieldRequest,
+  ) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+    let _ = request;
+    Err(anyhow!("Field-level matching rules are not supported by this plugin"))
+  }
+
+  /// Apply a plugin-provided matching rule to a single value, propagating call-chain cycle
+  /// detection and deadline metadata (see [`crate::call_chain`]) for transports that support it.
+  /// See [`PluginInstance::compare_contents_with_chain`] for the default/override split.
+  async fn match_field_with_chain(
+    &self,
+    request: proto_v2::MatchFieldRequest,
+    chain_id: &str,
+    deadline_ms: u64,
+  ) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+    let _ = (chain_id, deadline_ms);
+    self.match_field(request).await
+  }
+
+  /// Apply a plugin-provided generator to a single value (see proposal 006). See
+  /// [`PluginInstance::match_field`].
+  async fn generate_field(
+    &self,
+    request: proto_v2::GenerateFieldRequest,
+  ) -> anyhow::Result<proto_v2::GenerateFieldResponse> {
+    let _ = request;
+    Err(anyhow!("Field-level generators are not supported by this plugin"))
+  }
+
+  /// Apply a plugin-provided generator to a single value, propagating call-chain cycle detection
+  /// and deadline metadata. See [`PluginInstance::match_field_with_chain`].
+  async fn generate_field_with_chain(
+    &self,
+    request: proto_v2::GenerateFieldRequest,
+    chain_id: &str,
+    deadline_ms: u64,
+  ) -> anyhow::Result<proto_v2::GenerateFieldResponse> {
+    let _ = (chain_id, deadline_ms);
+    self.generate_field(request).await
+  }
+
   /// Start a mock server
   async fn start_mock_server(
     &self,

--- a/drivers/rust/driver/src/proto_v2.rs
+++ b/drivers/rust/driver/src/proto_v2.rs
@@ -915,7 +915,9 @@ pub struct HostGenerateContentRequest {
 /// 006 (Field-level matchers and generators) and 007 (Driver-plugin callback model).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HostMatchFieldRequest {
-    /// Catalogue entry key identifying the rule to invoke, e.g. "type" for matcher/type
+    /// Catalogue entry key identifying the rule to invoke. Either the name as a Pact file writes it
+    /// ("type"), or the key as hostCapabilities advertises it ("matcher/v2-type") - the core
+    /// catalogue prefixes the Pact specification version a rule was introduced in to its name.
     #[prost(string, tag = "1")]
     pub entry_key: ::prost::alloc::string::String,
     /// The match request, in the same shape as PactPlugin.MatchField
@@ -926,7 +928,8 @@ pub struct HostMatchFieldRequest {
 /// another plugin - resolved by catalogue entry key. See proposals 006 and 007.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HostGenerateFieldRequest {
-    /// Catalogue entry key identifying the generator to invoke, e.g. "date" for generator/date
+    /// Catalogue entry key identifying the generator to invoke, e.g. "date" or "generator/v3-date".
+    /// See HostMatchFieldRequest.entryKey.
     #[prost(string, tag = "1")]
     pub entry_key: ::prost::alloc::string::String,
     /// The generation request, in the same shape as PactPlugin.GenerateField

--- a/drivers/rust/driver/src/proto_v2.rs
+++ b/drivers/rust/driver/src/proto_v2.rs
@@ -63,6 +63,8 @@ pub mod catalogue_entry {
         Matcher = 3,
         /// Type of interaction
         Interaction = 4,
+        /// Generator for a content field/value. See proposal 006 (Field-level matchers and generators).
+        Generator = 5,
     }
     impl EntryType {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -76,6 +78,7 @@ pub mod catalogue_entry {
                 Self::Transport => "TRANSPORT",
                 Self::Matcher => "MATCHER",
                 Self::Interaction => "INTERACTION",
+                Self::Generator => "GENERATOR",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -86,6 +89,7 @@ pub mod catalogue_entry {
                 "TRANSPORT" => Some(Self::Transport),
                 "MATCHER" => Some(Self::Matcher),
                 "INTERACTION" => Some(Self::Interaction),
+                "GENERATOR" => Some(Self::Generator),
                 _ => None,
             }
         }
@@ -556,6 +560,106 @@ pub struct GenerateContentResponse {
     #[prost(message, optional, tag = "1")]
     pub contents: ::core::option::Option<Body>,
 }
+/// A single value being matched or generated at the field/element level. Binary-safe: follows the
+/// same oneof pattern as MetadataValue rather than assuming every value can be represented as
+/// JSON. See proposal 006 (Field-level matchers and generators).
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FieldValue {
+    #[prost(oneof = "field_value::Value", tags = "1, 2")]
+    pub value: ::core::option::Option<field_value::Value>,
+}
+/// Nested message and enum types in `FieldValue`.
+pub mod field_value {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        /// A JSON-like value
+        #[prost(message, tag = "1")]
+        NonBinaryValue(::prost_types::Value),
+        /// Raw bytes, for a value that is not representable as JSON
+        #[prost(bytes, tag = "2")]
+        BinaryValue(::prost::alloc::vec::Vec<u8>),
+    }
+}
+/// Request to apply a plugin-provided matching rule to a single value. The plugin sees the value,
+/// its path and the rule's own configuration, but not the document that contains it - a rule that
+/// needs the surrounding document is a content matcher. See proposal 006.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MatchFieldRequest {
+    /// Catalogue entry key of the rule being applied, e.g. "creditcard" for matcher/creditcard
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+    /// The rule as stored in the Pact file: its name and configured values
+    #[prost(message, optional, tag = "2")]
+    pub rule: ::core::option::Option<MatchingRule>,
+    /// Path to the value being matched. This is the value as per the documented Pact matching rule expressions.
+    #[prost(string, tag = "3")]
+    pub path: ::prost::alloc::string::String,
+    /// Part of the interaction the value came from: body, headers, metadata, query, path, status
+    #[prost(string, tag = "4")]
+    pub mismatch_type: ::prost::alloc::string::String,
+    /// Expected value from the Pact interaction
+    #[prost(message, optional, tag = "5")]
+    pub expected: ::core::option::Option<FieldValue>,
+    /// Actual value received
+    #[prost(message, optional, tag = "6")]
+    pub actual: ::core::option::Option<FieldValue>,
+    /// Additional data added to the Pact/Interaction by the plugin
+    #[prost(message, optional, tag = "7")]
+    pub plugin_configuration: ::core::option::Option<PluginConfiguration>,
+    /// Context data provided by the test framework (carries testRunId for log correlation)
+    #[prost(message, optional, tag = "8")]
+    pub test_context: ::core::option::Option<::prost_types::Struct>,
+}
+/// Response to the MatchFieldRequest with the result of applying the rule
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MatchFieldResponse {
+    /// Error message if the rule could not be applied at all. If this field is set, the remaining
+    /// fields will be ignored and the verification marked as failed
+    #[prost(string, tag = "1")]
+    pub error: ::prost::alloc::string::String,
+    /// Mismatches found. An empty list means the value matched. A mismatch with an empty path is
+    /// reported against the path from the request
+    #[prost(message, repeated, tag = "2")]
+    pub mismatches: ::prost::alloc::vec::Vec<ContentMismatch>,
+}
+/// Request to generate a single value using a plugin-provided generator. Generators are pure
+/// functions of this request: anything from the host they need arrives in testContext or is
+/// fetched with an explicit callback. See proposal 006.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenerateFieldRequest {
+    /// Catalogue entry key of the generator being applied, e.g. "creditcard" for generator/creditcard
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+    /// The generator as stored in the Pact file: its name and configured values
+    #[prost(message, optional, tag = "2")]
+    pub generator: ::core::option::Option<Generator>,
+    /// Path to the value being generated. This is the value as per the documented Pact matching rule expressions.
+    #[prost(string, tag = "3")]
+    pub path: ::prost::alloc::string::String,
+    /// The example value from the Pact interaction that the generated value replaces
+    #[prost(message, optional, tag = "4")]
+    pub example_value: ::core::option::Option<FieldValue>,
+    /// Additional data added to the Pact/Interaction by the plugin
+    #[prost(message, optional, tag = "5")]
+    pub plugin_configuration: ::core::option::Option<PluginConfiguration>,
+    /// Context data provided by the test framework
+    #[prost(message, optional, tag = "6")]
+    pub test_context: ::core::option::Option<::prost_types::Struct>,
+    /// The mode of the generation, if running from a consumer test or during provider verification
+    #[prost(enumeration = "generate_content_request::TestMode", tag = "7")]
+    pub test_mode: i32,
+}
+/// Response to the GenerateFieldRequest with the generated value
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenerateFieldResponse {
+    /// Error message if the value could not be generated. If this field is set, the value will be
+    /// ignored
+    #[prost(string, tag = "1")]
+    pub error: ::prost::alloc::string::String,
+    /// The generated value
+    #[prost(message, optional, tag = "2")]
+    pub value: ::core::option::Option<FieldValue>,
+}
 /// Request to start a mock server
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StartMockServerRequest {
@@ -806,6 +910,29 @@ pub struct HostGenerateContentRequest {
     #[prost(message, optional, tag = "2")]
     pub request: ::core::option::Option<GenerateContentRequest>,
 }
+/// Callback request from a plugin to invoke a field-level matching rule - host-provided (one of the
+/// standard Pact rules) or owned by another plugin - resolved by catalogue entry key. See proposals
+/// 006 (Field-level matchers and generators) and 007 (Driver-plugin callback model).
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HostMatchFieldRequest {
+    /// Catalogue entry key identifying the rule to invoke, e.g. "type" for matcher/type
+    #[prost(string, tag = "1")]
+    pub entry_key: ::prost::alloc::string::String,
+    /// The match request, in the same shape as PactPlugin.MatchField
+    #[prost(message, optional, tag = "2")]
+    pub request: ::core::option::Option<MatchFieldRequest>,
+}
+/// Callback request from a plugin to invoke a field-level generator - host-provided or owned by
+/// another plugin - resolved by catalogue entry key. See proposals 006 and 007.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HostGenerateFieldRequest {
+    /// Catalogue entry key identifying the generator to invoke, e.g. "date" for generator/date
+    #[prost(string, tag = "1")]
+    pub entry_key: ::prost::alloc::string::String,
+    /// The generation request, in the same shape as PactPlugin.GenerateField
+    #[prost(message, optional, tag = "2")]
+    pub request: ::core::option::Option<GenerateFieldRequest>,
+}
 /// Generated client implementations.
 pub mod plugin_host_client {
     #![allow(
@@ -826,8 +953,8 @@ pub mod plugin_host_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-          D: TryInto<tonic::transport::Endpoint>,
-          D::Error: Into<StdError>,
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
             Ok(Self::new(conn))
@@ -835,10 +962,10 @@ pub mod plugin_host_client {
     }
     impl<T> PluginHostClient<T>
     where
-      T: tonic::client::GrpcService<tonic::body::Body>,
-      T::Error: Into<StdError>,
-      T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
-      <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+        T: tonic::client::GrpcService<tonic::body::Body>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
@@ -853,17 +980,17 @@ pub mod plugin_host_client {
             interceptor: F,
         ) -> PluginHostClient<InterceptedService<T, F>>
         where
-          F: tonic::service::Interceptor,
-          T::ResponseBody: Default,
-          T: tonic::codegen::Service<
-              http::Request<tonic::body::Body>,
-              Response = http::Response<
-                  <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
-              >,
-          >,
-          <T as tonic::codegen::Service<
-              http::Request<tonic::body::Body>,
-          >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PluginHostClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -904,20 +1031,20 @@ pub mod plugin_host_client {
             request: impl tonic::IntoRequest<super::LogMessage>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PluginHost/Log",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(GrpcMethod::new("io.pact.plugin.v2.PluginHost", "Log"));
+                .insert(GrpcMethod::new("io.pact.plugin.v2.PluginHost", "Log"));
             self.inner.unary(req, path, codec).await
         }
         /// Invoke a content matcher capability by catalogue entry key. The driver resolves the key to
@@ -930,22 +1057,22 @@ pub mod plugin_host_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PluginHost/CompareContents",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new("io.pact.plugin.v2.PluginHost", "CompareContents"),
-              );
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PluginHost", "CompareContents"),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Invoke a content generator capability by catalogue entry key. The driver resolves the key to
@@ -958,22 +1085,77 @@ pub mod plugin_host_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PluginHost/GenerateContent",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new("io.pact.plugin.v2.PluginHost", "GenerateContent"),
-              );
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PluginHost", "GenerateContent"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Invoke a field-level matching rule by catalogue entry key, resolved the same way. This is how
+        /// a plugin delegates one field of a document it owns to a standard Pact rule instead of
+        /// reimplementing it. See proposals 006 and 009.
+        pub async fn match_field(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HostMatchFieldRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::MatchFieldResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/io.pact.plugin.v2.PluginHost/MatchField",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("io.pact.plugin.v2.PluginHost", "MatchField"));
+            self.inner.unary(req, path, codec).await
+        }
+        /// Invoke a field-level generator by catalogue entry key, resolved the same way.
+        /// See proposals 006 and 009.
+        pub async fn generate_field(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HostGenerateFieldRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GenerateFieldResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/io.pact.plugin.v2.PluginHost/GenerateField",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PluginHost", "GenerateField"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1014,6 +1196,25 @@ pub mod plugin_host_server {
             tonic::Response<super::GenerateContentResponse>,
             tonic::Status,
         >;
+        /// Invoke a field-level matching rule by catalogue entry key, resolved the same way. This is how
+        /// a plugin delegates one field of a document it owns to a standard Pact rule instead of
+        /// reimplementing it. See proposals 006 and 009.
+        async fn match_field(
+            &self,
+            request: tonic::Request<super::HostMatchFieldRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::MatchFieldResponse>,
+            tonic::Status,
+        >;
+        /// Invoke a field-level generator by catalogue entry key, resolved the same way.
+        /// See proposals 006 and 009.
+        async fn generate_field(
+            &self,
+            request: tonic::Request<super::HostGenerateFieldRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GenerateFieldResponse>,
+            tonic::Status,
+        >;
     }
     /// Driver-side service implemented by the driver and called by plugins
     #[derive(Debug)]
@@ -1042,7 +1243,7 @@ pub mod plugin_host_server {
             interceptor: F,
         ) -> InterceptedService<Self, F>
         where
-          F: tonic::service::Interceptor,
+            F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
@@ -1077,9 +1278,9 @@ pub mod plugin_host_server {
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for PluginHostServer<T>
     where
-      T: PluginHost,
-      B: Body + std::marker::Send + 'static,
-      B::Error: Into<StdError> + std::marker::Send + 'static,
+        T: PluginHost,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
     {
         type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
@@ -1122,14 +1323,14 @@ pub mod plugin_host_server {
                         let method = LogSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -1167,14 +1368,14 @@ pub mod plugin_host_server {
                         let method = CompareContentsSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -1212,14 +1413,104 @@ pub mod plugin_host_server {
                         let method = GenerateContentSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/io.pact.plugin.v2.PluginHost/MatchField" => {
+                    #[allow(non_camel_case_types)]
+                    struct MatchFieldSvc<T: PluginHost>(pub Arc<T>);
+                    impl<
+                        T: PluginHost,
+                    > tonic::server::UnaryService<super::HostMatchFieldRequest>
+                    for MatchFieldSvc<T> {
+                        type Response = super::MatchFieldResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::HostMatchFieldRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as PluginHost>::match_field(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = MatchFieldSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/io.pact.plugin.v2.PluginHost/GenerateField" => {
+                    #[allow(non_camel_case_types)]
+                    struct GenerateFieldSvc<T: PluginHost>(pub Arc<T>);
+                    impl<
+                        T: PluginHost,
+                    > tonic::server::UnaryService<super::HostGenerateFieldRequest>
+                    for GenerateFieldSvc<T> {
+                        type Response = super::GenerateFieldResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::HostGenerateFieldRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as PluginHost>::generate_field(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GenerateFieldSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -1232,15 +1523,15 @@ pub mod plugin_host_server {
                         );
                         let headers = response.headers_mut();
                         headers
-                          .insert(
-                              tonic::Status::GRPC_STATUS,
-                              (tonic::Code::Unimplemented as i32).into(),
-                          );
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
                         headers
-                          .insert(
-                              http::header::CONTENT_TYPE,
-                              tonic::metadata::GRPC_CONTENT_TYPE,
-                          );
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
                         Ok(response)
                     })
                 }
@@ -1284,8 +1575,8 @@ pub mod pact_plugin_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-          D: TryInto<tonic::transport::Endpoint>,
-          D::Error: Into<StdError>,
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
             Ok(Self::new(conn))
@@ -1293,10 +1584,10 @@ pub mod pact_plugin_client {
     }
     impl<T> PactPluginClient<T>
     where
-      T: tonic::client::GrpcService<tonic::body::Body>,
-      T::Error: Into<StdError>,
-      T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
-      <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+        T: tonic::client::GrpcService<tonic::body::Body>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
@@ -1311,17 +1602,17 @@ pub mod pact_plugin_client {
             interceptor: F,
         ) -> PactPluginClient<InterceptedService<T, F>>
         where
-          F: tonic::service::Interceptor,
-          T::ResponseBody: Default,
-          T: tonic::codegen::Service<
-              http::Request<tonic::body::Body>,
-              Response = http::Response<
-                  <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
-              >,
-          >,
-          <T as tonic::codegen::Service<
-              http::Request<tonic::body::Body>,
-          >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PactPluginClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1365,20 +1656,20 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/InitPlugin",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "InitPlugin"));
+                .insert(GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "InitPlugin"));
             self.inner.unary(req, path, codec).await
         }
         /// Updated catalogue. This will be sent when the core catalogue has been updated (probably by a plugin loading).
@@ -1387,22 +1678,22 @@ pub mod pact_plugin_client {
             request: impl tonic::IntoRequest<super::Catalogue>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/UpdateCatalogue",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "UpdateCatalogue"),
-              );
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "UpdateCatalogue"),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Request to perform a comparison of some contents (matching request)
@@ -1414,22 +1705,22 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/CompareContents",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "CompareContents"),
-              );
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "CompareContents"),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Request to configure/setup the interaction for later verification. Data returned will be persisted in the pact file.
@@ -1441,25 +1732,25 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/ConfigureInteraction",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new(
-                      "io.pact.plugin.v2.PactPlugin",
-                      "ConfigureInteraction",
-                  ),
-              );
+                .insert(
+                    GrpcMethod::new(
+                        "io.pact.plugin.v2.PactPlugin",
+                        "ConfigureInteraction",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Request to generate the content using any defined generators
@@ -1471,22 +1762,76 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/GenerateContent",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "GenerateContent"),
-              );
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "GenerateContent"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Apply a plugin-provided matching rule to a single value. Required for any plugin that
+        /// registers a MATCHER catalogue entry. See proposal 006 (Field-level matchers and generators).
+        pub async fn match_field(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MatchFieldRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::MatchFieldResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/io.pact.plugin.v2.PactPlugin/MatchField",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "MatchField"));
+            self.inner.unary(req, path, codec).await
+        }
+        /// Apply a plugin-provided generator to a single value. Required for any plugin that registers
+        /// a GENERATOR catalogue entry. See proposal 006.
+        pub async fn generate_field(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GenerateFieldRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GenerateFieldResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/io.pact.plugin.v2.PactPlugin/GenerateField",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "GenerateField"),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Start a mock server
@@ -1498,22 +1843,22 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/StartMockServer",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "StartMockServer"),
-              );
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "StartMockServer"),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Shutdown a running mock server
@@ -1525,22 +1870,22 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/ShutdownMockServer",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "ShutdownMockServer"),
-              );
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "ShutdownMockServer"),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Get the matching results from a running mock server
@@ -1552,25 +1897,25 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/GetMockServerResults",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new(
-                      "io.pact.plugin.v2.PactPlugin",
-                      "GetMockServerResults",
-                  ),
-              );
+                .insert(
+                    GrpcMethod::new(
+                        "io.pact.plugin.v2.PactPlugin",
+                        "GetMockServerResults",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Prepare an interaction for verification. This should return any data required to construct any request
@@ -1583,25 +1928,25 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/PrepareInteractionForVerification",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new(
-                      "io.pact.plugin.v2.PactPlugin",
-                      "PrepareInteractionForVerification",
-                  ),
-              );
+                .insert(
+                    GrpcMethod::new(
+                        "io.pact.plugin.v2.PactPlugin",
+                        "PrepareInteractionForVerification",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Execute the verification for the interaction.
@@ -1613,22 +1958,22 @@ pub mod pact_plugin_client {
             tonic::Status,
         > {
             self.inner
-              .ready()
-              .await
-              .map_err(|e| {
-                  tonic::Status::unknown(
-                      format!("Service was not ready: {}", e.into()),
-                  )
-              })?;
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/io.pact.plugin.v2.PactPlugin/VerifyInteraction",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-              .insert(
-                  GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "VerifyInteraction"),
-              );
+                .insert(
+                    GrpcMethod::new("io.pact.plugin.v2.PactPlugin", "VerifyInteraction"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1681,6 +2026,24 @@ pub mod pact_plugin_server {
             request: tonic::Request<super::GenerateContentRequest>,
         ) -> std::result::Result<
             tonic::Response<super::GenerateContentResponse>,
+            tonic::Status,
+        >;
+        /// Apply a plugin-provided matching rule to a single value. Required for any plugin that
+        /// registers a MATCHER catalogue entry. See proposal 006 (Field-level matchers and generators).
+        async fn match_field(
+            &self,
+            request: tonic::Request<super::MatchFieldRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::MatchFieldResponse>,
+            tonic::Status,
+        >;
+        /// Apply a plugin-provided generator to a single value. Required for any plugin that registers
+        /// a GENERATOR catalogue entry. See proposal 006.
+        async fn generate_field(
+            &self,
+            request: tonic::Request<super::GenerateFieldRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GenerateFieldResponse>,
             tonic::Status,
         >;
         /// Start a mock server
@@ -1751,7 +2114,7 @@ pub mod pact_plugin_server {
             interceptor: F,
         ) -> InterceptedService<Self, F>
         where
-          F: tonic::service::Interceptor,
+            F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
@@ -1786,9 +2149,9 @@ pub mod pact_plugin_server {
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for PactPluginServer<T>
     where
-      T: PactPlugin,
-      B: Body + std::marker::Send + 'static,
-      B::Error: Into<StdError> + std::marker::Send + 'static,
+        T: PactPlugin,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
     {
         type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
@@ -1833,14 +2196,14 @@ pub mod pact_plugin_server {
                         let method = InitPluginSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -1876,14 +2239,14 @@ pub mod pact_plugin_server {
                         let method = UpdateCatalogueSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -1921,14 +2284,14 @@ pub mod pact_plugin_server {
                         let method = CompareContentsSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -1953,7 +2316,7 @@ pub mod pact_plugin_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as PactPlugin>::configure_interaction(&inner, request)
-                                  .await
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1967,14 +2330,14 @@ pub mod pact_plugin_server {
                         let method = ConfigureInteractionSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -2012,14 +2375,104 @@ pub mod pact_plugin_server {
                         let method = GenerateContentSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/io.pact.plugin.v2.PactPlugin/MatchField" => {
+                    #[allow(non_camel_case_types)]
+                    struct MatchFieldSvc<T: PactPlugin>(pub Arc<T>);
+                    impl<
+                        T: PactPlugin,
+                    > tonic::server::UnaryService<super::MatchFieldRequest>
+                    for MatchFieldSvc<T> {
+                        type Response = super::MatchFieldResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MatchFieldRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as PactPlugin>::match_field(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = MatchFieldSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/io.pact.plugin.v2.PactPlugin/GenerateField" => {
+                    #[allow(non_camel_case_types)]
+                    struct GenerateFieldSvc<T: PactPlugin>(pub Arc<T>);
+                    impl<
+                        T: PactPlugin,
+                    > tonic::server::UnaryService<super::GenerateFieldRequest>
+                    for GenerateFieldSvc<T> {
+                        type Response = super::GenerateFieldResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GenerateFieldRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as PactPlugin>::generate_field(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GenerateFieldSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -2057,14 +2510,14 @@ pub mod pact_plugin_server {
                         let method = StartMockServerSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -2089,7 +2542,7 @@ pub mod pact_plugin_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as PactPlugin>::shutdown_mock_server(&inner, request)
-                                  .await
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2103,14 +2556,14 @@ pub mod pact_plugin_server {
                         let method = ShutdownMockServerSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -2135,7 +2588,7 @@ pub mod pact_plugin_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as PactPlugin>::get_mock_server_results(&inner, request)
-                                  .await
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2149,14 +2602,14 @@ pub mod pact_plugin_server {
                         let method = GetMockServerResultsSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -2185,10 +2638,10 @@ pub mod pact_plugin_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as PactPlugin>::prepare_interaction_for_verification(
-                                    &inner,
-                                    request,
-                                )
-                                  .await
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2202,14 +2655,14 @@ pub mod pact_plugin_server {
                         let method = PrepareInteractionForVerificationSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -2247,14 +2700,14 @@ pub mod pact_plugin_server {
                         let method = VerifyInteractionSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
-                          .apply_compression_config(
-                              accept_compression_encodings,
-                              send_compression_encodings,
-                          )
-                          .apply_max_message_size_config(
-                              max_decoding_message_size,
-                              max_encoding_message_size,
-                          );
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -2267,15 +2720,15 @@ pub mod pact_plugin_server {
                         );
                         let headers = response.headers_mut();
                         headers
-                          .insert(
-                              tonic::Status::GRPC_STATUS,
-                              (tonic::Code::Unimplemented as i32).into(),
-                          );
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
                         headers
-                          .insert(
-                              http::header::CONTENT_TYPE,
-                              tonic::metadata::GRPC_CONTENT_TYPE,
-                          );
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
                         Ok(response)
                     })
                 }

--- a/drivers/rust/driver/src/proto_v2.rs
+++ b/drivers/rust/driver/src/proto_v2.rs
@@ -560,24 +560,49 @@ pub struct GenerateContentResponse {
     #[prost(message, optional, tag = "1")]
     pub contents: ::core::option::Option<Body>,
 }
-/// A single value being matched or generated at the field/element level. Binary-safe: follows the
-/// same oneof pattern as MetadataValue rather than assuming every value can be represented as
-/// JSON. See proposal 006 (Field-level matchers and generators).
+/// A single value being matched or generated at the field/element level.
+///
+/// Each type Pact's matching rules discriminate has its own arm, rather than everything
+/// JSON-representable sharing a google.protobuf.Value. That type carries a single number type (a
+/// double), which would make `integer` and `decimal` indistinguishable and `type` wrong between a
+/// whole number and a decimal - and these are exactly the rules whose job is to check the runtime
+/// type of a value. Binary data has its own arm for the same reason: so it never has to be
+/// stringified into a form it does not fit.
+///
+/// See proposal 006 (Field-level matchers and generators).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldValue {
-    #[prost(oneof = "field_value::Value", tags = "1, 2")]
+    #[prost(oneof = "field_value::Value", tags = "1, 2, 3, 4, 5, 6, 7")]
     pub value: ::core::option::Option<field_value::Value>,
 }
 /// Nested message and enum types in `FieldValue`.
 pub mod field_value {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
-        /// A JSON-like value
-        #[prost(message, tag = "1")]
-        NonBinaryValue(::prost_types::Value),
-        /// Raw bytes, for a value that is not representable as JSON
-        #[prost(bytes, tag = "2")]
+        /// A null value
+        #[prost(enumeration = "::prost_types::NullValue", tag = "1")]
+        NullValue(i32),
+        /// A boolean
+        #[prost(bool, tag = "2")]
+        BooleanValue(bool),
+        /// A string
+        #[prost(string, tag = "3")]
+        StringValue(::prost::alloc::string::String),
+        /// A whole number
+        #[prost(int64, tag = "4")]
+        IntegerValue(i64),
+        /// A number with a fractional part
+        #[prost(double, tag = "5")]
+        DecimalValue(f64),
+        /// Raw bytes, for a value that is not representable as text
+        #[prost(bytes, tag = "6")]
         BinaryValue(::prost::alloc::vec::Vec<u8>),
+        /// A map or list, for a rule applied to a collection rather than a scalar. Numbers nested
+        /// inside follow JSON semantics (every number is a double) - a collection rule only needs the
+        /// shape and size of the collection, and the values inside it are matched by their own
+        /// field-level calls, at their own paths, where they arrive under the arms above.
+        #[prost(message, tag = "7")]
+        StructuredValue(::prost_types::Value),
     }
 }
 /// Request to apply a plugin-provided matching rule to a single value. The plugin sees the value,

--- a/drivers/rust/driver_ffi/Cargo.lock
+++ b/drivers/rust/driver_ffi/Cargo.lock
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "pact-plugin-driver"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2466,7 +2466,7 @@ version = "0.0.0"
 dependencies = [
  "env_logger",
  "expectest",
- "pact-plugin-driver 1.1.0",
+ "pact-plugin-driver 1.1.1",
  "pact_ffi",
  "prost",
  "reqwest 0.12.28",

--- a/drivers/rust/driver_pact_tests/Cargo.lock
+++ b/drivers/rust/driver_pact_tests/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
  "async-trait",
  "env_logger",
  "expectest",
- "pact-plugin-driver 1.1.0",
+ "pact-plugin-driver 1.1.1",
  "pact_consumer",
  "prost",
  "prost-types",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "pact-plugin-driver"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,8 +1,18 @@
 # Example/Prototype plugins
 
+## Credit card
+
+Plugin providing a field-level matching rule and generator for credit card numbers, written in Lua. The reference
+implementation for [proposal 006](../docs/proposals/006_Field_level_matchers_and_generators.md); not runnable until
+that lands.
+
 ## CSV
 
 Plugin to support comma-separated text payloads, written in Rust.
+
+## JWT
+
+Plugin to support signed JSON Web Tokens as request/response bodies, written in Lua.
 
 ## JSON-RPC
 

--- a/plugins/creditcard/README.md
+++ b/plugins/creditcard/README.md
@@ -1,0 +1,133 @@
+# Credit card plugin (written in Lua)
+
+An example plugin providing a **field-level** matching rule and generator for credit card numbers. Unlike the
+[CSV](../csv), [Protobuf](../protobuf) and [JWT](../jwt) plugins, it does not own a content type at all - it
+contributes one rule that applies to a single value inside somebody else's content: a field in a JSON body, a
+header, a message metadata value, and so on.
+
+It is the reference implementation for
+[proposal 006, Field-level matchers and generators](../../docs/proposals/006_Field_level_matchers_and_generators.md),
+and was written alongside that design to keep it honest. Like the [JWT plugin](../jwt), it is written in Lua and
+runs embedded in the driver's own process rather than as a separate gRPC server - see
+[Writing plugins in Lua](../../docs/writing-plugin-guide.md#writing-plugins-in-lua).
+
+> [!IMPORTANT]
+> Field-level matchers and generators are **not implemented in either driver yet** - proposal 006 is still a draft.
+> This plugin cannot be loaded and run against a real test today. Until it can, [`test.lua`](test.lua) exercises it
+> directly. See [Compatibility](#compatibility) below.
+
+## What it does
+
+The plugin registers two catalogue entries, both named `creditcard`:
+
+| Entry type | What it does |
+|---|---|
+| `MATCHER` | Asserts the actual value is a plausible credit card number |
+| `GENERATOR` | Produces a fresh, valid credit card number on each test run |
+
+The matcher checks, in order:
+
+1. The value is text (or an integer) - binary data and other types are a mismatch.
+2. After removing spaces and dashes, it is all digits.
+3. Its last digit is a valid [Luhn](https://en.wikipedia.org/wiki/Luhn_algorithm) check digit. This is the part no
+   core Pact matching rule can express: `regex` can check the shape of a card number, but not its checksum.
+4. If the rule is configured with a `brand`, the number starts with an issuer identification number used by that
+   brand and has a length that brand issues. If no `brand` is configured, any well-formed number of 12 to 19 digits
+   is accepted, whichever issuer it belongs to.
+
+Known brands: `amex`, `diners`, `discover`, `jcb`, `mastercard`, `visa`. Configuring a brand the plugin doesn't know
+is reported as an *error* rather than a mismatch - it's a mistake in the test, not in the provider's response.
+
+The generator produces a number for the configured `brand`; with no brand configured it uses whichever brand the
+example value in the Pact file looks like, falling back to Visa. It is a pure function of the request - the brand,
+the example value, and the test context are all it reads.
+
+## Using it in a test
+
+Set the rule up on a field the same way as any core matching rule, by name:
+
+```json
+{
+  "card": {
+    "number": "matching(creditcard, 'visa', '4111111111111111')",
+    "expiry": "matching(regex, '\\d{2}/\\d{2}', '04/28')"
+  }
+}
+```
+
+The optional middle argument is the brand - the plugin declares `config-key = "brand"` on its catalogue entries,
+which is what maps that positional argument onto the rule's `brand` value. The equivalent JSON form, which can carry
+any number of configuration values and can attach the generator too, is:
+
+```json
+{
+  "pact:matcher:type": "creditcard",
+  "pact:generator:type": "creditcard",
+  "brand": "visa",
+  "value": "4111111111111111"
+}
+```
+
+Either way it is persisted into the Pact file as an ordinary matching rule whose name happens to come from a plugin:
+
+```json
+"matchingRules": {
+  "body": {
+    "$.card.number": {
+      "combine": "AND",
+      "matchers": [ { "match": "creditcard", "brand": "visa" } ]
+    }
+  }
+}
+```
+
+The consumer test has to load the plugin (`usingPlugin("creditcard")` or your framework's equivalent) before the
+rule can be resolved.
+
+## Files
+
+- [`plugin.lua`](plugin.lua) - the entry point (see `entryPoint` in [`pact-plugin.json`](pact-plugin.json)).
+  Defines `init`, `match_field` and `generate_field`.
+- [`creditcard.lua`](creditcard.lua) - the card number logic itself: normalisation, the Luhn checksum, per-brand IIN
+  prefixes and lengths, brand detection and number generation. Knows nothing about Pact.
+- [`test.lua`](test.lua) - a standalone test harness that stands in for the driver.
+
+There are no vendored third-party libraries - everything the plugin needs is in Lua's standard library.
+
+## Testing
+
+```console
+$ lua5.4 test.lua
+ok   - init returns two catalogue entries
+...
+All checks passed
+```
+
+The harness stubs the `logger` host function, loads `plugin.lua`, and calls its global functions with the same table
+shapes the driver builds. It covers each scheme's published test numbers, the mismatch cases, and round-trips every
+generated number back through the matcher.
+
+## Installing the plugin
+
+There's no build step - it's plain Lua files. Run [`install-local.sh`](install-local.sh), which copies the plugin
+into `$PACT_PLUGIN_DIR/creditcard-0.0.0/` (or `~/.pact/plugins/creditcard-0.0.0/` if `PACT_PLUGIN_DIR` isn't set):
+
+```console
+$ ./install-local.sh
+Installed the creditcard plugin into /home/you/.pact/plugins/creditcard-0.0.0
+```
+
+## Compatibility
+
+Requires a driver that implements field-level matchers and generators
+([proposal 006](../../docs/proposals/006_Field_level_matchers_and_generators.md)), and a host Pact framework that can
+resolve a plugin-provided matching rule. Neither exists yet - the proposal's sequencing section tracks what has to
+land first:
+
+- the `GENERATOR` catalogue entry type and the `MatchField`/`GenerateField` operations in `proto/plugin_v2.proto`;
+- the field matcher/generator surface in the Rust and JVM drivers, including the Lua `match_field`/`generate_field`
+  entry points this plugin defines;
+- carrier variants for plugin-provided rules and generators in `pact_models` and the Pact-JVM model, plus dispatch
+  from the matching engines.
+
+Until then this plugin is a design artefact and a test fixture, not something you can run in a consumer test.

--- a/plugins/creditcard/README.md
+++ b/plugins/creditcard/README.md
@@ -12,9 +12,10 @@ runs embedded in the driver's own process rather than as a separate gRPC server 
 [Writing plugins in Lua](../../docs/writing-plugin-guide.md#writing-plugins-in-lua).
 
 > [!IMPORTANT]
-> Field-level matchers and generators are **not implemented in either driver yet** - proposal 006 is still a draft.
-> This plugin cannot be loaded and run against a real test today. Until it can, [`test.lua`](test.lua) exercises it
-> directly. See [Compatibility](#compatibility) below.
+> Both drivers can now load this plugin and call its rule and generator - the driver-side tests do exactly that -
+> but no host Pact framework can yet resolve a plugin-provided rule from a test, so it cannot be used in a real
+> consumer test. See [Compatibility](#compatibility) below. [`test.lua`](test.lua) also exercises the plugin
+> standalone, with no driver involved.
 
 ## What it does
 
@@ -120,14 +121,20 @@ Installed the creditcard plugin into /home/you/.pact/plugins/creditcard-0.0.0
 ## Compatibility
 
 Requires a driver that implements field-level matchers and generators
-([proposal 006](../../docs/proposals/006_Field_level_matchers_and_generators.md)), and a host Pact framework that can
-resolve a plugin-provided matching rule. Neither exists yet - the proposal's sequencing section tracks what has to
-land first:
+([proposal 006](../../docs/proposals/006_Field_level_matchers_and_generators.md)), and a host Pact framework that
+can resolve a plugin-provided matching rule from a test. The driver half is done; the host half is not.
+
+In place:
 
 - the `GENERATOR` catalogue entry type and the `MatchField`/`GenerateField` operations in `proto/plugin_v2.proto`;
 - the field matcher/generator surface in the Rust and JVM drivers, including the Lua `match_field`/`generate_field`
-  entry points this plugin defines;
-- carrier variants for plugin-provided rules and generators in `pact_models` and the Pact-JVM model, plus dispatch
-  from the matching engines.
+  entry points this plugin defines. Both drivers' test suites load this plugin and exercise it end to end
+  (`lua_plugin.rs` and `LuaPactPluginTest.kt`).
 
-Until then this plugin is a design artefact and a test fixture, not something you can run in a consumer test.
+Still to come:
+
+- carrier variants for plugin-provided rules and generators in `pact_models` and the Pact-JVM model, plus dispatch
+  from the matching engines - without these there is no way to *write* `matching(creditcard, ...)` in a test and
+  have it reach this plugin.
+
+Until that lands, this plugin runs, but only from a driver test rather than from a consumer test.

--- a/plugins/creditcard/creditcard.lua
+++ b/plugins/creditcard/creditcard.lua
@@ -1,0 +1,197 @@
+-- Credit card number helpers: normalisation, Luhn checksum, brand rules and generation.
+--
+-- Nothing in here knows anything about Pact - plugin.lua does all the talking to the driver.
+
+local creditcard = {}
+
+-- Issuer identification number (IIN) rules per brand.
+--
+--   prefixes  - Lua patterns matched against the start of the number
+--   ranges    - { min, max } pairs matched against the first 4 digits as a number, for brands
+--               whose IIN ranges don't fall on a clean prefix boundary
+--   lengths   - permitted total digit counts
+--   seeds     - literal prefixes used when *generating* a number for this brand (the patterns
+--               above can't be used for that - "^5[1-5]" isn't a number)
+--
+-- These are the commonly published ranges rather than an exhaustive registry: a test double
+-- needs to produce and recognise plausible numbers, not to be an authoritative BIN database.
+creditcard.brands = {
+    visa = {
+        name = "Visa",
+        prefixes = { "^4" },
+        lengths = { 13, 16, 19 },
+        seeds = { "4" }
+    },
+    mastercard = {
+        name = "Mastercard",
+        prefixes = { "^5[1-5]" },
+        ranges = { { 2221, 2720 } },
+        lengths = { 16 },
+        seeds = { "51", "52", "53", "54", "55", "2221", "2500", "2720" }
+    },
+    amex = {
+        name = "American Express",
+        prefixes = { "^34", "^37" },
+        lengths = { 15 },
+        seeds = { "34", "37" }
+    },
+    discover = {
+        name = "Discover",
+        prefixes = { "^6011", "^64[4-9]", "^65" },
+        lengths = { 16, 19 },
+        seeds = { "6011", "644", "65" }
+    },
+    jcb = {
+        name = "JCB",
+        prefixes = { "^35" },
+        lengths = { 16, 19 },
+        seeds = { "3528", "3589" }
+    },
+    diners = {
+        name = "Diners Club",
+        prefixes = { "^30[0-5]", "^36", "^38" },
+        lengths = { 14, 16, 19 },
+        seeds = { "300", "36", "38" }
+    }
+}
+
+-- Brand detection has to be order-dependent, and `pairs` order over a Lua table is not stable,
+-- so keep an explicit order. Most specific ranges first.
+creditcard.brand_order = { "amex", "diners", "discover", "jcb", "mastercard", "visa" }
+
+-- Shortest and longest number accepted when no brand is configured (ISO/IEC 7812 allows up
+-- to 19 digits; 12 is the shortest number in real-world use).
+creditcard.min_length = 12
+creditcard.max_length = 19
+
+--- Convert a value from a Pact interaction into a plain digit string.
+-- Accepts a string (with spaces and dashes as separators, as cards are usually written) or an
+-- integer. Returns nil plus a description of the problem if it isn't one.
+function creditcard.normalise(value)
+    local as_string
+    if type(value) == "string" then
+        as_string = value
+    elseif type(value) == "number" then
+        if math.type(value) ~= "integer" then
+            return nil, "is not a whole number"
+        end
+        as_string = string.format("%d", value)
+    else
+        return nil, "is a " .. type(value) .. ", expected a string of digits"
+    end
+
+    local digits = as_string:gsub("[%s%-]", "")
+    if digits == "" then
+        return nil, "is empty"
+    end
+    if not digits:match("^%d+$") then
+        return nil, "contains characters that are not digits (after removing spaces and dashes)"
+    end
+    return digits
+end
+
+-- Sum of the digits under the Luhn doubling rule, working right to left.
+local function luhn_sum(digits)
+    local sum = 0
+    local double = false
+    for i = #digits, 1, -1 do
+        local digit = tonumber(digits:sub(i, i))
+        if double then
+            digit = digit * 2
+            if digit > 9 then
+                digit = digit - 9
+            end
+        end
+        sum = sum + digit
+        double = not double
+    end
+    return sum
+end
+
+--- Is the number's final digit a valid Luhn check digit for the digits preceding it?
+function creditcard.luhn_valid(digits)
+    return #digits > 0 and luhn_sum(digits) % 10 == 0
+end
+
+--- The check digit to append to a number that doesn't have one yet.
+function creditcard.luhn_check_digit(partial)
+    -- Appending a digit flips the doubling parity of every digit already there, so compute the
+    -- sum of the number as it will be once a placeholder digit is on the end.
+    return (10 - (luhn_sum(partial .. "0") % 10)) % 10
+end
+
+--- Does the number look like it was issued under `brand_key`?
+-- Returns true, or false plus the reason it didn't match.
+function creditcard.matches_brand(digits, brand_key)
+    local brand = creditcard.brands[brand_key]
+    if not brand then
+        return false, "'" .. tostring(brand_key) .. "' is not a brand this plugin knows about"
+    end
+
+    local prefix_matched = false
+    for _, pattern in ipairs(brand.prefixes or {}) do
+        if digits:match(pattern) then
+            prefix_matched = true
+            break
+        end
+    end
+    if not prefix_matched and brand.ranges then
+        local leading = tonumber(digits:sub(1, 4))
+        for _, range in ipairs(brand.ranges) do
+            if leading and leading >= range[1] and leading <= range[2] then
+                prefix_matched = true
+                break
+            end
+        end
+    end
+    if not prefix_matched then
+        return false, "does not start with an issuer identification number used by " .. brand.name
+    end
+
+    for _, length in ipairs(brand.lengths) do
+        if #digits == length then
+            return true
+        end
+    end
+    return false, string.format("has %d digits, but %s numbers have %s",
+        #digits, brand.name, table.concat(brand.lengths, " or "))
+end
+
+--- The brand a number appears to belong to, or nil if it doesn't look like any known brand.
+function creditcard.detect_brand(digits)
+    for _, brand_key in ipairs(creditcard.brand_order) do
+        if creditcard.matches_brand(digits, brand_key) then
+            return brand_key
+        end
+    end
+    return nil
+end
+
+--- Generate a fresh, Luhn-valid number for the given brand.
+function creditcard.generate(brand_key)
+    local brand = creditcard.brands[brand_key]
+    if not brand then
+        return nil, "'" .. tostring(brand_key) .. "' is not a brand this plugin knows about"
+    end
+
+    local prefix = brand.seeds[math.random(#brand.seeds)]
+    local length = brand.lengths[math.random(#brand.lengths)]
+
+    local digits = prefix
+    while #digits < length - 1 do
+        digits = digits .. tostring(math.random(0, 9))
+    end
+    return digits .. tostring(creditcard.luhn_check_digit(digits))
+end
+
+--- The list of brands this plugin knows, for error messages.
+function creditcard.known_brands()
+    local names = {}
+    for _, brand_key in ipairs(creditcard.brand_order) do
+        table.insert(names, brand_key)
+    end
+    table.sort(names)
+    return table.concat(names, ", ")
+end
+
+return creditcard

--- a/plugins/creditcard/install-local.sh
+++ b/plugins/creditcard/install-local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+#
+# Installs the credit card Lua example plugin into the local plugin directory so it can be
+# discovered by the driver. There is nothing to compile (it's plain Lua files), so this
+# just copies the plugin directory into place.
+
+set -e
+
+VERSION="0.0.0"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="${PACT_PLUGIN_DIR:-$HOME/.pact/plugins}"
+DEST="$PLUGIN_DIR/creditcard-$VERSION"
+
+mkdir -p "$DEST"
+# test.lua is the standalone test harness, not part of the plugin itself
+cp "$SCRIPT_DIR"/creditcard.lua "$SCRIPT_DIR"/plugin.lua "$SCRIPT_DIR"/pact-plugin.json "$DEST"/
+
+echo "Installed the creditcard plugin into $DEST"

--- a/plugins/creditcard/pact-plugin.json
+++ b/plugins/creditcard/pact-plugin.json
@@ -1,0 +1,8 @@
+{
+  "manifestVersion": 1,
+  "pluginInterfaceVersion": 2,
+  "name": "creditcard",
+  "version": "0.0.0",
+  "executableType": "lua",
+  "entryPoint": "plugin.lua"
+}

--- a/plugins/creditcard/plugin.lua
+++ b/plugins/creditcard/plugin.lua
@@ -1,0 +1,162 @@
+-- Credit card plugin written in Lua
+--
+-- This is the entry point loaded by the driver (see pact-plugin.json's "entryPoint"). Unlike the
+-- JWT plugin next door, which owns a whole content type, this plugin contributes a single
+-- matching rule and a single generator that apply to one *value* inside somebody else's content
+-- - a field in a JSON body, a header, a message metadata value, and so on.
+--
+-- It defines the global functions the driver calls into:
+--   init(implementation, version)  -> catalogue entries
+--   match_field(request)           -> mismatches for one value
+--   generate_field(request)        -> a replacement value
+--
+-- There is no configure_interaction/match_contents here: those belong to content matchers, and
+-- this plugin never owns the content it appears in.
+--
+-- See docs/proposals/006_Field_level_matchers_and_generators.md for the design this implements.
+
+local creditcard = require "creditcard"
+
+-- Called once after the plugin script is loaded. Must return an array of catalogue entries to be
+-- added to the global catalogue.
+--
+-- "MATCHER" and "GENERATOR" entries are named after the rule they provide: the key IS the name a
+-- test writes, so `matching(creditcard, ...)` in a test resolves to the entry registered here.
+-- Both entries deliberately share the key "creditcard" - the entry type is what tells them apart.
+--
+-- "config-key" names the values key that a single positional config argument in a matching rule
+-- definition expression maps to, so `matching(creditcard, 'visa', '4111111111111111')` is stored
+-- in the Pact file as { "match": "creditcard", "brand": "visa" }.
+function init(implementation, version)
+    logger("hello from the credit card plugin: " .. implementation .. ", " .. version)
+
+    -- Add some entropy to the random number generator, used when generating card numbers
+    math.randomseed(os.time())
+
+    local params = { ["config-key"] = "brand" }
+    return {
+        { entryType = "MATCHER", key = "creditcard", values = params },
+        { entryType = "GENERATOR", key = "creditcard", values = params }
+    }
+end
+
+-- Field values arrive either as a plain Lua value or, for binary data, as a { binary = "..." }
+-- wrapper - the same convention message metadata values already use. A card number is text, so a
+-- binary value is always a mismatch rather than something to decode.
+local function unwrap(value)
+    if type(value) == "table" and value.binary ~= nil then
+        return nil, "is binary data, expected a string of digits"
+    end
+    return value
+end
+
+local function display(value)
+    if value == nil then
+        return ""
+    elseif type(value) == "table" then
+        return "<binary>"
+    else
+        return tostring(value)
+    end
+end
+
+-- Called to apply the "creditcard" matching rule to a single value.
+--
+-- `request` has:
+--   key                   - the catalogue key ("creditcard")
+--   rule                  - { type = "creditcard", values = { brand = "visa" } }
+--   path                  - where the value lives, e.g. "$.card.number"
+--   mismatch_type         - which part of the interaction it came from, e.g. "body"
+--   expected              - the example value from the Pact file
+--   actual                - the value received
+--   plugin_configuration  - anything this plugin persisted into the Pact file (unused here)
+--   test_context          - context data from the test framework
+--
+-- Returns { mismatches = { ... } } - an empty (or absent) list means the value matched - or
+-- { error = "..." } if the rule itself could not be applied.
+function match_field(request)
+    local brand_key = (request.rule.values or {}).brand
+    if brand_key ~= nil and creditcard.brands[brand_key] == nil then
+        -- The rule is misconfigured, which is the test author's mistake rather than the
+        -- provider's, so it's an error and not a mismatch.
+        return { error = "'" .. tostring(brand_key) .. "' is not a credit card brand this plugin "
+            .. "knows about. Known brands: " .. creditcard.known_brands() }
+    end
+
+    local function mismatch(description)
+        return {
+            mismatches = {
+                {
+                    expected = display(request.expected),
+                    actual = display(request.actual),
+                    mismatch = description,
+                    path = request.path,
+                    mismatch_type = request.mismatch_type
+                }
+            }
+        }
+    end
+
+    local value, binary_error = unwrap(request.actual)
+    if binary_error then
+        return mismatch("Expected a credit card number, but the value " .. binary_error)
+    end
+
+    local digits, normalise_error = creditcard.normalise(value)
+    if normalise_error then
+        return mismatch("Expected a credit card number, but the value " .. normalise_error)
+    end
+
+    if not creditcard.luhn_valid(digits) then
+        return mismatch("Expected a credit card number, but '" .. digits ..
+            "' fails the Luhn check (its last digit is not a valid check digit)")
+    end
+
+    if brand_key then
+        local matched, reason = creditcard.matches_brand(digits, brand_key)
+        if not matched then
+            return mismatch("Expected a " .. creditcard.brands[brand_key].name ..
+                " credit card number, but '" .. digits .. "' " .. reason)
+        end
+    else
+        -- No brand configured: any number that is well formed and passes the check digit is
+        -- acceptable, whatever issuer it belongs to.
+        if #digits < creditcard.min_length or #digits > creditcard.max_length then
+            return mismatch(string.format(
+                "Expected a credit card number, but '%s' has %d digits (credit card numbers have %d to %d)",
+                digits, #digits, creditcard.min_length, creditcard.max_length))
+        end
+    end
+
+    logger("'" .. digits .. "' at " .. tostring(request.path) .. " is a valid credit card number")
+    return { mismatches = {} }
+end
+
+-- Called to generate a value for the "creditcard" generator, replacing the example value from
+-- the Pact file with a fresh, valid one.
+--
+-- `request` has `key`, `generator` ({ type, values }), `path`, `example_value`,
+-- `plugin_configuration`, `test_context` and `test_mode` ("Consumer"/"Provider"/"Unknown").
+--
+-- Returns { value = ... } or { error = "..." }.
+--
+-- This is a pure function of the request: the brand comes from the generator's own configuration,
+-- falling back to whatever brand the example value in the Pact file looks like, and finally to
+-- Visa. Nothing is read from anywhere else.
+function generate_field(request)
+    local brand_key = (request.generator.values or {}).brand
+
+    if brand_key == nil then
+        local value = unwrap(request.example_value)
+        local digits = value ~= nil and creditcard.normalise(value) or nil
+        brand_key = digits and creditcard.detect_brand(digits) or "visa"
+    end
+
+    local number, error_message = creditcard.generate(brand_key)
+    if error_message then
+        return { error = error_message .. ". Known brands: " .. creditcard.known_brands() }
+    end
+
+    logger("generated a " .. creditcard.brands[brand_key].name .. " number for " .. tostring(request.path))
+    return { value = number }
+end

--- a/plugins/creditcard/test.lua
+++ b/plugins/creditcard/test.lua
@@ -1,0 +1,165 @@
+-- Standalone test for the credit card plugin. Run it with a Lua 5.4 interpreter from this
+-- directory:
+--
+--   $ lua5.4 test.lua
+--
+-- It stands in for the driver: it stubs the `logger` host function, loads plugin.lua, and calls
+-- the plugin's global functions with the same table shapes the driver builds. Field-level
+-- matchers aren't implemented in either driver yet (see
+-- ../../docs/proposals/006_Field_level_matchers_and_generators.md), so until they are, this is
+-- the only way to exercise the plugin at all.
+
+local script_dir = arg[0]:match("^(.*)[/\\][^/\\]*$") or "."
+package.path = script_dir .. "/?.lua;" .. package.path
+
+-- Host functions the driver registers as globals before loading a plugin script.
+function logger(_) end
+
+dofile(script_dir .. "/plugin.lua")
+
+local creditcard = require "creditcard"
+
+local failures = 0
+local function check(description, ok, detail)
+    if ok then
+        print("ok   - " .. description)
+    else
+        failures = failures + 1
+        print("FAIL - " .. description .. (detail and (" : " .. detail) or ""))
+    end
+end
+
+-- Build a match_field request the way the driver would.
+local function match(actual, brand, expected)
+    return match_field({
+        key = "creditcard",
+        rule = { type = "creditcard", values = brand and { brand = brand } or {} },
+        path = "$.card.number",
+        mismatch_type = "body",
+        expected = expected or "4111111111111111",
+        actual = actual
+    })
+end
+
+local function matched(result)
+    return result.error == nil and (result.mismatches == nil or #result.mismatches == 0)
+end
+
+local function generate(brand, example)
+    return generate_field({
+        key = "creditcard",
+        generator = { type = "creditcard", values = brand and { brand = brand } or {} },
+        path = "$.card.number",
+        example_value = example,
+        test_mode = "Consumer"
+    })
+end
+
+local function first_mismatch(result)
+    return result.mismatches and result.mismatches[1] and result.mismatches[1].mismatch or "<none>"
+end
+
+-- init --------------------------------------------------------------------------------------
+
+local entries = init("test-harness", "0.0.0")
+check("init returns two catalogue entries", #entries == 2, tostring(#entries))
+check("init registers a MATCHER named creditcard",
+    entries[1].entryType == "MATCHER" and entries[1].key == "creditcard")
+check("init registers a GENERATOR named creditcard",
+    entries[2].entryType == "GENERATOR" and entries[2].key == "creditcard")
+check("init declares brand as the positional config key",
+    entries[1].values["config-key"] == "brand" and entries[2].values["config-key"] == "brand")
+
+-- matching valid numbers --------------------------------------------------------------------
+
+-- The publicly published test numbers each card scheme provides. All are Luhn valid.
+local test_numbers = {
+    { "4111111111111111", "visa" },
+    { "4012888888881881", "visa" },
+    { "5555555555554444", "mastercard" },
+    { "2223003122003222", "mastercard" },
+    { "378282246310005",  "amex" },
+    { "6011111111111117", "discover" },
+    { "3530111333300000", "jcb" },
+    { "36227206271667",   "diners" }
+}
+for _, case in ipairs(test_numbers) do
+    local number, brand = case[1], case[2]
+    check("matches " .. number .. " with no brand configured", matched(match(number)),
+        first_mismatch(match(number)))
+    check("matches " .. number .. " configured as " .. brand, matched(match(number, brand)),
+        first_mismatch(match(number, brand)))
+    check("detects " .. number .. " as " .. brand, creditcard.detect_brand(number) == brand,
+        tostring(creditcard.detect_brand(number)))
+end
+
+check("tolerates spaces and dashes between digit groups", matched(match("4111-1111 1111-1111")))
+check("accepts a number supplied as a JSON integer", matched(match(4111111111111111)))
+
+-- mismatches ---------------------------------------------------------------------------------
+
+local bad_luhn = match("4111111111111112")
+check("rejects a number with a bad check digit", not matched(bad_luhn))
+check("says so in the mismatch description", first_mismatch(bad_luhn):find("Luhn") ~= nil,
+    first_mismatch(bad_luhn))
+check("reports the mismatch against the request's path", bad_luhn.mismatches[1].path == "$.card.number")
+check("reports the part of the interaction it came from", bad_luhn.mismatches[1].mismatch_type == "body")
+check("reports both the expected and the actual value",
+    bad_luhn.mismatches[1].expected == "4111111111111111"
+    and bad_luhn.mismatches[1].actual == "4111111111111112")
+
+check("rejects a value that isn't digits", not matched(match("not a card")))
+check("rejects an empty value", not matched(match("")))
+check("rejects a boolean", not matched(match(true)))
+check("rejects a non-integer number", not matched(match(4111111111111111.5)))
+check("rejects binary data", not matched(match({ binary = "\1\2\3" })))
+check("rejects a number that is too short", not matched(match("4111111111")))
+
+local wrong_brand = match("5555555555554444", "visa")
+check("rejects a valid number of the wrong brand", not matched(wrong_brand))
+check("names the configured brand in the mismatch", first_mismatch(wrong_brand):find("Visa") ~= nil,
+    first_mismatch(wrong_brand))
+
+local short_visa = match("4111111111111", "amex")
+check("rejects a number of the wrong length for its brand", not matched(short_visa))
+
+-- a misconfigured rule is the test author's mistake, so an error rather than a mismatch
+local unknown_brand = match("4111111111111111", "amx")
+check("treats an unknown configured brand as an error, not a mismatch",
+    unknown_brand.error ~= nil and unknown_brand.mismatches == nil, unknown_brand.error)
+
+-- generation ----------------------------------------------------------------------------------
+
+for _, brand in ipairs(creditcard.brand_order) do
+    local result = generate(brand)
+    check("generates a " .. brand .. " number", result.error == nil and result.value ~= nil, result.error)
+    if result.value then
+        check("the generated " .. brand .. " number (" .. result.value .. ") passes its own matcher",
+            matched(match(result.value, brand)), first_mismatch(match(result.value, brand)))
+    end
+end
+
+local from_example = generate(nil, "378282246310005")
+check("takes the brand from the example value when not configured",
+    from_example.value ~= nil and creditcard.detect_brand(from_example.value) == "amex",
+    tostring(from_example.value))
+
+local no_example = generate(nil, nil)
+check("falls back to Visa with neither configuration nor an example",
+    no_example.value ~= nil and creditcard.detect_brand(no_example.value) == "visa",
+    tostring(no_example.value))
+
+local first, second = generate("visa").value, generate("visa").value
+check("generates a different number on each call", first ~= second, first .. " / " .. second)
+
+check("treats an unknown brand for generation as an error", generate("nope").error ~= nil)
+
+-- ----------------------------------------------------------------------------------------------
+
+print("")
+if failures == 0 then
+    print("All checks passed")
+else
+    print(failures .. " check(s) failed")
+    os.exit(1)
+end

--- a/proto/plugin_v2.proto
+++ b/proto/plugin_v2.proto
@@ -38,6 +38,8 @@ message CatalogueEntry {
     MATCHER = 3;
     // Type of interaction
     INTERACTION = 4;
+    // Generator for a content field/value. See proposal 006 (Field-level matchers and generators).
+    GENERATOR = 5;
   }
   // Entry type
   EntryType type = 1;
@@ -283,6 +285,79 @@ message GenerateContentResponse {
   Body contents = 1;
 }
 
+// A single value being matched or generated at the field/element level. Binary-safe: follows the
+// same oneof pattern as MetadataValue rather than assuming every value can be represented as
+// JSON. See proposal 006 (Field-level matchers and generators).
+message FieldValue {
+  oneof value {
+    // A JSON-like value
+    google.protobuf.Value nonBinaryValue = 1;
+    // Raw bytes, for a value that is not representable as JSON
+    bytes binaryValue = 2;
+  }
+}
+
+// Request to apply a plugin-provided matching rule to a single value. The plugin sees the value,
+// its path and the rule's own configuration, but not the document that contains it - a rule that
+// needs the surrounding document is a content matcher. See proposal 006.
+message MatchFieldRequest {
+  // Catalogue entry key of the rule being applied, e.g. "creditcard" for matcher/creditcard
+  string key = 1;
+  // The rule as stored in the Pact file: its name and configured values
+  MatchingRule rule = 2;
+  // Path to the value being matched. This is the value as per the documented Pact matching rule expressions.
+  string path = 3;
+  // Part of the interaction the value came from: body, headers, metadata, query, path, status
+  string mismatchType = 4;
+  // Expected value from the Pact interaction
+  FieldValue expected = 5;
+  // Actual value received
+  FieldValue actual = 6;
+  // Additional data added to the Pact/Interaction by the plugin
+  PluginConfiguration pluginConfiguration = 7;
+  // Context data provided by the test framework (carries testRunId for log correlation)
+  google.protobuf.Struct testContext = 8;
+}
+
+// Response to the MatchFieldRequest with the result of applying the rule
+message MatchFieldResponse {
+  // Error message if the rule could not be applied at all. If this field is set, the remaining
+  // fields will be ignored and the verification marked as failed
+  string error = 1;
+  // Mismatches found. An empty list means the value matched. A mismatch with an empty path is
+  // reported against the path from the request
+  repeated ContentMismatch mismatches = 2;
+}
+
+// Request to generate a single value using a plugin-provided generator. Generators are pure
+// functions of this request: anything from the host they need arrives in testContext or is
+// fetched with an explicit callback. See proposal 006.
+message GenerateFieldRequest {
+  // Catalogue entry key of the generator being applied, e.g. "creditcard" for generator/creditcard
+  string key = 1;
+  // The generator as stored in the Pact file: its name and configured values
+  Generator generator = 2;
+  // Path to the value being generated. This is the value as per the documented Pact matching rule expressions.
+  string path = 3;
+  // The example value from the Pact interaction that the generated value replaces
+  FieldValue exampleValue = 4;
+  // Additional data added to the Pact/Interaction by the plugin
+  PluginConfiguration pluginConfiguration = 5;
+  // Context data provided by the test framework
+  google.protobuf.Struct testContext = 6;
+  // The mode of the generation, if running from a consumer test or during provider verification
+  GenerateContentRequest.TestMode testMode = 7;
+}
+
+// Response to the GenerateFieldRequest with the generated value
+message GenerateFieldResponse {
+  // Error message if the value could not be generated. If this field is set, the value will be
+  // ignored
+  string error = 1;
+  // The generated value
+  FieldValue value = 2;
+}
+
 // Request to start a mock server
 message StartMockServerRequest {
   // Interface to bind to. Will default to the loopback adapter
@@ -456,6 +531,25 @@ message HostGenerateContentRequest {
   GenerateContentRequest request = 2;
 }
 
+// Callback request from a plugin to invoke a field-level matching rule - host-provided (one of the
+// standard Pact rules) or owned by another plugin - resolved by catalogue entry key. See proposals
+// 006 (Field-level matchers and generators) and 007 (Driver-plugin callback model).
+message HostMatchFieldRequest {
+  // Catalogue entry key identifying the rule to invoke, e.g. "type" for matcher/type
+  string entryKey = 1;
+  // The match request, in the same shape as PactPlugin.MatchField
+  MatchFieldRequest request = 2;
+}
+
+// Callback request from a plugin to invoke a field-level generator - host-provided or owned by
+// another plugin - resolved by catalogue entry key. See proposals 006 and 007.
+message HostGenerateFieldRequest {
+  // Catalogue entry key identifying the generator to invoke, e.g. "date" for generator/date
+  string entryKey = 1;
+  // The generation request, in the same shape as PactPlugin.GenerateField
+  GenerateFieldRequest request = 2;
+}
+
 // Driver-side service implemented by the driver and called by plugins
 service PluginHost {
   // Forward a structured log record from the plugin to the driver's logging framework
@@ -466,6 +560,13 @@ service PluginHost {
   // Invoke a content generator capability by catalogue entry key. The driver resolves the key to
   // either a host-registered core handler or another running plugin. See proposal 007.
   rpc GenerateContent(HostGenerateContentRequest) returns (GenerateContentResponse);
+  // Invoke a field-level matching rule by catalogue entry key, resolved the same way. This is how
+  // a plugin delegates one field of a document it owns to a standard Pact rule instead of
+  // reimplementing it. See proposals 006 and 009.
+  rpc MatchField(HostMatchFieldRequest) returns (MatchFieldResponse);
+  // Invoke a field-level generator by catalogue entry key, resolved the same way.
+  // See proposals 006 and 009.
+  rpc GenerateField(HostGenerateFieldRequest) returns (GenerateFieldResponse);
 }
 
 service PactPlugin {
@@ -479,6 +580,13 @@ service PactPlugin {
   rpc ConfigureInteraction(ConfigureInteractionRequest) returns (ConfigureInteractionResponse);
   // Request to generate the content using any defined generators
   rpc GenerateContent(GenerateContentRequest) returns (GenerateContentResponse);
+
+  // Apply a plugin-provided matching rule to a single value. Required for any plugin that
+  // registers a MATCHER catalogue entry. See proposal 006 (Field-level matchers and generators).
+  rpc MatchField(MatchFieldRequest) returns (MatchFieldResponse);
+  // Apply a plugin-provided generator to a single value. Required for any plugin that registers
+  // a GENERATOR catalogue entry. See proposal 006.
+  rpc GenerateField(GenerateFieldRequest) returns (GenerateFieldResponse);
 
   // Start a mock server
   rpc StartMockServer(StartMockServerRequest) returns (StartMockServerResponse);

--- a/proto/plugin_v2.proto
+++ b/proto/plugin_v2.proto
@@ -535,7 +535,9 @@ message HostGenerateContentRequest {
 // standard Pact rules) or owned by another plugin - resolved by catalogue entry key. See proposals
 // 006 (Field-level matchers and generators) and 007 (Driver-plugin callback model).
 message HostMatchFieldRequest {
-  // Catalogue entry key identifying the rule to invoke, e.g. "type" for matcher/type
+  // Catalogue entry key identifying the rule to invoke. Either the name as a Pact file writes it
+  // ("type"), or the key as hostCapabilities advertises it ("matcher/v2-type") - the core
+  // catalogue prefixes the Pact specification version a rule was introduced in to its name.
   string entryKey = 1;
   // The match request, in the same shape as PactPlugin.MatchField
   MatchFieldRequest request = 2;
@@ -544,7 +546,8 @@ message HostMatchFieldRequest {
 // Callback request from a plugin to invoke a field-level generator - host-provided or owned by
 // another plugin - resolved by catalogue entry key. See proposals 006 and 007.
 message HostGenerateFieldRequest {
-  // Catalogue entry key identifying the generator to invoke, e.g. "date" for generator/date
+  // Catalogue entry key identifying the generator to invoke, e.g. "date" or "generator/v3-date".
+  // See HostMatchFieldRequest.entryKey.
   string entryKey = 1;
   // The generation request, in the same shape as PactPlugin.GenerateField
   GenerateFieldRequest request = 2;

--- a/proto/plugin_v2.proto
+++ b/proto/plugin_v2.proto
@@ -285,15 +285,35 @@ message GenerateContentResponse {
   Body contents = 1;
 }
 
-// A single value being matched or generated at the field/element level. Binary-safe: follows the
-// same oneof pattern as MetadataValue rather than assuming every value can be represented as
-// JSON. See proposal 006 (Field-level matchers and generators).
+// A single value being matched or generated at the field/element level.
+//
+// Each type Pact's matching rules discriminate has its own arm, rather than everything
+// JSON-representable sharing a google.protobuf.Value. That type carries a single number type (a
+// double), which would make `integer` and `decimal` indistinguishable and `type` wrong between a
+// whole number and a decimal - and these are exactly the rules whose job is to check the runtime
+// type of a value. Binary data has its own arm for the same reason: so it never has to be
+// stringified into a form it does not fit.
+//
+// See proposal 006 (Field-level matchers and generators).
 message FieldValue {
   oneof value {
-    // A JSON-like value
-    google.protobuf.Value nonBinaryValue = 1;
-    // Raw bytes, for a value that is not representable as JSON
-    bytes binaryValue = 2;
+    // A null value
+    google.protobuf.NullValue nullValue = 1;
+    // A boolean
+    bool booleanValue = 2;
+    // A string
+    string stringValue = 3;
+    // A whole number
+    int64 integerValue = 4;
+    // A number with a fractional part
+    double decimalValue = 5;
+    // Raw bytes, for a value that is not representable as text
+    bytes binaryValue = 6;
+    // A map or list, for a rule applied to a collection rather than a scalar. Numbers nested
+    // inside follow JSON semantics (every number is a double) - a collection rule only needs the
+    // shape and size of the collection, and the values inside it are matched by their own
+    // field-level calls, at their own paths, where they arrive under the arms above.
+    google.protobuf.Value structuredValue = 7;
   }
 }
 


### PR DESCRIPTION
Implements [proposal 006, Field-level matchers and generators](https://github.com/pact-foundation/pact-plugins/blob/feat/field-level-matchers/docs/proposals/006_Field_level_matchers_and_generators.md) — the last piece of the v2 plugin design. The proposal itself was written as part of this branch, derived from a worked example (a credit card number rule), and its sequencing section tracks what has landed.

A **content matcher** owns a whole content type. A **field matcher** is a smaller thing: one rule applied to one *value* inside somebody else's content — a field in a JSON body, a header, a message metadata value. That's what this adds.

## What's here

**Proto (`plugin_v2.proto`)** — a `GENERATOR` catalogue entry type, `FieldValue`, the four request/response messages, and `MatchField`/`GenerateField` on both `PactPlugin` and `PluginHost`. Field-level operations are V2-only; a V1 plugin gets a clear error rather than a silent no-op.

**Both drivers** — `field.rs` / `Field.kt` (the value type, context, and the matcher/generator pair dispatching on core-vs-plugin), the two core capability registries, the `PluginHost` callbacks, and the client methods.

**Lua support in both drivers** — `match_field`/`generate_field` entry points and `host_match_field`/`host_generate_field` callbacks, so a Lua plugin can provide a field-level rule, and a plugin that owns a content type can delegate one value inside it to a standard Pact rule instead of reimplementing it.

**`plugins/creditcard`** — a reference plugin in Lua, written against the design to keep it honest. Both drivers' suites load it and exercise it end to end.

**Docs** — the Lua reference and writing guide cover the new functions, entry types and value shapes, plus proposal 007's `host_compare_contents`/`host_generate_content`, which had never been documented.

## Three things worth a reviewer's attention

**`FieldValue` has an arm per scalar type**, not a `google.protobuf.Value`. A `Value` makes every number a double, and rules like `integer`, `decimal` and `type` check the runtime type of what they're given — `100` becoming `100.0` would quietly break them. This shaped work throughout: the JVM's `LuaJavaEngine` needed fixing one level down, because luajava's `toObject` returns every Lua number as a `Double` and every Lua string as a Java `String`, so a whole number came back as a decimal and a binary value was truncated at its first NUL byte. Reading the stack directly fixes both, and fixes the pre-existing metadata path too. The Rust driver needed no equivalent — mlua distinguishes integers from floats and its strings are byte-safe.

**Catalogue key resolution changed** (`98ff8c0`, `842de5a`). Key lookup was matching on substrings, so `type` could resolve to an unrelated entry that merely contained it. It's now exact-match first, then a `v*-` fallback scoped to matcher/generator entries — core matching rules are registered with the Pact specification version they were introduced in prefixed to the name (`v2-type`, `v3-date`), so a bare name still resolves without the caller knowing which version that was. This is a behaviour change to existing lookups, not just new code.

**`CatalogueEntryType` is now the driver's own type** (`6c82a44`), not the V1 proto enum. `GENERATOR` only exists in V2, and prost's generated accessor silently maps an unrecognised value to the default — a `GENERATOR` entry would have registered as a `CONTENT_MATCHER`. Rather than add the variant to the frozen V1 contract, the driver owns the type and treats V2 as the canonical wire form.

## Not here

Host framework integration (step 6) — the `MatchingRule::Plugin`/`Generator::Plugin` carriers and matching-engine dispatch that make `matching(creditcard, ...)` writable in a test. That lands in `pact-reference` and Pact-JVM, which consume these drivers as published dependencies, so it's blocked on releasing them first. Until then the credit-card plugin runs from a driver test but can't be reached from a consumer test, and its README says so.

WASM is explicitly out of scope; the operation shape is transport-neutral by construction so the mapping is mechanical once [003](https://github.com/pact-foundation/pact-plugins/blob/feat/field-level-matchers/docs/proposals/003_Support_WASM_plugins.md) lands.

## Testing

Rust driver: 103 tests, `cargo clippy --all-targets --all-features` clean of new warnings. JVM driver: 143 tests, detekt clean. Both include the credit-card plugin running for real, plus `plugins/creditcard/test.lua` (60 checks) exercising it standalone with no driver involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)