### PR TITLE
feat: Supports standard matching rules and generators as core plugin capabilities

### DIFF
--- a/docs/lua-plugin-reference.md
+++ b/docs/lua-plugin-reference.md
@@ -122,8 +122,13 @@ Each entry in `interactions`:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `contents` | table or nil | No | A [`Body`](#body-table). |
+| `rules` | table (path -> array of rule tables) | No | Matching rules for this part, in the same shape `match_contents` receives them - see [`MatchingRules`](#matchingrules-table). These are the interaction's ordinary matching rules: they are written to the Pact file's `matchingRules` and handed back to you as `rules` in later `match_contents` calls, on both sides of the test. Use them for a rule the *test author* declared on something inside your content type; use `plugin_config` for data of your own that you need back later (a key, a schema). |
 | `part_name` | string | No | Which part this is for (e.g. `"request"`/`"response"`), or `""` for a plain body. |
 | `plugin_config` | table or nil | No | Interaction-level plugin config - see [`PluginConfiguration`](#pluginconfiguration-table). This is handed back to you as `plugin_configuration` in later `match_contents` calls for the same interaction. |
+
+The paths in `rules` only have to mean something to you: the framework can not traverse a content type it does not
+understand, so it stores and returns them without interpreting them. The [JWT plugin](../plugins/jwt) keys a rule
+on a claim as `$.claims.<name>`, for instance.
 
 ```lua
 function configure_interaction(content_type, config)
@@ -131,6 +136,7 @@ function configure_interaction(content_type, config)
     interactions = {
       {
         contents = { contents = "signed-token-string", content_type = "application/jwt+json", content_type_hint = "BINARY" },
+        rules = { ["$.claims.customer_id"] = { { type = "regex", values = { regex = "CUST-\\d{6}" } } } },
         part_name = "",
         plugin_config = { interaction_configuration = { ["public-key"] = "...", algorithm = "RS512" } }
       }
@@ -536,11 +542,12 @@ The two field-level ones are how a content matcher applies a standard Pact rule 
 owns - the plugin keeps ownership of parsing and traversing its content type, and hands off the actual comparison
 of a leaf value.
 
-An `entry_key` is either the bare name of the capability (`"type"`, `"creditcard"`) or its full catalogue key
-(`"matcher/v2-type"`, `"plugin/creditcard/matcher/creditcard"`). The bare name is the usual choice: core matching
-rules are registered under a key with the Pact specification version they were introduced in prefixed to the name
-(`v2-type`, `v3-date`), and resolving a bare name finds those without you having to know which version that was.
-A key that matches nothing, or matches more than one capability, is an error rather than a silent no-op.
+An `entry_key` is either the bare name of the capability (`"type"`, `"creditcard"`) or more of its catalogue key
+(`"matcher/type"`, `"plugin/creditcard/matcher/creditcard"`). The bare name is the usual choice: core matching rules
+are registered under the name the rule carries in a request, so the `type` field of a rule you were handed is
+already a usable `entry_key`. A key that matches nothing, or matches more than one capability, is an error rather
+than a silent no-op - name more of the key (`"core/matcher/date"`) if a plugin has registered a rule under a name
+you also want from the host.
 
 ```lua
 function match_contents(request)

--- a/docs/plugin-driver-design.md
+++ b/docs/plugin-driver-design.md
@@ -157,33 +157,55 @@ messages (one off or fire and forget) and synchronous messages (request/response
 
 ### Core catalogue entries
 
-The driver must provide the following entries from the Pact framework:
+The driver must provide the following entries from the Pact framework. Matching rule entries are keyed by the name
+the rule carries in a request (the same string a `MatchFieldRequest` puts in `rule.type`); the Pact specification
+version the rule was introduced in is a `spec-version` value on the entry rather than part of the key. Frameworks
+register the rules and generators they implement, so the exact list varies - Pact-JVM adds the `ignore-order`,
+`min-ignore-order`, `max-ignore-order` and `min-max-ignore-order` matching rules and the `Null` generator (all V4),
+which the Rust implementation does not have. Generator keys are `PascalCase` because that is the `type` a generator
+carries in a Pact file and in a request, the same way matching rule keys are the `MatchingRule` name.
 
 | Key | Description |
 | --- | ----------- |
 | `core/interaction/http` | Support Http/1.1 interactions (request/response) | 
 | `core/interaction/https` | Support Http/1.1 + TLS interactions (request/response) |
 | `core/interaction/message` | Support message interactions |
-| `core/matcher/v2-regex` | V2 spec regex matcher |
-| `core/matcher/v2-type` | V2 spec type matcher |
-| `core/matcher/v3-number-type` | V3 spec number matcher |
-| `core/matcher/v3-integer-type` | V3 spec integer matcher |
-| `core/matcher/v3-decimal-type` | V3 spec decimal matcher |
-| `core/matcher/v3-date` | V3 spec date matcher |
-| `core/matcher/v3-time` | V3 spec time matcher |
-| `core/matcher/v3-datetime` | V3 spec DateTime matcher |
-| `core/matcher/v2-min-type` | V2 spec minimum type matcher |
-| `core/matcher/v2-max-type` | V2 spec maximum type matcher |
-| `core/matcher/v2-minmax-type` | V2 spec minimum/maximum type matcher |
-| `core/matcher/v3-includes` | V3 spec includes matcher |
-| `core/matcher/v3-null` | V3 spec null matcher |
-| `core/matcher/v4-equals-ignore-order` | V4 spec ignore array order matcher matcher |
-| `core/matcher/v4-min-equals-ignore-order` | V4 spec ignore array order matcher matcher |
-| `core/matcher/v4-max-equals-ignore-order` | V4 spec ignore array order matcher matcher |
-| `core/matcher/v4-minmax-equals-ignore-order` | V4 spec ignore array order matcher matcher |
-| `core/matcher/v3-content-type` | V3 spec content type matcher |
-| `core/matcher/v4-array-contains` | V4 spec array contains matcher |
-| `core/matcher/v1-equality` | V1 spec equality matcher |
+| `core/matcher/equality` | Equality matcher (V1) |
+| `core/matcher/regex` | Regex matcher (V2) |
+| `core/matcher/type` | Type matcher (V2) |
+| `core/matcher/min-type` | Minimum type matcher (V2) |
+| `core/matcher/max-type` | Maximum type matcher (V2) |
+| `core/matcher/min-max-type` | Minimum/maximum type matcher (V2) |
+| `core/matcher/include` | Includes matcher (V3) |
+| `core/matcher/number` | Number matcher (V3) |
+| `core/matcher/integer` | Integer matcher (V3) |
+| `core/matcher/decimal` | Decimal matcher (V3) |
+| `core/matcher/null` | Null matcher (V3) |
+| `core/matcher/date` | Date matcher (V3) |
+| `core/matcher/time` | Time matcher (V3) |
+| `core/matcher/datetime` | DateTime matcher (V3) |
+| `core/matcher/content-type` | Content type matcher (V3) |
+| `core/matcher/values` | Values matcher (V3) |
+| `core/matcher/array-contains` | Array contains matcher (V4) |
+| `core/matcher/boolean` | Boolean matcher (V4) |
+| `core/matcher/status-code` | Status code matcher (V4) |
+| `core/matcher/not-empty` | Not empty matcher (V4) |
+| `core/matcher/semver` | Semantic version matcher (V4) |
+| `core/matcher/each-key` | Each key matcher (V4) |
+| `core/matcher/each-value` | Each value matcher (V4) |
+| `core/generator/RandomInt` | Random integer generator (V3) |
+| `core/generator/RandomDecimal` | Random decimal generator (V3) |
+| `core/generator/RandomHexadecimal` | Random hexadecimal generator (V3) |
+| `core/generator/RandomString` | Random string generator (V3) |
+| `core/generator/RandomBoolean` | Random boolean generator (V3) |
+| `core/generator/Regex` | Regex generator (V3) |
+| `core/generator/Uuid` | UUID generator (V3) |
+| `core/generator/Date` | Date generator (V3) |
+| `core/generator/Time` | Time generator (V3) |
+| `core/generator/DateTime` | DateTime generator (V3) |
+| `core/generator/ProviderState` | Provider state generator (V3) |
+| `core/generator/MockServerURL` | Mock server URL generator (V4) |
+| `core/generator/ArrayContains` | Array contains generator (V4) |
 | `core/content-matcher/xml` | Matcher for XML content types |
 | `core/content-matcher/json` | Matcher for JSON content types |
 | `core/content-matcher/text` | Matcher for Text content types |

--- a/docs/proposals/006_Field_level_matchers_and_generators.md
+++ b/docs/proposals/006_Field_level_matchers_and_generators.md
@@ -96,23 +96,26 @@ The **rule name is the catalogue key**. A rule named `creditcard` resolves throu
 
 - a bare name (`creditcard`) matches the entry's key; a caller can also name more of the catalogue key
   (`matcher/creditcard`, `plugin/creditcard/matcher/creditcard`) to disambiguate if two plugins ever register the
-  same short name. Key components are compared whole, never as substrings;
-- failing that, the name is matched against the core catalogue's versioned naming convention - the Pact
-  specification version a rule was introduced in, prefixed to its name - so `type` resolves to `core/matcher/v2-type`
-  and `date` to `core/matcher/v3-date` without a caller having to know which version introduced what. This applies
-  only to `MATCHER` and `GENERATOR` entries: content matchers, content generators and transports are registered
-  under plain names (`xml`, `json`, `grpc`), where a leading `v<n>-` would be part of the name. Naming an entry
-  directly always wins over the fallback: a plugin registering its own `matcher/date` takes `date`, and a caller
-  that specifically wants the core rule asks for `v3-date`;
+  same short name. Key components are compared whole, never as substrings, so `type` names the `type` rule and not
+  `content-type` or `min-type`;
 - a name matching more than one entry of the expected type is a hard error naming the candidates, never a silent
   pick;
 - a name matching nothing is a hard error at match/generate time.
 
-Core rule names always win: the host resolves `type`, `regex`, `equality` and the rest of the standard set from its
-own matching engine before it ever consults the catalogue, so a plugin cannot shadow a standard rule. (Once
-[009](./009_Host_provided_core_matching_and_generation.md) registers the standard set as `CORE` entries, those become
-visible in the catalogue too - as `core/matcher/v2-type` etc. - which is what lets a *plugin* call back for them, but
-does not change how the host resolves its own rules.)
+The core rules are registered under the name the rule carries in a request - the string `MatchingRule::name()`
+returns, which is also what `MatchFieldRequest.rule.type` holds - so a plugin handed a rule it does not implement can
+name it straight back without translation, and without knowing which specification version introduced it. That
+version is a `spec-version` value on the entry rather than part of the key. (The original design prefixed the version
+to the key, `v2-type`/`v3-date`, and gave the resolver a second pass that stripped it. Keying by the rule name
+directly removes both the prefix and the pass.)
+
+Core rule names always win where it matters: the host resolves `type`, `regex`, `equality` and the rest of the
+standard set from its own matching engine before it ever consults the catalogue, so a plugin cannot shadow a standard
+rule for the host's own matching. In the callback direction a plugin registering its own `matcher/date` alongside the
+core `date` rule makes the bare name ambiguous - an error naming both candidates, which either caller resolves by
+naming more of the key (`core/matcher/date`, `plugin/my-plugin/matcher/date`). Registering the standard set as `CORE`
+entries is [009](./009_Host_provided_core_matching_and_generation.md)'s remaining job; the entries themselves already
+exist in both hosts.
 
 ### 3. Declaring a plugin rule in a test
 
@@ -287,7 +290,7 @@ Notes on specific choices:
   strings. A plugin declares it provides a field rule by registering the catalogue entry, and implementing the
   matching RPC is then part of that entry's contract. In the other direction, host-provided rules appear in
   `hostCapabilities` automatically, since the driver already derives that list from its core catalogue entries as
-  `<entry_type>/<key>` - `matcher/v2-type`, `generator/v3-date`, and so on, once 009 registers them.
+  `<entry_type>/<key>` - `matcher/type`, `generator/date`, and so on, once 009 registers them.
 
 ### 6. Context available to the plugin
 
@@ -337,7 +340,7 @@ resolver, the same `pact-call-chain-id` cycle detection and `pact-deadline-ms` p
 dispatch.
 
 This is what makes the "plugin owns a content type, delegates most fields to the host" story work: a protobuf plugin
-matching a `CreditCard` message can apply `matcher/v2-type` to most fields through the host and only implement what is
+matching a `CreditCard` message can apply `matcher/type` to most fields through the host and only implement what is
 actually protobuf-specific, and can hand a field carrying a `{ "match": "creditcard" }` rule straight to the
 `creditcard` plugin without knowing it exists.
 

--- a/docs/proposals/009_Host_provided_core_matching_and_generation.md
+++ b/docs/proposals/009_Host_provided_core_matching_and_generation.md
@@ -1,7 +1,7 @@
-# Host-provided core matching and generation (Draft)
+# Host-provided core matching and generation (In progress)
 
 > [!NOTE]
-> **Implementation phase:** Phase 4. Cannot be implemented until [005](./005_Plugin_capability_negotiation_and_versioning.md), [006](./006_Field_level_matchers_and_generators.md), and [007](./007_Driver_plugin_callback_model.md) are all finalised. See the [proposals README](./README.md) for the full delivery order.
+> **Implementation phase:** Phase 4. Its prerequisites - [005](./005_Plugin_capability_negotiation_and_versioning.md), [006](./006_Field_level_matchers_and_generators.md) and [007](./007_Driver_plugin_callback_model.md) - are all implemented. Both hosts now register the standard matching rules and generators, at content and field level, so a plugin can delegate a standard rule to the host it is running under. What remains is the WASM transport, which is blocked on [003](./003_Support_WASM_plugins.md). See [Sequencing](#sequencing) for the current state and the [proposals README](./README.md) for the full delivery order.
 
 ## Summary
 
@@ -39,8 +39,9 @@ and generator set (`type`, `regex`, `equality`, `date`/`time`, etc. — the same
 catalogue) as `CatalogueEntryProviderType::CORE` entries, each with a registered handler implementing the relevant
 trait from 007 (a content-level `CoreContentMatcher`/`CoreContentGenerator`, or the field-level equivalent 006 defines).
 A plugin that wants standard behaviour for a field it doesn't want to reimplement calls back through the mechanism 007
-already defines, naming the catalogue key for the standard rule it wants (e.g. `matcher/v2-type`,
-`matcher/v2-regex`, or just `type`/`regex` - see [006](./006_Field_level_matchers_and_generators.md#2-naming-and-resolution)).
+already defines, naming the catalogue key for the standard rule it wants (`type`, `regex`, `content-type` - the name
+the rule carries in a request, or more of the catalogue key to disambiguate it, `matcher/type`/`core/matcher/type` -
+see [006](./006_Field_level_matchers_and_generators.md#2-naming-and-resolution)).
 
 No new protocol messages, transports, or dependency-inversion mechanism are needed beyond what 006 and 007 already
 define. This proposal's remaining job is narrower than originally scoped: registering the existing standard matcher/
@@ -54,16 +55,84 @@ values).
 1. ✅ 007's content-level mechanism (the `CoreContentMatcher`/`CoreContentGenerator` registry and the extended
    `PluginHost` gRPC service with cycle detection and deadline propagation). Done in both drivers — Rust
    (`core_capabilities.rs`, `call_chain.rs`, `plugin_host.rs`) and JVM (`CoreCapabilities.kt`, `CallChain.kt`,
-   `PluginHostServer.kt`) — see [007](./007_Driver_plugin_callback_model.md#sequencing). This unblocks registering
-   any *content-level* standard matcher/generator (a whole content type, not a single field) through the mechanism
-   today.
-2. ⬜ [006](./006_Field_level_matchers_and_generators.md)'s field-level operation shape. Not started. Blocks
-   registering the field-level standard rules (`type`, `regex`, `equality`, etc. applied to a single field rather
-   than a whole content type), which is most of what this proposal is actually for.
-3. ⬜ Register the standard Pact matcher/generator set as `CORE` catalogue entries with handlers implementing 007's
-   traits (content-level now possible; field-level blocked on step 2). Not started.
-4. ⬜ WASM and Lua host-function equivalents, following [007](./007_Driver_plugin_callback_model.md#sequencing)'s
-   step 4. Not started.
+   `PluginHostServer.kt`) — see [007](./007_Driver_plugin_callback_model.md#sequencing).
+2. ✅ [006](./006_Field_level_matchers_and_generators.md)'s field-level operation shape, in both drivers and both
+   hosts — see [006's sequencing](./006_Field_level_matchers_and_generators.md#sequencing). What this proposal
+   needs from it is the four registration functions and the resolver behind them:
+   `register_core_field_matcher`/`register_core_field_generator` (`core_capabilities.rs`) and
+   `CoreCapabilityRegistry.registerFieldMatcher`/`registerFieldGenerator` (`CoreCapabilities.kt`), dispatched to by
+   `FieldMatcher`/`FieldGenerator` when the resolved entry is a `CORE` one.
+3. ✅ Register the standard Pact matcher/generator set as `CORE` catalogue entries with handlers implementing 007's
+   traits:
+   - **Catalogue entries.** Both hosts register one `MATCHER` entry per matching rule and one `GENERATOR`
+     entry per generator they implement — see [Registered entries](#registered-entries) below.
+   - **Content-level handlers.** `pact_matching`'s `core_capabilities.rs` registers `xml`, `json`, `text` and
+     `multipart-form-data` matchers plus `json` and `binary` generators; Pact-JVM's
+     `MatchingConfig.registerCoreCapabilities` registers the same four matchers plus `form-urlencoded`, and the
+     `json` generator.
+   - **Field-level handlers.** One handler serves every delegatable rule (the rule to apply comes from the
+     request, so there is nothing per-rule to write) and one serves every delegatable generator, registered
+     against each key: `CoreFieldRuleMatcher`/`CoreFieldValueGenerator` in `pact_matching`'s
+     `core_capabilities.rs` and in Pact-JVM's `CoreFieldCapabilities.kt`. The collection-wide rules get
+     `CollectionRuleMatcher`/`CollectionValueGenerator`, which answer with why the rule can not be applied to one
+     value — see [Delegatable set](#delegatable-set).
+4. ⬜ WASM host-function equivalents, following [007](./007_Driver_plugin_callback_model.md#sequencing)'s step 4.
+   Not started, and blocked on [003](./003_Support_WASM_plugins.md) landing WASM plugin support at all. The Lua
+   equivalents (`host_match_field`/`host_generate_field`) are done in both drivers, as 006 step 4.
+
+### Registered entries
+
+Both hosts key each entry by **the name the rule or generator carries in a request** — the string
+`MatchingRule::name()`/`MatchingRule.name` and `Generator::name()`/`Generator.type` return, which is exactly what the
+driver puts in `MatchFieldRequest.rule.type` and `GenerateFieldRequest.generator.type`. A plugin handed a rule it
+does not implement can therefore name it straight back with no translation. The Pact specification version the rule
+was introduced in is a `spec-version` value on the entry (`V1`…`V4`) rather than a prefix on the key.
+
+| | `pact_matching` (`matchingrules.rs`) | Pact-JVM (`MatcherExecutor.kt`) |
+|---|---|---|
+| `MATCHER` | `equality`, `regex`, `type`, `min-type`, `max-type`, `min-max-type`, `include`, `number`, `integer`, `decimal`, `null`, `date`, `time`, `datetime`, `content-type`, `values`, `array-contains`, `boolean`, `status-code`, `not-empty`, `semver`, `each-key`, `each-value` | the same 23, plus `ignore-order`, `min-ignore-order`, `max-ignore-order`, `min-max-ignore-order` |
+| `GENERATOR` | `RandomInt`, `RandomDecimal`, `RandomHexadecimal`, `RandomString`, `RandomBoolean`, `Regex`, `Uuid`, `Date`, `Time`, `DateTime`, `ProviderState`, `MockServerURL`, `ArrayContains` | the same 13, plus `Null` |
+
+Each list is exactly what that host implements — the differences are rules and generators the other genuinely does
+not have, not drift, and a test in each host pins the entry keys to the implemented set so a new rule cannot be added
+without an entry. Generator keys are `PascalCase` where matching rule keys are kebab-case, because that is what each
+carries on the wire; matching what a plugin was handed matters more than looking uniform.
+
+### Delegatable set
+
+Registering an entry says the capability exists; registering a handler says it can be called with one value. Those
+are not the same set, and step 3 should not pretend otherwise:
+
+- **Delegatable** — the rules whose semantics are "look at this one value": `equality`, `regex`, `type`, `include`,
+  `number`, `integer`, `decimal`, `boolean`, `null`, `date`, `time`, `datetime`, `content-type`, `not-empty`,
+  `semver`, `status-code`. These get a `CoreFieldMatcher`. Likewise the generators that are a pure function of their
+  configuration and the test context: `RandomInt`, `RandomDecimal`, `RandomHexadecimal`, `RandomString`,
+  `RandomBoolean`, `Regex`, `Uuid`, `Date`, `Time`, `DateTime`, `Null`, and `ProviderState`/`MockServerURL` provided
+  the value they need is in `testContext` (see [006 §6](./006_Field_level_matchers_and_generators.md#6-context-available-to-the-plugin)).
+- **Not delegatable** — the collection-wide rules [006 lists as non-goals](./006_Field_level_matchers_and_generators.md#non-goals-for-this-proposal):
+  `min-type`, `max-type`, `min-max-type`, `values`, `array-contains`, `each-key`, `each-value`, and Pact-JVM's four
+  `*ignore-order` rules; and the `ArrayContains` generator, which generates *into* a structure the caller owns.
+  A plugin cannot participate in "which values does this apply to" through a one-value-at-a-time interface. These
+  keep their catalogue entry — they are real capabilities the host has, and 005 discovery should see them — but a
+  callback naming one should fail with a message saying the rule is collection-wide and cannot be applied to a
+  single value, not with the generic "no handler registered".
+
+Every entry a host advertises in `hostCapabilities` (both drivers derive it from the core catalogue as
+`<entry_type>/<key>`) now has a handler behind it, so a plugin that takes `matcher/type` or `generator/Uuid` at its
+word gets an answer rather than *"No core field matcher registered"*. A test in each host compares the registered
+handler keys against the catalogue entry keys, so the two can not drift apart.
+
+Two things the handlers have to get right, both a consequence of what the interface can carry:
+
+- **A rule this framework does not provide is an error, not a call back out.** An unrecognised rule name parses into
+  the `Plugin` carrier variant 006 added, which would send the call straight back to a plugin - so the handlers
+  check the name against the core catalogue first and reject anything that is not theirs.
+- **Configuration numbers arrive as doubles.** A rule's or generator's configuration crosses the interface as a
+  `google.protobuf.Struct`, which has a single number type, so a `min` of `2` arrives as `2.0` - and both hosts read
+  those attributes with integer accessors that reject a float and fall back to the attribute's default. A
+  `RandomInt(5, 5)` from a plugin would have generated from `0..10`. Both handlers put whole floats back to integers
+  on the way in. This is the configuration-value counterpart of the per-type `FieldValue` arms that keep the *value*
+  being matched from going through the same lossy step.
 
 ## Recommended direction
 
@@ -106,8 +175,16 @@ required.
 ## Resolved questions
 
 - **Which host matcher and generator capabilities should be exposed first?** The standard Pact matching rule and
-  generator types already represented in the core catalogue (`type`, `regex`, `equality`, `include`, `date`, `time`,
-  `datetime`, etc.), registered as `CORE` entries with handlers implementing 006's field-level trait shape.
+  generator set, registered as `CORE` entries with handlers implementing 006's field-level trait shape. The entries
+  themselves now exist in both hosts, one per rule and generator each implements
+  (see [Registered entries](#registered-entries)); the handlers go on the subset that can act on a single value
+  (see [Delegatable set](#delegatable-set)).
+- **How is a standard rule named when a plugin calls back for it?** By the name it carries in the request it was
+  handed - `type`, `content-type`, `not-empty` for matching rules, `RandomInt`, `DateTime` for generators - which is
+  the catalogue entry key. The specification version the rule was introduced in is a `spec-version` value on the
+  entry, not part of the key: a plugin should not have to know that `type` arrived in V2 and `semver` in V4 to ask
+  for either. (The earlier design keyed entries `v2-type`/`v3-date` and had the drivers' resolver strip the prefix;
+  that pass has been removed from both drivers.)
 - **Should delegation be explicit in plugin responses, or should the host always be free to resolve standard rules
   itself?** Explicit. This follows from 007's model: a plugin calls a specific, named capability when it wants
   host-provided behaviour. The host never silently intercepts or overrides a plugin's own handling of a rule it chose
@@ -121,3 +198,19 @@ required.
   host functionality?** This is exactly what 007's registered-handler mechanism solves: a plugin only ever sees a
   catalogue key and a typed request/response. Which concrete Pact framework implementation registered the handler
   behind that key is invisible to both the plugin and the driver's compiled code.
+- **Do the collection-wide rules get handlers too?** No - `min-type`, `values`, `array-contains`, `each-key`,
+  `each-value` and the `*ignore-order` family stay host-only, per 006's non-goals, and so does the `ArrayContains`
+  generator. They keep their catalogue entries, since the host does have those capabilities and 005 discovery should
+  see them, but a callback naming one gets an error saying so.
+
+## Open questions
+
+- **Should a callback for a non-delegatable rule be branchable?** It currently returns `MatchFieldResponse.error`
+  with a message saying the rule applies to a collection as a whole. That is a bare string, so a plugin that wants
+  to fall back to its own handling has to match on the text. A typed reason on the response would be better, but it
+  is a proto change for a case no plugin has hit yet.
+- **Do `ProviderState` and `MockServerURL` generators need anything beyond `testContext`?** Both are registered and
+  both read what they need from the request's test context, so a caller that populates it gets the right answer -
+  but nothing yet checks that every host path which applies a field generator *does* populate it. A plugin calling
+  `ProviderState` from a verification where the context was not passed through would get a generation error rather
+  than a wrong value, so this is a diagnosability question rather than a correctness one.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -13,7 +13,7 @@ Here is the current list of proposed changes to the Pact Plugin architecture. Pr
 | [Plugin observability and logging](./008_Plugin_observability_and_logging.md) | Phase 2    | Implemented |  |
 | [Field-level matchers and generators](./006_Field_level_matchers_and_generators.md) | Phase 3    | Implemented |  |
 | [Driver-plugin callback model](./007_Driver_plugin_callback_model.md) | Phase 3    | Draft       |  |
-| [Host-provided core matching and generation](./009_Host_provided_core_matching_and_generation.md) | Phase 4    | Draft       |  |
+| [Host-provided core matching and generation](./009_Host_provided_core_matching_and_generation.md) | Phase 4    | In progress |  |
 
 ## Implementation phases
 
@@ -27,7 +27,10 @@ These two proposals are independent of each other and establish the groundwork f
 006 and 007 can be designed in parallel. 007 (the callback model) must define its logical interface first; the concrete gRPC and WASM transport mappings follow from that definition. 006 (field-level matchers and generators) aligns with 007's data model but does not depend on it being fully implemented first.
 
 **Phase 4 — Host-provided matching (009)**
-009 depends on 005, 006, and 007 all being finalised and cannot ship before them.
+009 depends on 005, 006, and 007 all being finalised; all three are now implemented. Both hosts register the standard
+matching rules and generators as core catalogue entries with handlers behind them, at content and field level, so a
+plugin can delegate a standard rule or generator to the host it is running under. What remains is the WASM transport,
+which is blocked on 003.
 
 ## WASM compatibility
 

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CatalogueManager.kt
@@ -63,9 +63,8 @@ object CatalogueManager {
 
   /**
    * Lookup entry by key. Entries are keyed by <core|plugin>/<plugin-name>?/<entry-type>/<entry-key>,
-   * and are matched the same way [resolveCapability] matches them: by name first - the whole
-   * catalogue key, or a trailing run of its `/`-separated components - then against the core
-   * catalogue's versioned naming convention.
+   * and are matched the same way [resolveCapability] matches them: by name - the whole catalogue
+   * key, or a trailing run of its `/`-separated components.
    *
    * Unlike [resolveCapability], this takes the first match when more than one entry matches. Prefer
    * [resolveCapability] wherever the expected entry type is known and a deterministic answer
@@ -73,7 +72,6 @@ object CatalogueManager {
    */
   fun lookupEntry(key: String): CatalogueEntry? {
     return catalogue.entries.firstOrNull { namesCatalogueKey(it.key, key) }?.value
-      ?: catalogue.entries.firstOrNull { namesVersionedCoreKey(it.value, key) }?.value
   }
 
   /**
@@ -84,16 +82,16 @@ object CatalogueManager {
    * functions ([LuaPactPlugin]) - so there is exactly one place that decides "who provides this
    * entry". See proposal 007 ("One resolver, multiple call directions").
    *
-   * `entryKey` is matched against the catalogue in two passes:
+   * `entryKey` is matched against the catalogue by name - the whole catalogue key
+   * (`core/content-matcher/xml`) or a trailing run of its components (`content-matcher/xml`,
+   * `xml`), compared component by component. Core matching rules and generators are registered
+   * under the name the rule carries in a request (`type`, `regex`, `content-type`), so a bare rule
+   * name resolves to the core entry without any further convention.
    *
-   * 1. by name - the whole catalogue key (`core/content-matcher/xml`) or a trailing run of its
-   *    components (`content-matcher/xml`, `xml`), compared component by component;
-   * 2. failing that, against the core catalogue's versioned naming convention, so `type` resolves
-   *    to `v2-type` and `date` to `v3-date`.
-   *
-   * Naming an entry directly always wins over the versioned fallback: if a plugin registers its
-   * own `matcher/date`, `date` resolves to that plugin, and a caller that specifically wants the
-   * core rule asks for `v3-date`.
+   * A short name that matches both a core entry and a plugin's own - a plugin registering
+   * `matcher/date` alongside the core `date` rule - is an ambiguity error, not a silent pick;
+   * either caller disambiguates with more of the key (`core/matcher/date`,
+   * `plugin/my-plugin/matcher/date`).
    *
    * Unlike [lookupEntry], this does not just take the first hit when more than one entry matches.
    * A short, unqualified `entryKey` can still match more than one entry of the *same*
@@ -113,22 +111,13 @@ object CatalogueManager {
   }
 
   /**
-   * Resolve a catalogue entry key to the entry itself, using the same two-pass matching
+   * Resolve a catalogue entry key to the entry itself, matching it the same way
    * [resolveCapability] documents. Callers that need the entry rather than a dispatch target -
    * [findFieldMatcher] and [findFieldGenerator], which wrap it in a matcher/generator - use this
    * directly.
    */
   fun resolveCapabilityEntry(entryKey: String, expectedType: CatalogueEntryType): CatalogueEntry {
-    val named = catalogue.entries.filter { namesCatalogueKey(it.key, entryKey) }.map { it.key to it.value }
-    val candidates = if (named.any { (_, entry) -> entry.type == expectedType }) {
-      named
-    } else {
-      val versioned = catalogue.entries
-        .filter { namesVersionedCoreKey(it.value, entryKey) }
-        .map { it.key to it.value }
-      // Keep any wrong-typed direct matches for the diagnostic below if the fallback finds nothing
-      if (versioned.isEmpty()) named else versioned
-    }
+    val candidates = catalogue.entries.filter { namesCatalogueKey(it.key, entryKey) }.map { it.key to it.value }
 
     val ofExpectedType = candidates.filter { (_, entry) -> entry.type == expectedType }
     val entry = when (ofExpectedType.size) {
@@ -202,12 +191,8 @@ object CatalogueManager {
  * Does `entryKey` name this catalogue key? Either the whole key (`core/content-matcher/xml`), or a
  * trailing run of its `/`-separated components (`content-matcher/xml`, or just `xml`).
  *
- * Components are compared whole, never as substrings: `"type"` does not name
- * `core/matcher/v2-type`. That distinction is the point - the core catalogue prefixes the Pact
- * specification version a matcher was introduced in to its name, so a substring match would let an
- * unqualified name collide with a versioned core key it has nothing to do with (a plugin's own
- * `matcher/date` against `core/matcher/v3-date`, say). The versioned form is handled deliberately
- * by [namesVersionedCoreKey] instead, as a fallback rather than a coincidence.
+ * Components are compared whole, never as substrings: `"type"` names `core/matcher/type` but not
+ * `core/matcher/content-type`, which is the `content-type` rule and has nothing to do with it.
  *
  * Must stay consistent with `catalogue_manager::names_catalogue_key` in the Rust driver.
  */
@@ -216,33 +201,6 @@ internal fun namesCatalogueKey(catalogueKey: String, entryKey: String): Boolean 
   val queryParts = entryKey.split('/')
   return queryParts.size <= keyParts.size &&
     keyParts.subList(keyParts.size - queryParts.size, keyParts.size) == queryParts
-}
-
-private val VERSION_PREFIX = Regex("^v\\d+$")
-
-/**
- * Does `entryKey` name this entry under the core catalogue's versioned naming convention - the Pact
- * specification version the rule was introduced in, prefixed to its name (`v2-type`, `v3-date`,
- * `v4-not-empty`)? This is what lets a caller ask for `type` and get `v2-type` without having to
- * know which specification version introduced it.
- *
- * Only the whole name after the version prefix counts, so `type` names `v2-type` but not
- * `v3-content-type` or `v2-min-type` - those are the `content-type` and `min-type` rules.
- *
- * The convention only applies to matching rules and generators. Content matchers, content
- * generators and transports are registered under plain names (`xml`, `json`, `grpc`), so a leading
- * `v<n>-` there is part of the name rather than a version, and stripping it would be wrong.
- *
- * Must stay consistent with `catalogue_manager::names_versioned_core_key` in the Rust driver.
- */
-internal fun namesVersionedCoreKey(entry: CatalogueEntry, entryKey: String): Boolean {
-  if (entry.type != CatalogueEntryType.MATCHER && entry.type != CatalogueEntryType.GENERATOR) {
-    return false
-  }
-  val separator = entry.key.indexOf('-')
-  if (separator <= 0) return false
-  return entry.key.substring(separator + 1) == entryKey &&
-    VERSION_PREFIX.matches(entry.key.substring(0, separator))
 }
 
 /**

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CoreCapabilities.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/CoreCapabilities.kt
@@ -106,7 +106,7 @@ object CoreCapabilityRegistry {
 
   /**
    * Register a handler for a host-provided field matching rule, keyed by the catalogue entry key
-   * (e.g. `"v2-type"` for the `core/matcher/v2-type` entry). Replaces any handler previously
+   * (e.g. `"type"` for the `core/matcher/type` entry). Replaces any handler previously
    * registered under the same key.
    */
   fun registerFieldMatcher(key: String, handler: CoreFieldMatcher) {
@@ -115,7 +115,7 @@ object CoreCapabilityRegistry {
 
   /**
    * Register a handler for a host-provided field generator, keyed by the catalogue entry key
-   * (e.g. `"v3-date"` for the `core/generator/v3-date` entry). Replaces any handler previously
+   * (e.g. `"date"` for the `core/generator/date` entry). Replaces any handler previously
    * registered under the same key.
    */
   fun registerFieldGenerator(key: String, handler: CoreFieldGenerator) {

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/Field.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/Field.kt
@@ -148,7 +148,7 @@ enum class FieldTestMode {
 /**
  * Find the field-level matching rule with the given name. The name is resolved against the
  * catalogue the same way any other capability key is - see [CatalogueManager.resolveCapability] - so
- * `creditcard` finds a plugin's own rule and `type` finds the core `v2-type` rule. Throws if the
+ * `creditcard` finds a plugin's own rule and `type` finds the core `type` rule. Throws if the
  * name matches nothing, matches more than one rule, or names something that is not a matching rule.
  */
 fun findFieldMatcher(name: String): FieldMatcher =

--- a/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPluginRpcClient.kt
+++ b/drivers/jvm/core/src/main/kotlin/io/pact/plugins/jvm/core/LuaPluginRpcClient.kt
@@ -222,9 +222,22 @@ class LuaPluginRpcClient(private val engine: LuaEngine) : PactPluginRpcClient {
     return builder.build()
   }
 
+  /**
+   * Converts a single Lua interaction-contents map (shaped as
+   * `{ contents = <body>, rules = <table>, part_name = "...", plugin_config = <table> }`) into an
+   * `InteractionResponse`.
+   *
+   * `rules` is keyed by matching rule expression path, in the same shape a plugin's own
+   * `match_contents` receives them (see [matchingRulesToLua]). They are the interaction's ordinary
+   * matching rules - they end up in the Pact file's `matchingRules` for the part, and come back to
+   * the plugin in a later `CompareContentsRequest`. A plugin that owns a content type the framework
+   * can not itself traverse still decides what the paths mean, but they belong in the standard
+   * place rather than in the plugin's own configuration.
+   */
   private fun luaToInteractionResponse(item: Map<String, Any?>): Plugin.InteractionResponse {
     val builder = Plugin.InteractionResponse.newBuilder()
     luaToBody(item["contents"])?.let { builder.contents = it }
+    builder.putAllRules(luaToMatchingRules(item["rules"]))
     item["plugin_config"]?.let { builder.pluginConfiguration = luaToPluginConfiguration(it) }
     (item["part_name"] as? String)?.let { builder.partName = it }
     return builder.build()

--- a/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/CatalogueManagerSpec.groovy
+++ b/drivers/jvm/core/src/test/groovy/io/pact/plugins/jvm/core/CatalogueManagerSpec.groovy
@@ -129,18 +129,21 @@ class CatalogueManagerSpec extends Specification {
   }
 
   /**
-   * The core matcher entries as the Pact frameworks actually register them - the Pact
-   * specification version the rule was introduced in, prefixed to the name. Kept in sync with
-   * MatcherExecutor.kt in Pact-JVM and MATCHER_CATALOGUE_ENTRIES in pact_matching.
+   * The core matcher entries as the Pact frameworks actually register them - keyed by the name the
+   * rule carries in a request (MatchingRule.name), with the specification version it was
+   * introduced in as a value. Kept in sync with MatcherExecutor.kt in Pact-JVM and
+   * MATCHER_CATALOGUE_ENTRIES in pact_matching.
    */
   private static void registerCoreMatcherEntries() {
     CatalogueManager.INSTANCE.registerCoreEntries(
-      ['v2-regex', 'v2-type', 'v3-number-type', 'v3-integer-type', 'v3-decimal-type', 'v3-date',
-       'v3-time', 'v3-datetime', 'v2-min-type', 'v2-max-type', 'v2-minmax-type', 'v3-includes',
-       'v3-null', 'v4-equals-ignore-order', 'v4-min-equals-ignore-order',
-       'v4-max-equals-ignore-order', 'v4-minmax-equals-ignore-order', 'v3-content-type',
-       'v4-array-contains', 'v1-equality', 'v4-not-empty', 'v4-semver'].collect {
-        new CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, 'core', it)
+      [equality: 'V1', regex: 'V2', type: 'V2', 'min-type': 'V2', 'max-type': 'V2',
+       'min-max-type': 'V2', include: 'V3', number: 'V3', integer: 'V3', decimal: 'V3', null: 'V3',
+       date: 'V3', time: 'V3', datetime: 'V3', 'content-type': 'V3', values: 'V3',
+       'array-contains': 'V4', boolean: 'V4', 'status-code': 'V4', 'not-empty': 'V4', semver: 'V4',
+       'each-key': 'V4', 'each-value': 'V4', 'ignore-order': 'V4', 'min-ignore-order': 'V4',
+       'max-ignore-order': 'V4', 'min-max-ignore-order': 'V4'].collect { key, version ->
+        new CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, 'core', key,
+          ['spec-version': version])
       }
     )
   }
@@ -151,67 +154,44 @@ class CatalogueManagerSpec extends Specification {
     ((ResolvedCapability.Core) resolved).key
   }
 
-  def 'resolveCapability falls back to the versioned core key'() {
+  def 'resolveCapability resolves a core rule by the name it is registered under'() {
     given:
     registerCoreMatcherEntries()
 
     expect:
-    // The name a Pact file (and a plugin calling back) uses, without needing to know which
-    // specification version introduced the rule
+    // The name a Pact file (and a plugin calling back) uses - the same string the driver puts in
+    // MatchFieldRequest.rule.type, so a plugin can forward a rule it was handed straight back
     resolvedCoreKey(name) == expected
 
     where:
-    name                  || expected
-    'type'                || 'v2-type'
-    'regex'               || 'v2-regex'
-    'date'                || 'v3-date'
-    'equality'            || 'v1-equality'
-    'semver'              || 'v4-semver'
-    'not-empty'           || 'v4-not-empty'
-    // Only the whole name after the version prefix counts, so these are distinct rules and not
-    // ambiguous with `type`/`equals-ignore-order`
-    'content-type'        || 'v3-content-type'
-    'min-type'            || 'v2-min-type'
-    'equals-ignore-order' || 'v4-equals-ignore-order'
-    // The versioned key itself still resolves, by name
-    'v2-type'             || 'v2-type'
-    'matcher/v3-date'     || 'v3-date'
-    'core/matcher/v3-date' || 'v3-date'
+    name                   || expected
+    'type'                 || 'type'
+    'regex'                || 'regex'
+    'date'                 || 'date'
+    'equality'             || 'equality'
+    'semver'               || 'semver'
+    'not-empty'            || 'not-empty'
+    // Rules whose name ends in another rule's name are distinct entries, not ambiguous with it
+    'content-type'         || 'content-type'
+    'min-type'             || 'min-type'
+    'min-max-type'         || 'min-max-type'
+    'ignore-order'         || 'ignore-order'
+    // More of the catalogue key resolves the same entry
+    'matcher/date'         || 'date'
+    'core/matcher/date'    || 'date'
   }
 
   def 'a key component is never matched as a substring'() {
-    // "type" must not name core/matcher/v2-type - if it did, it would match all eight core keys
-    // ending in "type" and be ambiguous. It resolves through the versioned fallback instead.
+    // "type" names the `type` rule and nothing else - if a component matched by suffix it would
+    // also name `content-type`, `min-type` and `max-type`, and be ambiguous across all of them
     expect:
-    !CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'type')
-    CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'v2-type')
-    CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'matcher/v2-type')
-    CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'core/matcher/v2-type')
-    !CatalogueManagerKt.namesCatalogueKey('core/matcher/v2-type', 'r/v2-type')
+    CatalogueManagerKt.namesCatalogueKey('core/matcher/type', 'type')
+    !CatalogueManagerKt.namesCatalogueKey('core/matcher/content-type', 'type')
+    CatalogueManagerKt.namesCatalogueKey('core/matcher/type', 'matcher/type')
+    CatalogueManagerKt.namesCatalogueKey('core/matcher/type', 'core/matcher/type')
+    !CatalogueManagerKt.namesCatalogueKey('core/matcher/type', 'r/type')
     CatalogueManagerKt.namesCatalogueKey('core/content-matcher/xml', 'xml')
     !CatalogueManagerKt.namesCatalogueKey('core/content-matcher/xml', 'ml')
-  }
-
-  def 'the versioned fallback only applies to matcher and generator entries'() {
-    given:
-    // Content matchers, content generators and transports are registered under plain names, so a
-    // leading "v<n>-" there is part of the name, not a version to be stripped.
-    def key = 'versioned fallback entry types'
-    CatalogueManager.INSTANCE.registerCoreEntries([
-      new CatalogueEntry(CatalogueEntryType.CONTENT_MATCHER, CatalogueEntryProviderType.CORE, 'core', "v2-$key"),
-      new CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, 'core', "v2-matcher-$key")
-    ])
-
-    when:
-    CatalogueManager.INSTANCE.resolveCapability(key, CatalogueEntryType.CONTENT_MATCHER)
-
-    then:
-    // The content matcher is only reachable by its actual name
-    thrown(PactCatalogueEntryNotFoundException)
-    CatalogueManager.INSTANCE.lookupEntry(key) == null
-    CatalogueManager.INSTANCE.resolveCapability("v2-$key", CatalogueEntryType.CONTENT_MATCHER) != null
-    // ... while the matcher entry still gets the fallback
-    resolvedCoreKey("matcher-$key") == "v2-matcher-$key"
   }
 
   def 'lookupEntry matches by name, not by substring'() {
@@ -235,43 +215,50 @@ class CatalogueManagerSpec extends Specification {
     CatalogueManager.INSTANCE.removePluginEntries('CatalogueManagerSpec-lookup')
   }
 
-  def 'lookupEntry falls back to the versioned core key'() {
+  def 'lookupEntry finds a core rule by name'() {
     given:
     registerCoreMatcherEntries()
 
     expect:
-    CatalogueManager.INSTANCE.lookupEntry('type')?.key == 'v2-type'
-    CatalogueManager.INSTANCE.lookupEntry('v3-date')?.key == 'v3-date'
-    CatalogueManager.INSTANCE.lookupEntry('matcher/v3-date')?.key == 'v3-date'
+    CatalogueManager.INSTANCE.lookupEntry('type')?.key == 'type'
+    CatalogueManager.INSTANCE.lookupEntry('date')?.key == 'date'
+    CatalogueManager.INSTANCE.lookupEntry('matcher/date')?.key == 'date'
+    CatalogueManager.INSTANCE.lookupEntry('core/matcher/date')?.key == 'date'
   }
 
-  def 'resolveCapability prefers an entry named directly over the versioned fallback'() {
+  def 'resolveCapability reports a plugin rule sharing a core rule name as ambiguous'() {
     given:
-    def key = 'resolveCapability prefers an entry named directly'
+    // Core rules are now keyed by the rule name itself, so a plugin registering the same name is a
+    // genuine collision. Neither wins silently - both are reachable by a fully qualified key.
+    def key = 'resolveCapability plugin rule sharing a core rule name'
     CatalogueManager.INSTANCE.registerCoreEntries([
-      new CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, 'core', "v3-$key")
+      new CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, 'core', key)
     ])
-    // Before the plugin registers anything, the bare name finds the core rule via the fallback
+    // Before the plugin registers anything, the bare name finds the core rule
     def coreFirst = resolvedCoreKey(key)
 
     def pluginEntry = Plugin.CatalogueEntry.newBuilder()
       .setTypeValue(CatalogueEntryType.MATCHER.toEntryValue())
       .setKey(key)
       .build()
-    CatalogueManager.INSTANCE.registerPluginEntries('CatalogueManagerSpec-versioned', [pluginEntry])
+    CatalogueManager.INSTANCE.registerPluginEntries('CatalogueManagerSpec-shared-name', [pluginEntry])
 
     when:
-    def resolved = CatalogueManager.INSTANCE.resolveCapability(key, CatalogueEntryType.MATCHER)
+    CatalogueManager.INSTANCE.resolveCapability(key, CatalogueEntryType.MATCHER)
 
     then:
-    coreFirst == "v3-$key"
-    resolved instanceof ResolvedCapability.Plugin
-    ((ResolvedCapability.Plugin) resolved).pluginName == 'CatalogueManagerSpec-versioned'
-    // A caller that specifically wants the core rule can still name its versioned key
-    resolvedCoreKey("v3-$key") == "v3-$key"
+    coreFirst == key
+    def ex = thrown(PactCatalogueEntryAmbiguousException)
+    ex.matchingKeys == ["core/matcher/$key".toString(),
+                        "plugin/CatalogueManagerSpec-shared-name/matcher/$key".toString()]
+    // Each is still reachable by a fully qualified key
+    resolvedCoreKey("core/matcher/$key") == key
+    CatalogueManager.INSTANCE.resolveCapability(
+      "plugin/CatalogueManagerSpec-shared-name/matcher/$key",
+      CatalogueEntryType.MATCHER) instanceof ResolvedCapability.Plugin
 
     cleanup:
-    CatalogueManager.INSTANCE.removePluginEntries('CatalogueManagerSpec-versioned')
+    CatalogueManager.INSTANCE.removePluginEntries('CatalogueManagerSpec-shared-name')
   }
 
   def 'resolveCapability throws a clear error for an unregistered key'() {

--- a/drivers/jvm/core/src/test/kotlin/io/pact/plugins/jvm/core/LuaPactPluginTest.kt
+++ b/drivers/jvm/core/src/test/kotlin/io/pact/plugins/jvm/core/LuaPactPluginTest.kt
@@ -161,6 +161,48 @@ class LuaPactPluginTest {
     )
   }
 
+  /**
+   * A plugin can return the interaction's matching rules from `configure_interaction`, so a rule on
+   * something inside a content type the framework can not traverse still ends up in the Pact file's
+   * `matchingRules` rather than in the plugin's own configuration.
+   */
+  @Test
+  fun `configure_interaction carries matching rules from the plugin`() {
+    val pluginDir = kotlin.io.path.createTempDirectory("lua-configure-rules-test").toFile()
+    val manifest = hostCallbackManifest(pluginDir, "configure-rules-test", """
+      function configure_interaction(content_type, config)
+        return {
+          interactions = {
+            {
+              contents = { contents = "a-body", content_type = content_type },
+              rules = {
+                ["${'$'}.one"] = { { type = "regex", values = { regex = "\\d+" } } },
+                ["${'$'}.two"] = { { type = "type" } }
+              }
+            }
+          }
+        }
+      end
+    """.trimIndent())
+    val plugin = LuaPactPlugin(manifest)
+
+    try {
+      val response = plugin.withRpcClient {
+        it.configureInteraction(Plugin.ConfigureInteractionRequest.newBuilder()
+          .setContentType("application/x-test")
+          .build())
+      }
+
+      val interaction = response.getInteraction(0)
+      val regexRule = interaction.rulesMap["${'$'}.one"]!!.getRule(0)
+      assertEquals("regex", regexRule.type)
+      assertEquals("\\d+", Utils.structToMap(regexRule.values)["regex"])
+      assertEquals("type", interaction.rulesMap["${'$'}.two"]!!.getRule(0).type)
+    } finally {
+      plugin.shutdown()
+    }
+  }
+
   @Test
   fun `match_contents calls host_compare_contents for a registered core capability`() {
     val key = "match_contents-calls-host_compare_contents-for-a-registered-core-capability"

--- a/drivers/rust/driver/src/catalogue_manager.rs
+++ b/drivers/rust/driver/src/catalogue_manager.rs
@@ -246,8 +246,7 @@ pub fn register_core_entries(entries: &Vec<CatalogueEntry>) {
 }
 
 /// Lookup an entry in the catalogue by the key, matched the same way [`resolve_capability`] does:
-/// by name first - the whole catalogue key, or a trailing run of its `/`-separated components -
-/// then against the core catalogue's versioned naming convention.
+/// by name - the whole catalogue key, or a trailing run of its `/`-separated components.
 ///
 /// Unlike [`resolve_capability`], this takes the first match when more than one entry matches, and
 /// `HashMap` iteration order is randomised per process. Prefer [`resolve_capability`] wherever the
@@ -256,7 +255,6 @@ pub fn lookup_entry(key: &str) -> Option<CatalogueEntry> {
   let inner = CATALOGUE_REGISTER.lock().unwrap();
   inner.iter()
     .find(|(k, _)| names_catalogue_key(k, key))
-    .or_else(|| inner.iter().find(|(_, entry)| names_versioned_core_key(entry, key)))
     .map(|(_, v)| v.clone())
 }
 
@@ -275,12 +273,8 @@ pub enum ResolvedCapability {
 /// Does `entry_key` name this catalogue key? Either the whole key (`core/content-matcher/xml`),
 /// or a trailing run of its `/`-separated components (`content-matcher/xml`, or just `xml`).
 ///
-/// Components are compared whole, never as substrings: `"type"` does not name
-/// `core/matcher/v2-type`. That distinction is the point - the core catalogue prefixes the Pact
-/// specification version a matcher was introduced in to its name, so a substring match would let
-/// an unqualified name collide with a versioned core key it has nothing to do with (a plugin's
-/// own `matcher/date` against `core/matcher/v3-date`, say). The versioned form is handled
-/// deliberately by [`names_versioned_core_key`] instead, as a fallback rather than a coincidence.
+/// Components are compared whole, never as substrings: `"type"` names `core/matcher/type` but not
+/// `core/matcher/content-type`, which is the `content-type` rule and has nothing to do with it.
 fn names_catalogue_key(catalogue_key: &str, entry_key: &str) -> bool {
   let key_parts = catalogue_key.split('/').collect::<Vec<_>>();
   let query_parts = entry_key.split('/').collect::<Vec<_>>();
@@ -288,45 +282,20 @@ fn names_catalogue_key(catalogue_key: &str, entry_key: &str) -> bool {
     && key_parts[key_parts.len() - query_parts.len()..] == query_parts[..]
 }
 
-/// Does `entry_key` name this entry under the core catalogue's versioned naming convention - the
-/// Pact specification version the rule was introduced in, prefixed to its name (`v2-type`,
-/// `v3-date`, `v4-not-empty`)? This is what lets a caller ask for `type` and get `v2-type`
-/// without having to know which specification version introduced it.
-///
-/// Only the whole name after the version prefix counts, so `type` names `v2-type` but not
-/// `v3-content-type` or `v2-min-type` - those are the `content-type` and `min-type` rules.
-///
-/// The convention only applies to matching rules and generators. Content matchers, content
-/// generators and transports are registered under plain names (`xml`, `json`, `grpc`), so a
-/// leading `v<n>-` there is part of the name rather than a version, and stripping it would be
-/// wrong.
-fn names_versioned_core_key(entry: &CatalogueEntry, entry_key: &str) -> bool {
-  if entry.entry_type != CatalogueEntryType::MATCHER && entry.entry_type != CatalogueEntryType::GENERATOR {
-    return false;
-  }
-  match entry.key.split_once('-') {
-    Some((version, name)) => name == entry_key
-      && version.len() > 1
-      && version.starts_with('v')
-      && version[1..].chars().all(|c| c.is_ascii_digit()),
-    None => false
-  }
-}
-
 /// Resolve a callback's catalogue entry key to a dispatch target, the same way
 /// [`crate::content::ContentMatcher::is_core`]/[`crate::content::ContentGenerator::is_core`] do
 /// for the driver's own outbound calls.
 ///
-/// `entry_key` is matched against the catalogue in two passes:
+/// `entry_key` is matched against the catalogue by name - the whole catalogue key
+/// (`core/content-matcher/xml`) or a trailing run of its components (`content-matcher/xml`,
+/// `xml`), compared component by component. Core matching rules and generators are registered
+/// under the name the rule carries in a request (`type`, `regex`, `content-type`), so a bare rule
+/// name resolves to the core entry without any further convention.
 ///
-/// 1. by name - the whole catalogue key (`core/content-matcher/xml`) or a trailing run of its
-///    components (`content-matcher/xml`, `xml`), compared component by component;
-/// 2. failing that, against the core catalogue's versioned naming convention, so `type` resolves
-///    to `v2-type` and `date` to `v3-date`.
-///
-/// Naming an entry directly always wins over the versioned fallback: if a plugin registers its
-/// own `matcher/date`, `date` resolves to that plugin, and a caller that specifically wants the
-/// core rule asks for `v3-date`.
+/// A short name that matches both a core entry and a plugin's own - a plugin registering
+/// `matcher/date` alongside the core `date` rule - is an ambiguity error, not a silent pick;
+/// either caller disambiguates with more of the key (`core/matcher/date`,
+/// `plugin/my-plugin/matcher/date`).
 ///
 /// Unlike [`lookup_entry`], this does not just take the first `HashMap` hit when more than one
 /// entry matches. A short, unqualified `entry_key` can still match more than one entry of the
@@ -346,29 +315,17 @@ pub fn resolve_capability(entry_key: &str, expected_type: CatalogueEntryType) ->
   }
 }
 
-/// Resolve a catalogue entry key to the entry itself, using the same two-pass matching
+/// Resolve a catalogue entry key to the entry itself, matching it the same way
 /// [`resolve_capability`] documents. Callers that need the entry rather than a dispatch target -
 /// [`crate::field::find_field_matcher`] and [`crate::field::find_field_generator`], which wrap it
 /// in a matcher/generator - use this directly.
 pub fn resolve_capability_entry(entry_key: &str, expected_type: CatalogueEntryType) -> anyhow::Result<CatalogueEntry> {
-  let all_entries: Vec<(String, CatalogueEntry)> = {
+  let candidates: Vec<(String, CatalogueEntry)> = {
     let inner = CATALOGUE_REGISTER.lock().unwrap();
-    inner.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
-  };
-
-  let named: Vec<(String, CatalogueEntry)> = all_entries.iter()
-    .filter(|(k, _)| names_catalogue_key(k, entry_key))
-    .cloned()
-    .collect();
-  let candidates = if named.iter().any(|(_, entry)| entry.entry_type == expected_type) {
-    named
-  } else {
-    let versioned: Vec<(String, CatalogueEntry)> = all_entries.iter()
-      .filter(|(_, entry)| names_versioned_core_key(entry, entry_key))
-      .cloned()
-      .collect();
-    // Keep any wrong-typed direct matches for the diagnostic below if the fallback finds nothing
-    if versioned.is_empty() { named } else { versioned }
+    inner.iter()
+      .filter(|(k, _)| names_catalogue_key(k, entry_key))
+      .map(|(k, v)| (k.clone(), v.clone()))
+      .collect()
   };
 
   let mut of_expected_type = candidates.iter().filter(|(_, entry)| entry.entry_type == expected_type);
@@ -699,22 +656,24 @@ mod tests {
     expect!(core_key).to(be_equal_to(key.to_string()));
   }
 
-  /// The core matcher entries as the Pact frameworks actually register them - the Pact
-  /// specification version the rule was introduced in, prefixed to the name. Kept in sync with
-  /// `MATCHER_CATALOGUE_ENTRIES` in pact_matching and `MatcherExecutor.kt` in Pact-JVM.
+  /// The core matcher entries as the Pact frameworks actually register them - keyed by the name
+  /// the rule carries in a request (`MatchingRule::name()`), with the specification version it was
+  /// introduced in as a value. Kept in sync with `MATCHER_CATALOGUE_ENTRIES` in pact_matching and
+  /// `MatcherExecutor.kt` in Pact-JVM.
   fn register_core_matcher_entries() {
-    let entries = ["v2-regex", "v2-type", "v3-number-type", "v3-integer-type", "v3-decimal-type",
-      "v3-date", "v3-time", "v3-datetime", "v2-min-type", "v2-max-type", "v2-minmax-type",
-      "v3-includes", "v3-null", "v4-equals-ignore-order", "v4-min-equals-ignore-order",
-      "v4-max-equals-ignore-order", "v4-minmax-equals-ignore-order", "v3-content-type",
-      "v4-array-contains", "v1-equality", "v4-not-empty", "v4-semver"]
+    let entries = [("equality", "V1"), ("regex", "V2"), ("type", "V2"), ("min-type", "V2"),
+      ("max-type", "V2"), ("min-max-type", "V2"), ("include", "V3"), ("number", "V3"),
+      ("integer", "V3"), ("decimal", "V3"), ("null", "V3"), ("date", "V3"), ("time", "V3"),
+      ("datetime", "V3"), ("content-type", "V3"), ("values", "V3"), ("array-contains", "V4"),
+      ("boolean", "V4"), ("status-code", "V4"), ("not-empty", "V4"), ("semver", "V4"),
+      ("each-key", "V4"), ("each-value", "V4")]
       .iter()
-      .map(|key| CatalogueEntry {
+      .map(|(key, version)| CatalogueEntry {
         entry_type: CatalogueEntryType::MATCHER,
         provider_type: CatalogueEntryProviderType::CORE,
         plugin: None,
         key: key.to_string(),
-        values: hashmap!{}
+        values: hashmap!{ "spec-version".to_string() => version.to_string() }
       })
       .collect();
     register_core_entries(&entries);
@@ -728,76 +687,39 @@ mod tests {
   }
 
   #[test]
-  fn resolve_capability_falls_back_to_the_versioned_core_key() {
+  fn resolve_capability_resolves_a_core_rule_by_the_name_it_is_registered_under() {
     register_core_matcher_entries();
 
-    // The name a Pact file (and a plugin calling back) uses, without needing to know which
-    // specification version introduced the rule
-    expect!(resolved_core_key("type")).to(be_equal_to("v2-type".to_string()));
-    expect!(resolved_core_key("regex")).to(be_equal_to("v2-regex".to_string()));
-    expect!(resolved_core_key("date")).to(be_equal_to("v3-date".to_string()));
-    expect!(resolved_core_key("equality")).to(be_equal_to("v1-equality".to_string()));
-    expect!(resolved_core_key("semver")).to(be_equal_to("v4-semver".to_string()));
-    expect!(resolved_core_key("not-empty")).to(be_equal_to("v4-not-empty".to_string()));
+    // The name a Pact file (and a plugin calling back) uses - the same string the driver puts in
+    // MatchFieldRequest.rule.type, so a plugin can forward a rule it was handed straight back
+    expect!(resolved_core_key("type")).to(be_equal_to("type".to_string()));
+    expect!(resolved_core_key("regex")).to(be_equal_to("regex".to_string()));
+    expect!(resolved_core_key("date")).to(be_equal_to("date".to_string()));
+    expect!(resolved_core_key("equality")).to(be_equal_to("equality".to_string()));
+    expect!(resolved_core_key("semver")).to(be_equal_to("semver".to_string()));
+    expect!(resolved_core_key("not-empty")).to(be_equal_to("not-empty".to_string()));
 
-    // Only the whole name after the version prefix counts, so these are distinct rules and not
-    // ambiguous with `type`/`equals-ignore-order`
-    expect!(resolved_core_key("content-type")).to(be_equal_to("v3-content-type".to_string()));
-    expect!(resolved_core_key("min-type")).to(be_equal_to("v2-min-type".to_string()));
-    expect!(resolved_core_key("equals-ignore-order"))
-      .to(be_equal_to("v4-equals-ignore-order".to_string()));
+    // Rules whose name ends in another rule's name are distinct entries, not ambiguous with it
+    expect!(resolved_core_key("content-type")).to(be_equal_to("content-type".to_string()));
+    expect!(resolved_core_key("min-type")).to(be_equal_to("min-type".to_string()));
+    expect!(resolved_core_key("min-max-type")).to(be_equal_to("min-max-type".to_string()));
 
-    // The versioned key itself still resolves, by name
-    expect!(resolved_core_key("v2-type")).to(be_equal_to("v2-type".to_string()));
-    expect!(resolved_core_key("core/matcher/v3-date")).to(be_equal_to("v3-date".to_string()));
-    expect!(resolved_core_key("matcher/v3-date")).to(be_equal_to("v3-date".to_string()));
+    // More of the catalogue key resolves the same entry
+    expect!(resolved_core_key("core/matcher/date")).to(be_equal_to("date".to_string()));
+    expect!(resolved_core_key("matcher/date")).to(be_equal_to("date".to_string()));
   }
 
   #[test]
   fn resolve_capability_does_not_match_a_key_component_as_a_substring() {
-    // "type" must not name `core/matcher/v2-type` by suffix - if it did, it would match all eight
-    // core keys ending in "type" and be ambiguous. It resolves through the versioned fallback to
-    // exactly one entry instead.
-    expect!(names_catalogue_key("core/matcher/v2-type", "type")).to(be_false());
-    expect!(names_catalogue_key("core/matcher/v2-type", "v2-type")).to(be_true());
-    expect!(names_catalogue_key("core/matcher/v2-type", "matcher/v2-type")).to(be_true());
-    expect!(names_catalogue_key("core/matcher/v2-type", "core/matcher/v2-type")).to(be_true());
-    expect!(names_catalogue_key("core/matcher/v2-type", "r/v2-type")).to(be_false());
+    // "type" names the `type` rule and nothing else - if a component matched by suffix it would
+    // also name `content-type`, `min-type` and `max-type`, and be ambiguous across all of them
+    expect!(names_catalogue_key("core/matcher/type", "type")).to(be_true());
+    expect!(names_catalogue_key("core/matcher/content-type", "type")).to(be_false());
+    expect!(names_catalogue_key("core/matcher/type", "matcher/type")).to(be_true());
+    expect!(names_catalogue_key("core/matcher/type", "core/matcher/type")).to(be_true());
+    expect!(names_catalogue_key("core/matcher/type", "r/type")).to(be_false());
     expect!(names_catalogue_key("core/content-matcher/xml", "xml")).to(be_true());
     expect!(names_catalogue_key("core/content-matcher/xml", "ml")).to(be_false());
-  }
-
-  #[test]
-  fn the_versioned_fallback_only_applies_to_matcher_and_generator_entries() {
-    // Content matchers, content generators and transports are registered under plain names, so a
-    // leading "v<n>-" there is part of the name, not a version to be stripped.
-    let name = "the_versioned_fallback_only_applies_to_matcher_and_generator_entries";
-    register_core_entries(&vec![
-      CatalogueEntry {
-        entry_type: CatalogueEntryType::CONTENT_MATCHER,
-        provider_type: CatalogueEntryProviderType::CORE,
-        plugin: None,
-        key: format!("v2-{}", name),
-        values: hashmap!{}
-      },
-      CatalogueEntry {
-        entry_type: CatalogueEntryType::MATCHER,
-        provider_type: CatalogueEntryProviderType::CORE,
-        plugin: None,
-        key: format!("v2-matcher-{}", name),
-        values: hashmap!{}
-      }
-    ]);
-
-    // The content matcher is only reachable by its actual name
-    expect!(resolve_capability(name, CatalogueEntryType::CONTENT_MATCHER).is_err()).to(be_true());
-    expect!(lookup_entry(name).map(|entry| entry.key)).to(be_none());
-    expect!(resolve_capability(&format!("v2-{}", name), CatalogueEntryType::CONTENT_MATCHER).is_ok())
-      .to(be_true());
-
-    // ... while the matcher entry still gets the fallback
-    expect!(resolved_core_key(&format!("matcher-{}", name)))
-      .to(be_equal_to(format!("v2-matcher-{}", name)));
   }
 
   #[test]
@@ -812,7 +734,7 @@ mod tests {
       },
       ProtoCatalogueEntry {
         r#type: CatalogueEntryType::MATCHER.to_proto_value(),
-        key: format!("v3-{}", name),
+        key: format!("other-{}", name),
         values: hashmap!{}
       }
     ]);
@@ -823,8 +745,6 @@ mod tests {
       .map(|entry| entry.entry_type);
     // A trailing substring of a component names nothing
     let by_substring = lookup_entry(&name[3..]);
-    // But the versioned convention still resolves for a matcher entry
-    let versioned = lookup_entry(&format!("{}-{}", "matcher-fallback", name));
 
     remove_plugin_entries(name);
 
@@ -832,29 +752,31 @@ mod tests {
     expect!(by_components).to(be_some().value(CatalogueEntryType::CONTENT_MATCHER));
     expect!(fully_qualified).to(be_some().value(CatalogueEntryType::CONTENT_MATCHER));
     expect!(by_substring).to(be_none());
-    expect!(versioned).to(be_none());
   }
 
   #[test]
-  fn lookup_entry_falls_back_to_the_versioned_core_key() {
+  fn lookup_entry_finds_a_core_rule_by_name() {
     register_core_matcher_entries();
 
-    expect!(lookup_entry("type").map(|entry| entry.key)).to(be_some().value("v2-type".to_string()));
-    expect!(lookup_entry("v3-date").map(|entry| entry.key)).to(be_some().value("v3-date".to_string()));
-    expect!(lookup_entry("matcher/v3-date").map(|entry| entry.key)).to(be_some().value("v3-date".to_string()));
+    expect!(lookup_entry("type").map(|entry| entry.key)).to(be_some().value("type".to_string()));
+    expect!(lookup_entry("date").map(|entry| entry.key)).to(be_some().value("date".to_string()));
+    expect!(lookup_entry("matcher/date").map(|entry| entry.key)).to(be_some().value("date".to_string()));
+    expect!(lookup_entry("core/matcher/date").map(|entry| entry.key)).to(be_some().value("date".to_string()));
   }
 
   #[test]
-  fn resolve_capability_prefers_an_entry_named_directly_over_the_versioned_fallback() {
-    let name = "resolve_capability_prefers_an_entry_named_directly_over_the_versioned_fallback";
+  fn resolve_capability_reports_a_plugin_rule_sharing_a_core_rule_name_as_ambiguous() {
+    // Core rules are now keyed by the rule name itself, so a plugin registering the same name is a
+    // genuine collision. Neither wins silently - both are reachable by a fully qualified key.
+    let name = "resolve_capability_reports_a_plugin_rule_sharing_a_core_rule_name_as_ambiguous";
     register_core_entries(&vec![CatalogueEntry {
       entry_type: CatalogueEntryType::MATCHER,
       provider_type: CatalogueEntryProviderType::CORE,
       plugin: None,
-      key: format!("v3-{}", name),
+      key: name.to_string(),
       values: hashmap!{}
     }]);
-    // Before the plugin registers anything, the bare name finds the core rule via the fallback
+    // Before the plugin registers anything, the bare name finds the core rule
     let core_first = resolved_core_key(name);
 
     let manifest = PactPluginManifest { name: name.to_string(), .. PactPluginManifest::default() };
@@ -864,17 +786,23 @@ mod tests {
       values: hashmap!{}
     }]);
 
-    let resolved = resolve_capability(name, CatalogueEntryType::MATCHER);
-    // A caller that specifically wants the core rule can still name its versioned key
-    let still_core = resolved_core_key(&format!("v3-{}", name));
+    let ambiguous = resolve_capability(name, CatalogueEntryType::MATCHER);
+    let still_core = resolved_core_key(&format!("core/matcher/{}", name));
+    let plugin_rule = resolve_capability(
+      &format!("plugin/{}/matcher/{}", name, name), CatalogueEntryType::MATCHER
+    );
     remove_plugin_entries(name);
 
-    expect!(core_first).to(be_equal_to(format!("v3-{}", name)));
-    match resolved.expect("expected the plugin's own entry to resolve") {
+    expect!(core_first).to(be_equal_to(name.to_string()));
+    let error = ambiguous.expect_err("expected the shared name to be ambiguous").to_string();
+    expect!(error.contains("Ambiguous catalogue entry key")).to(be_true());
+    expect!(error.contains(&format!("core/matcher/{}", name))).to(be_true());
+    expect!(error.contains(&format!("plugin/{}/matcher/{}", name, name))).to(be_true());
+    expect!(still_core).to(be_equal_to(name.to_string()));
+    match plugin_rule.expect("expected the plugin's own entry to resolve when fully qualified") {
       ResolvedCapability::Plugin(resolved_manifest) => expect!(resolved_manifest.name).to(be_equal_to(name.to_string())),
-      ResolvedCapability::Core(key) => panic!("expected the plugin entry to win, got core '{}'", key)
+      ResolvedCapability::Core(key) => panic!("expected the plugin entry, got core '{}'", key)
     };
-    expect!(still_core).to(be_equal_to(format!("v3-{}", name)));
   }
 
   #[test]

--- a/drivers/rust/driver/src/core_capabilities.rs
+++ b/drivers/rust/driver/src/core_capabilities.rs
@@ -98,7 +98,7 @@ pub fn lookup_core_content_generator(key: &str) -> Option<Arc<dyn CoreContentGen
 }
 
 /// Register a handler for a host-provided field matching rule, keyed by the catalogue entry key
-/// (e.g. `"v2-type"` for the `core/matcher/v2-type` entry). Replaces any handler previously
+/// (e.g. `"type"` for the `core/matcher/type` entry). Replaces any handler previously
 /// registered under the same key.
 pub fn register_core_field_matcher(key: &str, handler: Arc<dyn CoreFieldMatcher>) {
   CORE_FIELD_MATCHERS.lock()
@@ -107,7 +107,7 @@ pub fn register_core_field_matcher(key: &str, handler: Arc<dyn CoreFieldMatcher>
 }
 
 /// Register a handler for a host-provided field generator, keyed by the catalogue entry key
-/// (e.g. `"v3-date"` for the `core/generator/v3-date` entry). Replaces any handler previously
+/// (e.g. `"date"` for the `core/generator/date` entry). Replaces any handler previously
 /// registered under the same key.
 pub fn register_core_field_generator(key: &str, handler: Arc<dyn CoreFieldGenerator>) {
   CORE_FIELD_GENERATORS.lock()
@@ -259,10 +259,10 @@ mod tests {
 
     expect!(handler.is_some()).to(be_true());
     let response = handler.unwrap()
-      .match_field(MatchFieldRequest { key: "v2-type".to_string(), .. MatchFieldRequest::default() })
+      .match_field(MatchFieldRequest { key: "type".to_string(), .. MatchFieldRequest::default() })
       .await;
     // The stub echoes the request key back, so this also proves the request reached the handler
-    expect!(response.unwrap().error).to(be_equal_to("v2-type".to_string()));
+    expect!(response.unwrap().error).to(be_equal_to("type".to_string()));
   }
 
   #[test_log::test(tokio::test)]
@@ -274,8 +274,8 @@ mod tests {
 
     expect!(handler.is_some()).to(be_true());
     let response = handler.unwrap()
-      .generate_field(GenerateFieldRequest { key: "v3-date".to_string(), .. GenerateFieldRequest::default() })
+      .generate_field(GenerateFieldRequest { key: "date".to_string(), .. GenerateFieldRequest::default() })
       .await;
-    expect!(response.unwrap().error).to(be_equal_to("v3-date".to_string()));
+    expect!(response.unwrap().error).to(be_equal_to("date".to_string()));
   }
 }

--- a/drivers/rust/driver/src/field.rs
+++ b/drivers/rust/driver/src/field.rs
@@ -173,7 +173,7 @@ pub struct FieldGenerator {
 /// Find the field-level matching rule with the given name. The name is resolved against the
 /// catalogue the same way any other capability key is - see
 /// [`crate::catalogue_manager::resolve_capability`] - so `creditcard` finds a plugin's own rule and
-/// `type` finds the core `v2-type` rule. Returns a descriptive error if the name matches nothing,
+/// `type` finds the core `type` rule. Returns a descriptive error if the name matches nothing,
 /// matches more than one rule, or names something that is not a matching rule.
 pub fn find_field_matcher(name: &str) -> anyhow::Result<FieldMatcher> {
   resolve_capability_entry(name, CatalogueEntryType::MATCHER)

--- a/drivers/rust/driver/src/lua_plugin.rs
+++ b/drivers/rust/driver/src/lua_plugin.rs
@@ -1185,19 +1185,27 @@ fn lua_to_struct(lua: &Lua, value: Option<Value>) -> anyhow::Result<Option<prost
 // ---- ConfigureInteraction <-> Lua ----
 
 /// Converts a single Lua interaction-contents table (shaped as
-/// `{ contents = <body>, part_name = "...", plugin_config = <table> }`) into an
+/// `{ contents = <body>, rules = <table>, part_name = "...", plugin_config = <table> }`) into an
 /// `InteractionResponse`.
+///
+/// `rules` is keyed by matching rule expression path, in the same shape a plugin's own
+/// `match_contents` receives them (see [`matching_rules_to_lua`]). They are the interaction's
+/// ordinary matching rules - they end up in the Pact file's `matchingRules` for the part, and come
+/// back to the plugin in a later `CompareContentsRequest`. A plugin that owns a content type the
+/// framework can not itself traverse still decides what the paths mean, but they belong in the
+/// standard place rather than in the plugin's own configuration.
 fn lua_to_interaction_response(lua: &Lua, table: Table) -> anyhow::Result<InteractionResponse> {
   let contents: Option<Value> = table.get("contents")?;
   let body = match contents {
     Some(value) => lua_to_body(value)?,
     None => None,
   };
+  let rules: Option<Table> = table.get("rules")?;
   let plugin_config: Option<Value> = table.get("plugin_config")?;
   let part_name: Option<String> = table.get("part_name")?;
   Ok(InteractionResponse {
     contents: body,
-    rules: HashMap::new(),
+    rules: lua_to_matching_rules(lua, rules)?,
     generators: HashMap::new(),
     message_metadata: None,
     plugin_configuration: lua_to_plugin_configuration(lua, plugin_config)?,
@@ -1825,6 +1833,11 @@ impl PluginInstance for LuaPactPlugin {
 mod tests {
   use std::collections::HashMap;
 
+  use maplit::hashmap;
+  use crate::catalogue_manager::{CatalogueEntry, CatalogueEntryProviderType};
+  use crate::field::FieldValue;
+  use crate::utils::proto_struct_to_json;
+
   use super::*;
 
   fn jwt_manifest() -> PactPluginManifest {
@@ -2177,6 +2190,247 @@ mod tests {
     };
     let compare_response = plugin.compare_contents(compare_request).await.unwrap();
     assert!(!compare_response.results.is_empty(), "expected a mismatch to be detected");
+  }
+
+  /// A claim declared with a matching rule is handed to the host framework rather than compared
+  /// here - proposal 009 from the plugin's side. The host is stubbed in this crate (the driver has
+  /// no matching engine of its own to register); what is under test is that the plugin carries the
+  /// rule from the test config, through the Pact file's plugin configuration, to a `host_match_field`
+  /// call with the right request, and honours the answer.
+  #[derive(Debug)]
+  struct StubHostRule {
+    requests: Arc<Mutex<Vec<proto_v2::MatchFieldRequest>>>,
+    mismatches: Vec<proto_v2::ContentMismatch>
+  }
+
+  #[async_trait]
+  impl crate::core_capabilities::CoreFieldMatcher for StubHostRule {
+    async fn match_field(&self, request: proto_v2::MatchFieldRequest) -> anyhow::Result<proto_v2::MatchFieldResponse> {
+      self.requests.lock().unwrap().push(request);
+      Ok(proto_v2::MatchFieldResponse {
+        error: String::default(),
+        mismatches: self.mismatches.clone()
+      })
+    }
+  }
+
+  /// Configures a JWT interaction, so a test can mint an "expected" and an "actual" token that
+  /// differ. Returns the whole interaction: its matching rules go into the compare request the
+  /// same way the framework routes them, via the Pact file rather than the plugin's configuration.
+  async fn configure_jwt(plugin: &LuaPactPlugin, claim: serde_json::Value) -> InteractionResponse {
+    let mut config_fields = HashMap::new();
+    config_fields.insert("private-key".to_string(), serde_json::Value::String(PRIVATE_KEY.to_string()));
+    config_fields.insert("algorithm".to_string(), serde_json::Value::String("RS512".to_string()));
+    config_fields.insert("subject".to_string(), serde_json::Value::String("test-subject".to_string()));
+    config_fields.insert("issuer".to_string(), serde_json::Value::String("test-issuer".to_string()));
+    config_fields.insert("audience".to_string(), serde_json::Value::String("test-audience".to_string()));
+    config_fields.insert("customer_id".to_string(), claim);
+
+    let response = plugin.configure_interaction(ConfigureInteractionRequest {
+      content_type: "application/jwt+json".to_string(),
+      contents_config: Some(to_proto_struct(&config_fields)),
+    }).await.unwrap();
+    assert_eq!(response.error, "");
+    response.interaction[0].clone()
+  }
+
+  fn rule_claim() -> serde_json::Value {
+    serde_json::json!({
+      "pact:matcher:type": "regex",
+      "regex": "CUST-\\d{6}",
+      "value": "CUST-123456"
+    })
+  }
+
+  #[tokio::test]
+  async fn match_contents_delegates_a_claim_rule_to_the_host() {
+    let key = "regex";
+    let requests = Arc::new(Mutex::new(vec![]));
+    crate::core_capabilities::register_core_field_matcher(key, Arc::new(StubHostRule {
+      requests: requests.clone(),
+      mismatches: vec![]
+    }));
+    crate::catalogue_manager::register_core_entries(&vec![CatalogueEntry {
+      entry_type: CatalogueEntryType::MATCHER,
+      provider_type: CatalogueEntryProviderType::CORE,
+      plugin: None,
+      key: key.to_string(),
+      values: hashmap!{}
+    }]);
+
+    let manifest = jwt_manifest();
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+    // The expected token carries the example value, the actual one a different value: without the
+    // rule this is a plain claim mismatch
+    let expected = configure_jwt(&plugin, rule_claim()).await;
+    let actual = configure_jwt(&plugin, serde_json::json!("CUST-999999")).await;
+
+    // The rule is an ordinary matching rule on the interaction, keyed by a path into the claims
+    let rule_paths: Vec<&String> = expected.rules.keys().collect();
+    assert_eq!(rule_paths, vec!["$.claims.customer_id"]);
+
+    let response = plugin.compare_contents(CompareContentsRequest {
+      expected: expected.contents.clone(),
+      actual: actual.contents.clone(),
+      allow_unexpected_keys: false,
+      rules: expected.rules.clone(),
+      plugin_configuration: expected.plugin_configuration.clone()
+    }).await.unwrap();
+
+    crate::core_capabilities::deregister_core_field_matcher(key);
+
+    assert_eq!(response.error, "");
+    assert!(response.results.is_empty(), "expected the host rule to accept the claim, got {:?}",
+      response.results);
+
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 1, "expected exactly one callback for the one claim with a rule");
+    let request = &requests[0];
+    let rule = request.rule.clone().expect("expected the rule to be sent");
+    assert_eq!(rule.r#type, "regex");
+    assert_eq!(
+      proto_struct_to_json(&rule.values.unwrap()).get("regex").and_then(|v| v.as_str()),
+      Some("CUST-\\d{6}")
+    );
+    assert_eq!(request.path, "$.customer_id");
+    assert_eq!(request.mismatch_type, "body");
+    assert_eq!(
+      FieldValue::from_proto(&request.expected.clone().unwrap()),
+      FieldValue::Json(serde_json::Value::String("CUST-123456".to_string()))
+    );
+    assert_eq!(
+      FieldValue::from_proto(&request.actual.clone().unwrap()),
+      FieldValue::Json(serde_json::Value::String("CUST-999999".to_string()))
+    );
+  }
+
+  /// The control for [`match_contents_delegates_a_claim_rule_to_the_host`]: the same two tokens
+  /// with the claim given as a plain value are a mismatch, so it really is the rule that makes the
+  /// difference and not something else about the pair.
+  #[tokio::test]
+  async fn a_claim_without_a_rule_is_still_compared_for_equality() {
+    let manifest = jwt_manifest();
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+    let expected = configure_jwt(&plugin, serde_json::json!("CUST-123456")).await;
+    let actual = configure_jwt(&plugin, serde_json::json!("CUST-999999")).await;
+
+    assert!(expected.rules.is_empty(), "a claim given as a plain value has no rule");
+
+    let response = plugin.compare_contents(CompareContentsRequest {
+      expected: expected.contents.clone(),
+      actual: actual.contents.clone(),
+      allow_unexpected_keys: false,
+      rules: expected.rules.clone(),
+      plugin_configuration: expected.plugin_configuration.clone()
+    }).await.unwrap();
+
+    assert!(
+      response.results.contains_key("claims:customer_id"),
+      "expected the differing claim to mismatch, got {:?}",
+      response.results
+    );
+  }
+
+  #[tokio::test]
+  async fn match_contents_reports_a_mismatch_the_host_rule_found() {
+    let key = "regex-mismatching";
+    crate::core_capabilities::register_core_field_matcher(key, Arc::new(StubHostRule {
+      requests: Arc::new(Mutex::new(vec![])),
+      mismatches: vec![proto_v2::ContentMismatch {
+        mismatch: "Expected 'CUST-999999' to match 'CUST-\\d{6}'".to_string(),
+        .. proto_v2::ContentMismatch::default()
+      }]
+    }));
+    crate::catalogue_manager::register_core_entries(&vec![CatalogueEntry {
+      entry_type: CatalogueEntryType::MATCHER,
+      provider_type: CatalogueEntryProviderType::CORE,
+      plugin: None,
+      key: key.to_string(),
+      values: hashmap!{}
+    }]);
+
+    let manifest = jwt_manifest();
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+    let mut claim = rule_claim();
+    claim["pact:matcher:type"] = serde_json::Value::String(key.to_string());
+    let expected = configure_jwt(&plugin, claim).await;
+    let actual = configure_jwt(&plugin, serde_json::json!("CUST-999999")).await;
+
+    let response = plugin.compare_contents(CompareContentsRequest {
+      expected: expected.contents.clone(),
+      actual: actual.contents.clone(),
+      allow_unexpected_keys: false,
+      rules: expected.rules.clone(),
+      plugin_configuration: expected.plugin_configuration.clone()
+    }).await.unwrap();
+
+    crate::core_capabilities::deregister_core_field_matcher(key);
+
+    assert_eq!(response.error, "");
+    let mismatches = response.results.get("claims:customer_id")
+      .unwrap_or_else(|| panic!("expected a mismatch for the claim, got {:?}", response.results));
+    assert_eq!(mismatches.mismatches.len(), 1);
+    assert!(
+      mismatches.mismatches[0].mismatch.contains("to match"),
+      "expected the host's mismatch description to be reported, got {:?}",
+      mismatches.mismatches[0].mismatch
+    );
+  }
+
+  /// A plugin can return the interaction's matching rules from `configure_interaction`, so a rule
+  /// on something inside a content type the framework can not traverse still ends up in the Pact
+  /// file's `matchingRules` rather than in the plugin's own configuration.
+  #[tokio::test]
+  async fn configure_interaction_carries_matching_rules_from_the_plugin() {
+    let plugin_dir = tempdir::TempDir::new("lua-plugin-test").unwrap();
+    std::fs::write(
+      plugin_dir.path().join("entry.lua"),
+      r#"
+        function configure_interaction(content_type, config)
+          return {
+            interactions = {
+              {
+                contents = { contents = "a-body", content_type = content_type },
+                rules = {
+                  ["$.one"] = { { type = "regex", values = { regex = "\\d+" } } },
+                  ["$.two"] = { { type = "type" } }
+                }
+              }
+            }
+          }
+        end
+      "#,
+    ).unwrap();
+
+    let manifest = PactPluginManifest {
+      plugin_dir: plugin_dir.path().to_string_lossy().to_string(),
+      plugin_interface_version: 1,
+      name: "configure-rules-test".to_string(),
+      version: "0.0.0".to_string(),
+      executable_type: "lua".to_string(),
+      minimum_required_version: None,
+      entry_point: "entry.lua".to_string(),
+      entry_points: HashMap::new(),
+      args: None,
+      dependencies: None,
+      plugin_config: HashMap::new(),
+    };
+    let plugin = start_lua_plugin(&manifest, "test-instance".to_string()).unwrap();
+
+    let response = plugin.configure_interaction(ConfigureInteractionRequest {
+      content_type: "application/x-test".to_string(),
+      contents_config: None,
+    }).await.unwrap();
+
+    let interaction = &response.interaction[0];
+    let regex_rule = &interaction.rules.get("$.one").expect("expected a rule at $.one").rule[0];
+    assert_eq!(regex_rule.r#type, "regex");
+    assert_eq!(
+      proto_struct_to_json(regex_rule.values.as_ref().unwrap()).get("regex").and_then(|v| v.as_str()),
+      Some("\\d+")
+    );
+    let type_rule = &interaction.rules.get("$.two").expect("expected a rule at $.two").rule[0];
+    assert_eq!(type_rule.r#type, "type");
   }
 
   #[tokio::test]

--- a/drivers/rust/driver/src/proto_v2.rs
+++ b/drivers/rust/driver/src/proto_v2.rs
@@ -940,9 +940,9 @@ pub struct HostGenerateContentRequest {
 /// 006 (Field-level matchers and generators) and 007 (Driver-plugin callback model).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HostMatchFieldRequest {
-    /// Catalogue entry key identifying the rule to invoke. Either the name as a Pact file writes it
-    /// ("type"), or the key as hostCapabilities advertises it ("matcher/v2-type") - the core
-    /// catalogue prefixes the Pact specification version a rule was introduced in to its name.
+    /// Catalogue entry key identifying the rule to invoke. Either the rule name on its own ("type",
+    /// "content-type" - the same string MatchFieldRequest.rule.type carries), or more of the
+    /// catalogue key to disambiguate it ("matcher/type", "core/matcher/type").
     #[prost(string, tag = "1")]
     pub entry_key: ::prost::alloc::string::String,
     /// The match request, in the same shape as PactPlugin.MatchField
@@ -953,7 +953,7 @@ pub struct HostMatchFieldRequest {
 /// another plugin - resolved by catalogue entry key. See proposals 006 and 007.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HostGenerateFieldRequest {
-    /// Catalogue entry key identifying the generator to invoke, e.g. "date" or "generator/v3-date".
+    /// Catalogue entry key identifying the generator to invoke, e.g. "date" or "generator/date".
     /// See HostMatchFieldRequest.entryKey.
     #[prost(string, tag = "1")]
     pub entry_key: ::prost::alloc::string::String,

--- a/examples/jwt/README.md
+++ b/examples/jwt/README.md
@@ -4,6 +4,22 @@ These examples demonstrate using the [JWT plugin](../../plugins/jwt) (written in
 responses signed as JSON Web Tokens. There are two consumer projects, one written in Rust and the other in Java,
 and one provider, written in Rust.
 
+They also demonstrate a plugin **delegating a matching rule back to the host Pact framework**. Both consumer tests
+declare a `customer_id` claim with a `regex` rule rather than a fixed value:
+
+```json
+"customer_id": { "pact:matcher:type": "regex", "regex": "CUST-\\d{6}", "value": "CUST-123456" }
+```
+
+The JWT plugin implements no matching rules of its own - it decodes and validates the token, then hands that one
+claim to whoever owns `regex` in the running catalogue, which is the Pact framework doing the verifying (see
+proposals [006](../../docs/proposals/006_Field_level_matchers_and_generators.md) and
+[009](../../docs/proposals/009_Host_provided_core_matching_and_generation.md)). It is worth checking that this is
+really doing something: the token the consumer test's client sends carries `CUST-987654`, and the provider issues
+a different customer id on every request, so neither would match the example value under the plugin's usual
+equality check. Change the client's value to something outside the pattern and the test fails with the framework's
+own message, `Expected 'not-a-customer' to match 'CUST-\d{6}'`.
+
 The provider supports one endpoint:
 * `POST /token` - returns a freshly-signed JWT.
 
@@ -73,13 +89,18 @@ checkout of [pact-reference](https://github.com/pact-foundation/pact-reference):
 2. `pact_verifier`'s own dependency on `pact-plugin-driver` is `default-features = false` and doesn't request the
    `lua` feature, so add an explicit dependency in `rust/pact_verifier_cli/Cargo.toml` to turn it on:
    ```toml
-   pact-plugin-driver = { version = "~1.1.0", default-features = false, features = ["lua"] }
+   pact-plugin-driver = { version = "~1.2.2", default-features = false, features = ["lua"] }
    ```
 3. Build it:
    ```console
    $ cargo build -p pact_verifier_cli
    ```
    The binary ends up at `target/debug/pact-verifier` (hyphenated, not `pact_verifier_cli`).
+
+The `customer_id` claim's `regex` rule additionally needs a host that registers the standard matching rules as
+core catalogue capabilities - `pact_matching` 2.0.11+ (so a locally-built `pact_verifier_cli` picks it up
+automatically) and Pact-JVM 4.7.5+. Against an older host the claim is reported as a mismatch saying the rule
+could not be resolved, rather than being silently skipped.
 
 Once Lua plugin support is released, none of the above will be necessary - just use the normal released
 `pact_verifier_cli`/pact-jvm provider verifier.

--- a/examples/jwt/jwt-consumer-jvm/build.gradle
+++ b/examples/jwt/jwt-consumer-jvm/build.gradle
@@ -10,8 +10,11 @@ repositories {
 dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
-  testImplementation 'au.com.dius.pact.consumer:junit5:4.7.3'
-  testImplementation 'io.pact.plugin.driver:core:1.0.0-beta.6'
+  // A claim with a matching rule needs a Pact-JVM that registers the standard rules as core
+  // catalogue capabilities (4.7.5+) and a driver with the field-level Lua host functions (1.2.2+).
+  // Both are resolved from mavenLocal() until they are released - see ../README.md.
+  testImplementation 'au.com.dius.pact.consumer:junit5:4.7.5'
+  testImplementation 'io.pact.plugin.driver:core:1.2.2'
   testImplementation 'ch.qos.logback:logback-classic:1.4.11'
   testImplementation 'org.hamcrest:hamcrest:2.2'
   testImplementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/examples/jwt/jwt-consumer-jvm/src/test/java/io/pact/plugins/examples/jwt/JwtClientTest.java
+++ b/examples/jwt/jwt-consumer-jvm/src/test/java/io/pact/plugins/examples/jwt/JwtClientTest.java
@@ -71,7 +71,15 @@ class JwtClientTest {
           "issuer", "ldsdkdalds",
           "algorithm", "RS512",
           "key-id", "key-112345564",
-          "private-key", PRIVATE_KEY
+          "private-key", PRIVATE_KEY,
+          // The plugin does not implement `regex` - it hands this claim back to Pact-JVM's own
+          // regex rule through the host callback (proposals 006 and 009). The value here is just
+          // the example that goes into the token.
+          "customer_id", Map.of(
+            "pact:matcher:type", "regex",
+            "regex", "CUST-\\d{6}",
+            "value", "CUST-123456"
+          )
         ),
         "response.status", "200",
         "response.contents", Map.of(
@@ -81,7 +89,12 @@ class JwtClientTest {
           "issuer", "ldsdkdalds",
           "algorithm", "RS512",
           "key-id", "key-112345564",
-          "private-key", PRIVATE_KEY
+          "private-key", PRIVATE_KEY,
+          "customer_id", Map.of(
+            "pact:matcher:type", "regex",
+            "regex", "CUST-\\d{6}",
+            "value", "CUST-123456"
+          )
         )
       ))
       .toPact();
@@ -96,7 +109,10 @@ class JwtClientTest {
       .claims(Map.of(
         "aud", "1234566778",
         "sub", "slksjkdjkdks",
-        "iss", "ldsdkdalds"
+        "iss", "ldsdkdalds",
+        // Deliberately not the example value from the interaction: the request only matches
+        // because the regex rule is applied to this claim rather than an equality check
+        "customer_id", "CUST-987654"
       ))
       .expiration(new Date(System.currentTimeMillis() + 300_000))
       .signWith(privateKey, Jwts.SIG.RS512)

--- a/examples/jwt/jwt-consumer-rust/Cargo.lock
+++ b/examples/jwt/jwt-consumer-rust/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -30,18 +30,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -180,7 +180,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -283,6 +283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -391,13 +397,13 @@ dependencies = [
 
 [[package]]
 name = "cfb"
-version = "0.7.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+checksum = "a347dcabdae9c31b0825fd6a8bed285ec9c2acb89c47827126d52fa4f59cece3"
 dependencies = [
- "byteorder",
  "fnv",
  "uuid",
+ "web-time",
 ]
 
 [[package]]
@@ -647,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deflate64"
@@ -761,13 +767,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -784,9 +790,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1174,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1219,9 +1225,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1257,13 +1263,10 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1285,7 +1288,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1458,7 +1461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f85dac6c239acc85fd61934c572292d93adfd2de459d9c032aa22b553506e915"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "strum",
@@ -1481,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "infer"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+checksum = "f4200d433cbd5178df7797c9c2e75b348b728e39631cf14520d1e2fc424201f4"
 dependencies = [
  "cfb",
 ]
@@ -1499,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1519,6 +1522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,9 +1538,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -1550,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -1636,7 +1648,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -1656,7 +1668,7 @@ dependencies = [
  "pact-plugin-driver",
  "pact_consumer",
  "pact_models",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "test-log",
@@ -1719,9 +1731,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1796,18 +1808,18 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lua-src"
-version = "550.0.0"
+version = "550.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb"
+checksum = "75c110c2fa33f34e0de05448e1f3eb2e0631e7a69e2d8ae1586cffc9fc9f9949"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "luajit-src"
-version = "210.6.6+707c12b"
+version = "210.7.2+b925b3e"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
+checksum = "920cf654b23d217c550ceea57c32cd2a413ea27b6d47ed77b5ee0cf655adefa6"
 dependencies = [
  "cc",
  "which",
@@ -1890,28 +1902,28 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.11.6"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
+checksum = "ad72ffa037cf5970c9860674f32f703fda25d86cf217475fe7a79c5f9961bcaa"
 dependencies = [
  "bstr",
  "either",
  "erased-serde",
+ "futures-util",
  "libc",
  "mlua-sys",
  "num-traits",
  "parking_lot",
  "rustc-hash",
- "rustversion",
  "serde",
  "serde-value",
 ]
 
 [[package]]
 name = "mlua-sys"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
+checksum = "92136787b906d4e55cfe96cd6c62e010bb1a56889d0d6cf83eb016dbad07576b"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2300,21 +2312,19 @@ dependencies = [
 
 [[package]]
 name = "pact-plugin-driver"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6057f90dca5cfd3d86430fa5c6b483c8722a70651712af423e33b334a5c6eb"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "backtrace",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "flate2",
  "futures-util",
  "home",
  "indicatif",
- "itertools",
+ "itertools 0.15.0",
  "lazy_static",
  "lenient_semver",
  "log",
@@ -2326,7 +2336,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rsa",
  "semver",
  "serde",
@@ -2347,19 +2357,20 @@ dependencies = [
 
 [[package]]
 name = "pact_consumer"
-version = "1.4.6"
-source = "git+https://github.com/pact-foundation/pact-reference.git#b51c2bac0dfde600bf16adab19062ad8a3bc1974"
+version = "1.4.11"
+source = "git+https://github.com/pact-foundation/pact-reference.git#4ead7addf748fc854d4a54fd066375e2d0389aee"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "itertools",
+ "itertools 0.15.0",
  "maplit",
  "pact-plugin-driver",
  "pact_matching",
  "pact_mock_server",
  "pact_models",
  "regex",
+ "rustls",
  "serde_json",
  "termsize",
  "tokio",
@@ -2371,12 +2382,13 @@ dependencies = [
 
 [[package]]
 name = "pact_matching"
-version = "2.0.8"
-source = "git+https://github.com/pact-foundation/pact-reference.git#b51c2bac0dfde600bf16adab19062ad8a3bc1974"
+version = "2.0.11"
+source = "git+https://github.com/pact-foundation/pact-reference.git#4ead7addf748fc854d4a54fd066375e2d0389aee"
 dependencies = [
  "ansi_term",
  "anyhow",
- "base64",
+ "async-trait",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "difference",
@@ -2384,7 +2396,7 @@ dependencies = [
  "hex",
  "http",
  "infer",
- "itertools",
+ "itertools 0.15.0",
  "kiss_xml",
  "lazy_static",
  "lenient_semver",
@@ -2398,7 +2410,7 @@ dependencies = [
  "pact_models",
  "rand 0.9.5",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -2413,17 +2425,16 @@ dependencies = [
 
 [[package]]
 name = "pact_mock_server"
-version = "2.2.3"
-source = "git+https://github.com/pact-foundation/pact-core-mock-server.git#824c0606b907c27967027ac119cc5876fcb35246"
+version = "2.2.6"
+source = "git+https://github.com/pact-foundation/pact-core-mock-server.git#a891c2e88fad68d653df55c0fa2bf5703cd17708"
 dependencies = [
  "anyhow",
  "bytes",
  "futures",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
- "itertools",
+ "itertools 0.15.0",
  "lazy_static",
  "maplit",
  "pact-plugin-driver",
@@ -2432,7 +2443,6 @@ dependencies = [
  "rcgen",
  "rustls",
  "rustls-pemfile",
- "rustls-webpki",
  "serde",
  "serde_json",
  "thiserror",
@@ -2445,13 +2455,13 @@ dependencies = [
 
 [[package]]
 name = "pact_models"
-version = "1.3.11"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956270cedc5547fc941d03b686c651f08d25b37617608cc5d8c67299655269d0"
+checksum = "f27c04d9b4572559a611d0ab8c1e332fe3a8588f2791b13887af42074e2c7a90"
 dependencies = [
  "anyhow",
  "ariadne",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -2460,7 +2470,7 @@ dependencies = [
  "hashers",
  "hex",
  "indextree",
- "itertools",
+ "itertools 0.15.0",
  "kiss_xml",
  "lazy_static",
  "lenient_semver",
@@ -2474,7 +2484,7 @@ dependencies = [
  "rand_regex",
  "regex",
  "regex-syntax",
- "reqwest 0.12.28",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -2532,7 +2542,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2720,7 +2730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -2741,7 +2751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3005,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3022,56 +3032,16 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3088,15 +3058,20 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3180,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3217,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3366,7 +3341,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3384,11 +3359,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3605,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3753,7 +3728,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3767,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "js-sys",
@@ -3840,13 +3815,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3861,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3872,57 +3847,56 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -3932,7 +3906,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4316,9 +4290,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4352,15 +4326,6 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4578,12 +4543,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -4666,18 +4628,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4773,9 +4735,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
@@ -4822,7 +4784,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "pact-plugin-driver"
-version = "1.1.0"

--- a/examples/jwt/jwt-consumer-rust/Cargo.toml
+++ b/examples/jwt/jwt-consumer-rust/Cargo.toml
@@ -13,7 +13,7 @@ expectest = "0.12.0"
 env_logger = "0.11.3"
 pact_models = "1.3.11"
 pact_consumer = "~1.4.4"
-pact-plugin-driver = { version = "~1.0.0", default-features = false, features = ["lua"] }
+pact-plugin-driver = { version = "~1.2.2", default-features = false, features = ["lua"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.120"
 jsonwebtoken = "9.3.0"

--- a/examples/jwt/jwt-consumer-rust/src/lib.rs
+++ b/examples/jwt/jwt-consumer-rust/src/lib.rs
@@ -44,6 +44,9 @@ xGgMNbvImsticz5CUjXC1IkCnbdLrC16YFKMKguaRvTDDOF+
     exp: u64,
     iss: String,
     sub: String,
+    // A claim whose value is not fixed between the consumer and the provider - the test pins its
+    // shape with a matching rule instead of its value
+    customer_id: String,
   }
 
   #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
@@ -60,7 +63,15 @@ xGgMNbvImsticz5CUjXC1IkCnbdLrC16YFKMKguaRvTDDOF+
           "issuer": "ldsdkdalds",
           "algorithm": "RS512",
           "key-id": "key-112345564",
-          "private-key": PRIVATE_KEY
+          "private-key": PRIVATE_KEY,
+          // The plugin does not implement `regex` - it hands this claim back to the Pact
+          // framework's own regex rule through the host callback (proposals 006 and 009). The
+          // value here is just the example that goes into the token.
+          "customer_id": {
+            "pact:matcher:type": "regex",
+            "regex": "CUST-\\d{6}",
+            "value": "CUST-123456"
+          }
         })).await;
       i.response
         .ok()
@@ -70,7 +81,15 @@ xGgMNbvImsticz5CUjXC1IkCnbdLrC16YFKMKguaRvTDDOF+
           "issuer": "ldsdkdalds",
           "algorithm": "RS512",
           "key-id": "key-112345564",
-          "private-key": PRIVATE_KEY
+          "private-key": PRIVATE_KEY,
+          // The plugin does not implement `regex` - it hands this claim back to the Pact
+          // framework's own regex rule through the host callback (proposals 006 and 009). The
+          // value here is just the example that goes into the token.
+          "customer_id": {
+            "pact:matcher:type": "regex",
+            "regex": "CUST-\\d{6}",
+            "value": "CUST-123456"
+          }
         })).await;
       i
     }).await;
@@ -86,6 +105,9 @@ xGgMNbvImsticz5CUjXC1IkCnbdLrC16YFKMKguaRvTDDOF+
                       // time the plugin validates it
       iss: "ldsdkdalds".to_string(),
       sub: "slksjkdjkdks".to_string(),
+      // Deliberately not the example value from the interaction: the request only matches
+      // because the regex rule is applied to this claim rather than an equality check
+      customer_id: "CUST-987654".to_string(),
     };
 
     let encoding_key = EncodingKey::from_rsa_pem(PRIVATE_KEY.as_bytes()).unwrap();

--- a/examples/jwt/jwt-provider-rust/src/main.rs
+++ b/examples/jwt/jwt-provider-rust/src/main.rs
@@ -41,6 +41,7 @@ struct Claims {
     exp: u64,
     iss: String,
     sub: String,
+    customer_id: String,
 }
 
 #[post("/token")]
@@ -53,6 +54,10 @@ async fn issue_token(_req_body: String) -> HttpResponse {
         exp: now + 5 * 60,
         iss: "ldsdkdalds".to_string(),
         sub: "slksjkdjkdks".to_string(),
+        // A different customer id on every issued token: verification passes because the
+        // interaction pins this claim with a regex rule, which the jwt plugin applies by calling
+        // back into the verifier's own matching engine
+        customer_id: format!("CUST-{:06}", now % 1_000_000),
     };
 
     let encoding_key = EncodingKey::from_rsa_pem(PRIVATE_KEY.as_bytes()).unwrap();

--- a/plugins/jwt/README.md
+++ b/plugins/jwt/README.md
@@ -54,9 +54,14 @@ pseudo config):
   "issuer": "ldsdkdalds",       // "iss" claim
   "algorithm": "RS512",         // only RS512 is supported
   "key-id": "key-112345564",    // "kid" header, optional
-  "private-key": "-----BEGIN RSA PRIVATE KEY-----\n..."  // PKCS#1 PEM, required
+  "private-key": "-----BEGIN RSA PRIVATE KEY-----\n...",  // PKCS#1 PEM, required
+  "customer_id": "CUST-123456"  // any other field becomes a claim of that name
 }
 ```
+
+Any field that isn't one of the plugin's own (`private-key`, `public-key`, `algorithm`, `key-id`, `subject`,
+`issuer`, `audience`) becomes a claim of that name, so `"customer_id": "CUST-123456"` above adds a `customer_id`
+claim carrying that value.
 
 `private-key` is the only required field - the rest (`audience`/`subject`/`issuer`/`key-id`) default to random
 values if omitted, and `algorithm` defaults to `RS512` (the only one currently supported). A `public-key` field is
@@ -78,7 +83,56 @@ When verifying an actual token against the expected one, the plugin checks, in o
    ignored (present or not, its value isn't compared).
 4. **Claims** - `iss`, `sub`, `aud` are compulsory and compared exactly; any other claims are allowed and compared
    exactly too, except `exp`/`nbf`/`iat`/`jti` which are always ignored (since they're timestamps/random values
-   that legitimately differ between the expected and actual token).
+   that legitimately differ between the expected and actual token), and any claim given a matching rule (below).
+
+## Matching rules on a claim
+
+A claim whose value is not fixed between the consumer and the provider can be given a matching rule instead of an
+exact value, using the standard integration-JSON form:
+
+```javascript
+"request.contents": {
+  "pact:content-type": "application/jwt+json",
+  "private-key": "-----BEGIN RSA PRIVATE KEY-----\n...",
+  "customer_id": {
+    "pact:matcher:type": "regex",
+    "regex": "CUST-\\d{6}",
+    "value": "CUST-123456"
+  }
+}
+```
+
+`value` is the example that goes into the signed token; the rule is what the actual token's claim is checked
+against. Any rule name the host Pact framework provides works (`regex`, `type`, `date`, `not-empty`, …), as does
+any rule another loaded plugin provides - **this plugin implements none of them itself**. When it meets a claim
+with a rule it calls `host_match_field(rule_type, ...)`, which hands the two values to whoever owns that rule (see
+proposals [006](../../docs/proposals/006_Field_level_matchers_and_generators.md) and
+[009](../../docs/proposals/009_Host_provided_core_matching_and_generation.md)). The mismatch text you see on a
+failure is the host's own.
+
+A rule beats the ignore list: `exp` and `iat` are normally skipped, but a test that names one deliberately gets
+the rule applied to it.
+
+Rules go into the interaction's ordinary matching rules, keyed by a path into the claims, so the Pact file gets
+the standard block:
+
+```json
+"matchingRules": {
+  "body": {
+    "$.claims.customer_id": { "combine": "AND", "matchers": [ { "match": "regex", "regex": "CUST-\\d{6}" } ] }
+  }
+}
+```
+
+The framework stores and returns those paths without interpreting them - it can not traverse a signed token - but
+they are the interaction's rules, not this plugin's private configuration, and they are visible to anyone reading
+the Pact file. The plugin gets them back in the `rules` field of every match request, on both the consumer and the
+provider side. Only the first rule for a path is applied: a claim is a single value, so an `AND` of several rules
+has nothing to act on.
+
+The standard rules only reach the plugin if the host framework registers them as core catalogue capabilities,
+which needs `pact_matching` 2.0.11+ / Pact-JVM 4.7.5+. Against an older host the plugin reports the claim as a
+mismatch explaining that the rule could not be resolved, rather than silently ignoring it.
 
 ## Compatibility
 

--- a/plugins/jwt/jwt.lua
+++ b/plugins/jwt/jwt.lua
@@ -15,15 +15,46 @@ function jwt.build_header(config)
     return header
 end
 
+-- A claim value can be given either directly, or as an integration-JSON matcher table:
+--
+--   customer_id = { ["pact:matcher:type"] = "regex", regex = "CUST-%d+", value = "CUST-123456" }
+--
+-- in which case the example value goes into the token and the rule is returned separately, to be
+-- persisted with the interaction and applied when the token is matched (see plugin.lua). Returns
+-- the value to use, and the rule table (or nil when the value was given directly).
+local function claim_value_and_rule(value)
+    if type(value) == "table" and value["pact:matcher:type"] then
+        local values = {}
+        for k, v in pairs(value) do
+            if k ~= "pact:matcher:type" and k ~= "value" then
+                values[k] = v
+            end
+        end
+        return value["value"], { type = value["pact:matcher:type"], values = values }
+    end
+    return value, nil
+end
+
+-- Builds the token payload from the test's configuration. Returns the claims, and the matching
+-- rules any of them were declared with, keyed by claim name.
 function jwt.build_payload(config)
     local claims = {
         jti = utils.random_hex(16),
         iat = os.time()
     }
+    local rules = {}
 
-    claims["sub"] = config["subject"] or "sub_" .. utils.random_str(4)
-    claims["iss"] = config["issuer"] or "iss_" .. utils.random_str(4)
-    claims["aud"] = config["audience"] or "aud_" .. utils.random_str(4)
+    local function set_claim(claim, configured, default)
+        local value, rule = claim_value_and_rule(configured)
+        claims[claim] = value or default
+        if rule then
+            rules[claim] = rule
+        end
+    end
+
+    set_claim("sub", config["subject"], "sub_" .. utils.random_str(4))
+    set_claim("iss", config["issuer"], "iss_" .. utils.random_str(4))
+    set_claim("aud", config["audience"], "aud_" .. utils.random_str(4))
 
     -- exp: now + expiryInMinutes * 60, // Current time + STS_TOKEN_EXPIRY_MINUTES minutes
     claims["exp"] = os.time() + 5 * 60
@@ -38,11 +69,11 @@ function jwt.build_payload(config)
     config["public-key"] = nil
     for k, v in pairs(config) do
         if v then
-            claims[k] = v
+            set_claim(k, v)
         end
     end
 
-    return claims
+    return claims, rules
 end
 
 function jwt.sign_token(config, header, private_key, base_token)

--- a/plugins/jwt/matching.lua
+++ b/plugins/jwt/matching.lua
@@ -32,21 +32,85 @@ function matching.match_headers(expected_header, actual_header)
         Set({"alg", "jku", "jwk", "kid", "x5u", "x5c", "x5t", "x5t#S256", "typ", "cty", "crit"}), Set({"jku"}))
 end
 
-function matching.match_claims(expected_claims, actual_claims)
+function matching.match_claims(expected_claims, actual_claims, claim_rules)
     logger("matching JWT claims")
     logger("expected claims: " .. inspect(expected_claims))
     logger("actual claims: " .. inspect(actual_claims))
     -- "exp" is deliberately not compulsory here (unlike iss/sub/aud): it's a timestamp that
     -- legitimately differs between the expected and actual token, and its presence/validity
     -- is already checked semantically by validate_token above.
-    return match_map(expected_claims, actual_claims, Set({"iss", "sub", "aud"}), {}, Set({"exp", "nbf", "iat", "jti"}))
+    return match_map(expected_claims, actual_claims, Set({"iss", "sub", "aud"}),
+        {}, Set({"exp", "nbf", "iat", "jti"}), claim_rules)
 end
 
-function match_map(expected, actual, compulsory_keys, allowed_keys, keys_to_ignore)
+-- Applies a matching rule to a single claim by calling back into the host Pact framework, rather
+-- than reimplementing the rule here. This plugin knows how to decode and validate a JWT; it has no
+-- business owning what "regex" or "date" mean, and the host already has the correct implementation
+-- of both. See proposals 006 (field-level matchers) and 009 (host-provided core matching).
+--
+-- Returns a mismatch table, or nil if the claim matched.
+function match_claim_with_rule(key, rule, expected_value, actual_value)
+    if type(host_match_field) ~= "function" then
+        return {
+            expected = expected_value,
+            actual = actual_value,
+            path = key,
+            mismatch = "The '" .. rule.type .. "' matching rule was declared on claim '" .. key ..
+                "', but this driver does not provide the host_match_field function"
+        }
+    end
+
+    logger("Delegating claim '" .. key .. "' to the host's '" .. rule.type .. "' matching rule")
+    -- The rule name is the catalogue key, so the type a rule arrives with is directly usable
+    local result = host_match_field(rule.type, {
+        rule = rule,
+        path = "$." .. key,
+        mismatch_type = "body",
+        expected = expected_value,
+        actual = actual_value
+    })
+
+    if result.error then
+        return {
+            expected = expected_value,
+            actual = actual_value,
+            path = key,
+            mismatch = "Could not apply the '" .. rule.type .. "' matching rule to claim '" ..
+                key .. "' - " .. result.error
+        }
+    end
+
+    local mismatches = result.mismatches or {}
+    if #mismatches == 0 then
+        return nil
+    end
+
+    local descriptions = {}
+    for _, mismatch in ipairs(mismatches) do
+        table.insert(descriptions, mismatch.mismatch or inspect(mismatch))
+    end
+    return {
+        expected = expected_value,
+        actual = actual_value,
+        path = key,
+        mismatch = table.concat(descriptions, ", ")
+    }
+end
+
+function match_map(expected, actual, compulsory_keys, allowed_keys, keys_to_ignore, rules)
     local result = {}
+    rules = rules or {}
 
     for k, v in pairs(expected) do
-        if not keys_to_ignore[k] then
+        local rule = rules[k]
+        if rule then
+            -- A rule wins over the ignore list: a claim that normally varies freely between the
+            -- two tokens (exp, iat) is being constrained deliberately if a test names it
+            local mismatch = match_claim_with_rule(k, rule, v, actual[k])
+            if mismatch then
+                result[k] = mismatch
+            end
+        elseif not keys_to_ignore[k] then
             if actual[k] ~= v then
                 result[k] = {
                     expected = v,

--- a/plugins/jwt/plugin.lua
+++ b/plugins/jwt/plugin.lua
@@ -48,7 +48,7 @@ function configure_interaction(content_type, config)
     local public_key = config["public-key"] or rsa_public_key(private_key)
 
     local header = jwt.build_header(config)
-    local payload = jwt.build_payload(config)
+    local payload, claim_rules = jwt.build_payload(config)
 
     local base64 = require "base64"
     local encoded_header = base64.encode(json.encode(header))
@@ -67,9 +67,20 @@ function configure_interaction(content_type, config)
         }
     }
 
+    -- Matching rules declared on a claim are returned as the interaction's ordinary matching
+    -- rules, keyed by a path into the token's claims. They are written to the Pact file's
+    -- matchingRules like any other rule, and handed back to match_contents (below) on both sides
+    -- of the test - the framework can not traverse a signed token itself, but the rules are still
+    -- the interaction's, not this plugin's private configuration.
+    local rules = {}
+    for claim, rule in pairs(claim_rules) do
+        rules["$.claims." .. claim] = { rule }
+    end
+
     return {
         interactions = {
             {
+                rules = rules,
                 contents = {
                     contents = signed_token,
                     content_type = "application/jwt+json",
@@ -85,6 +96,23 @@ function configure_interaction(content_type, config)
         },
         plugin_config = plugin_config
     }
+end
+
+-- Picks the claim rules back out of the interaction's matching rules. `rules` is keyed by path
+-- expression, as it is for any content matcher; this plugin writes claim rules under
+-- "$.claims.<name>" (see configure_interaction), and only the first rule for a path is used - a
+-- claim is one value, so an AND of several rules has no meaning the plugin could act on.
+function claim_rules_from(rules)
+    local claim_rules = {}
+    for path, rule_list in pairs(rules or {}) do
+        local claim = string.match(path, "^%$%.claims%.(.+)$")
+        if claim and rule_list[1] then
+            claim_rules[claim] = rule_list[1]
+        else
+            logger("Ignoring a matching rule at '" .. path .. "': not a claim path")
+        end
+    end
+    return claim_rules
 end
 
 -- Compares the actual JWT received against the expected one from the Pact interaction.
@@ -123,7 +151,8 @@ function match_contents(match_request)
         mismatches["header:" .. k] = v
     end
 
-    local claim_mismatches = matching.match_claims(expected_jwt.payload, actual_jwt.payload)
+    local claim_mismatches = matching.match_claims(expected_jwt.payload, actual_jwt.payload,
+        claim_rules_from(match_request.rules))
     for k, v in pairs(claim_mismatches) do
         mismatches["claims:" .. k] = v
     end

--- a/proto/plugin_v2.proto
+++ b/proto/plugin_v2.proto
@@ -555,9 +555,9 @@ message HostGenerateContentRequest {
 // standard Pact rules) or owned by another plugin - resolved by catalogue entry key. See proposals
 // 006 (Field-level matchers and generators) and 007 (Driver-plugin callback model).
 message HostMatchFieldRequest {
-  // Catalogue entry key identifying the rule to invoke. Either the name as a Pact file writes it
-  // ("type"), or the key as hostCapabilities advertises it ("matcher/v2-type") - the core
-  // catalogue prefixes the Pact specification version a rule was introduced in to its name.
+  // Catalogue entry key identifying the rule to invoke. Either the rule name on its own ("type",
+  // "content-type" - the same string MatchFieldRequest.rule.type carries), or more of the
+  // catalogue key to disambiguate it ("matcher/type", "core/matcher/type").
   string entryKey = 1;
   // The match request, in the same shape as PactPlugin.MatchField
   MatchFieldRequest request = 2;
@@ -566,7 +566,7 @@ message HostMatchFieldRequest {
 // Callback request from a plugin to invoke a field-level generator - host-provided or owned by
 // another plugin - resolved by catalogue entry key. See proposals 006 and 007.
 message HostGenerateFieldRequest {
-  // Catalogue entry key identifying the generator to invoke, e.g. "date" or "generator/v3-date".
+  // Catalogue entry key identifying the generator to invoke, e.g. "date" or "generator/date".
   // See HostMatchFieldRequest.entryKey.
   string entryKey = 1;
   // The generation request, in the same shape as PactPlugin.GenerateField


### PR DESCRIPTION
This pull request updates the documentation for field-level matchers and generators in Pact plugins. The main focus is on simplifying and clarifying how standard (core) matching rules and generators are registered, named, and resolved, both in the host and for plugins. The changes standardize catalogue keys, improve explanations, and update examples to reflect the new approach. The documentation now reflects that the host registers standard rules by their request names (not version-prefixed), and plugins can refer to them directly, making delegation and interoperability easier.

**Key changes:**

### Core matcher and generator registration and naming

* Standard matching rules and generators are now registered under their plain names (e.g., `type`, `regex`, `equality`), not version-prefixed keys (e.g., `v2-type`). The specification version is now a value on the entry, not part of the key. [[1]](diffhunk://#diff-7e9fe9e356b90e05e55c9cf67abaccd7a71e561af872c96662d5ce514df11b71L160-R208) [[2]](diffhunk://#diff-525723f5a195469f339c3e5826c6de6ed8b8c98acd69d709602cce674959dba4L99-R118) [[3]](diffhunk://#diff-525723f5a195469f339c3e5826c6de6ed8b8c98acd69d709602cce674959dba4L290-R293) [[4]](diffhunk://#diff-525723f5a195469f339c3e5826c6de6ed8b8c98acd69d709602cce674959dba4L340-R343) [[5]](diffhunk://#diff-df70f0f23a4e6525e650c3e9d2573faa0503d27add9452d4d9d1a50cebf57dd9L57-R135)
* Documentation and examples have been updated to clarify that plugins and hosts can refer to rules and generators by these plain names, with more of the catalogue key added only to disambiguate if needed. [[1]](diffhunk://#diff-676987519fcf25bfef15f8c32f3e6acc2138218ed6b8fd279145ea52f697a0f4L539-R550) [[2]](diffhunk://#diff-df70f0f23a4e6525e650c3e9d2573faa0503d27add9452d4d9d1a50cebf57dd9L42-R44)

### Plugin interface and usage examples

* The `rules` field in interaction definitions is documented and exemplified, showing how to attach matching rules to specific paths in the content. Guidance is provided on how these paths are used and interpreted.
* Examples and explanations are updated to show how plugins can delegate standard rules to the host by name, and how ambiguity or missing rules are handled as errors. [[1]](diffhunk://#diff-525723f5a195469f339c3e5826c6de6ed8b8c98acd69d709602cce674959dba4L99-R118) [[2]](diffhunk://#diff-df70f0f23a4e6525e650c3e9d2573faa0503d27add9452d4d9d1a50cebf57dd9L42-R44)

### Host implementation status

* The status of core matcher/generator registration is updated: both Rust and JVM hosts now register all standard matchers and generators, and field-level delegation is implemented. Only WASM support remains outstanding. [[1]](diffhunk://#diff-df70f0f23a4e6525e650c3e9d2573faa0503d27add9452d4d9d1a50cebf57dd9L1-R4) [[2]](diffhunk://#diff-df70f0f23a4e6525e650c3e9d2573faa0503d27add9452d4d9d1a50cebf57dd9L57-R135)
* Detailed tables list the registered matchers and generators for each host, clarifying any differences. [[1]](diffhunk://#diff-7e9fe9e356b90e05e55c9cf67abaccd7a71e561af872c96662d5ce514df11b71L160-R208) [[2]](diffhunk://#diff-df70f0f23a4e6525e650c3e9d2573faa0503d27add9452d4d9d1a50cebf57dd9L57-R135)

These changes make the documentation more accurate and actionable for plugin authors and framework developers, ensuring consistent and predictable integration with core Pact matching and generation capabilities.